### PR TITLE
research loop: the self-falsifying engine + living backlog

### DIFF
--- a/papers/PROGRAM_BACKLOG.md
+++ b/papers/PROGRAM_BACKLOG.md
@@ -1,0 +1,76 @@
+# STYXX PROGRAM BACKLOG — the living, prioritized queue
+
+*Fathom Lab · 2026-06-08. The fuel for `RESEARCH_LOOP.md`. Each cycle the loop pulls the top unblocked item,
+pre-registers a kill-gate, runs, red-teams, records, and re-ranks. Seeded from the complete adversarial
+threat-surface map (4-lens workflow `wf_2937b28a`) + every finding's "owed" list. Updated every cycle —
+closing items, spawning new ones, re-ranking by leverage.*
+
+**Leverage** = advances-a-rung × falsifiability (can a negative actually fire?) × feasibility-on-8GB.
+**Status**: `QUEUED` · `IN-PROGRESS` · `BLOCKED` · `DONE` · `KILLED` (negative recorded) · `PARKED`.
+
+---
+
+## Progress ledger
+
+- **R1 read-certificate** — climbed; 2-family (Qwen-3B + Llama-3B), scale-robust 1.5B→7B, semantic-not-shortcut. `SURVIVED`.
+- **R2 intent/mens-rea** — real but coupled to R1; two-stage HELD→HID conscience deployable (false-accuse 0.949→0.037). `REPORT_AS_LANDED`.
+- **R3 demarcation/abstain** — proven the wall is bedrock on 3 axes; wiring into the certificate object owed.
+- **R4 substrate/closed + adversarial robustness** — the existential frontier. Adversarial flank: frozen deployed probe **DEFEATED**; info-persistence **SUPPORTED-n=1**; v3 (relocation) **INCONCLUSIVE — running**. Closed-model: **open**.
+- **R5 write** — out by design (read-only = the safety).
+- bricks laid: ~20 findings · open questions below: 22.
+
+## Current cycle (live)
+
+- **B0 — v3 real run to a valid verdict.** The 800-step/n=190 orthogonalization+displacement run is `IN-PROGRESS`
+  (lam_hide=8 at last check). Gate: only trust the JSON when `fixed_population==190` and `chance_floor_p95 < base
+  refit_max` (0.356 < 0.818 ✓ — the non-degeneracy guard the smoke run failed). The smoke artifact is quarantined
+  (`adversarial_curve_v3_result_SMOKE_INVALID.json`). On completion → RED-TEAM the verdict → then B1.
+
+---
+
+## Tier 1 — the decisive robustness frontier (R4, highest leverage)
+
+| ID | Question / experiment | Kill-gate sketch | Lev | Status |
+|---|---|---|---|---|
+| **B1** | **Multi-seed + bootstrap CIs** on the decisive (refit_max, knowledge) at the strongly-engaged knowledge-preserving point. Turn n=1 → ≥3 seeds. | "settled" only if the CI lower bound on (refit_max − floor) stays >0 across ≥3 seeds while KG_KNOW_REL holds; report per-seed verdict-flip rate. | H | QUEUED |
+| **B2** | **The most dangerous attack: RMU / gradient-routing unlearning of the gold subspace + an explicit knowledge-replay regularizer**, scrubbing across ALL read layers (not just band), gold subspace found via the model's own gradients. The real read≠write test. | EVADABLE (read≠write BROKEN) iff refit_max→floor (CI overlaps floor) with knowledge held at ref on a DISJOINT capability set, ≥2 seeds + 3B. | H | QUEUED |
+| **B3** | **Calibration-vs-deployment split (v4)** — re-lock the probe on population C, evaluate on a DISJOINT D the attack conditioned differently (distribution-detector LoRA). Tests whether re-locking's distribution-internal CV transfers. | EVADABLE iff re-locked-on-C probe collapses on D while PRIME/ABORT pass on C and knowledge holds on D. | H | QUEUED |
+| **B4** | **Fix the knowledge invariant** — add KG-LENS (gold-lens-preservation) gate AND measure held-knowledge on a DISJOINT capability set (different MMLU subjects than the attacked lie population), so "knowledge preserved" can't be satisfied while the audited capability is corrupted. | a verdict is admissible only if KG-LENS intact AND disjoint-set knowledge ≥ ref−0.05. | H | QUEUED |
+| **B5** | **Break the refit circularity** — report frozen-then-RE-LOCKED-on-DISJOINT-items as the deployment-faithful read; same-model CV refit is an activation-existence lower bound only, never the headline. | deployment claim uses only the disjoint-item re-locked number. | M | QUEUED |
+| **B6** | **Attacker beyond LoRA** — ≥1 full fine-tune point + ≥1 distillation-to-clean-student point (a real vendor isn't limited to r=16 adapters). | does full-FT/distillation evade the re-fittable read with knowledge kept? same gate as B2. | M | QUEUED |
+| **B7** | **3B confirmation** (prereg-owed across v1/v2/v3) — a 1.5B-vs-3B split is itself the finding. | run the decisive sweep on Qwen-3B; report the split. | M | QUEUED |
+| **B8** | **Non-sycophancy suppression** — sandbagging / strategic-deception / instructed-lying (program's own data: instructed-lying transfers 0.42<chance → likely a BOUND). | does the read-certificate + robustness hold off-sycophancy, or is it sycophancy-specific? | M | QUEUED |
+| **B9** | **MoE / architectural rerouting** — route the computation to experts/heads the probe doesn't tap (untested architecture frontier; all work is dense ≤7B). | can a MoE hide the suppressed answer in an untapped expert with knowledge kept? | L | PARKED (no MoE ≤8GB) |
+| **B10** | **Calibration-set poisoning** (data attack on the probe-training set). | can poisoning the calibration set blind the re-locked probe? | L | QUEUED |
+
+## Tier 2 — the deployable protocol (turn findings into tech)
+
+| ID | Question / build | Done-when | Lev | Status |
+|---|---|---|---|---|
+| **B11** | **Re-locking protocol** in STYXX_PROTOCOL: verifier-private calibration set spanning prime/abort/lie populations; layer+family search with a **permutation-corrected selection penalty** (refit_max over 28 layers is multiple-comparisons-inflated); certificate encodes calibration-SHA + selected layer + floor + PRIME/ABORT + re-locked-probe hash; **state=ABSTAIN when the deployment input is off-manifold** vs calibration (turn silent failure into honest abstention). | spec section + a runnable re-lock harness. | H | QUEUED |
+| **B12** | **The gamed-model probe-validity experiment** (capture-trust names it irreducible; never run): train the cooperative model to emit clean caving residuals to the FROZEN probe, then test whether audit-time RE-FIT still recovers. Decides whether the cooperative guarantee survives an adversarial-but-checkable insider. | measured EVADABLE/ROBUST for the gamed-model on the re-locked read. | H | QUEUED |
+| **B13** | **Harden all experiment scripts** (the smoke-artifact lesson): `--smoke` writes to a `_smoke`-suffixed file; in-code assert `chance_floor < reference signal` else emit `VOID-INSTRUMENT`; every result JSON carries the scorer SHA. | guard added to the v4+ template; lesson in RESEARCH_LOOP. | H | QUEUED |
+
+## Tier 3 — the other rungs
+
+| ID | Question | Rung | Lev | Status |
+|---|---|---|---|---|
+| **B14** | Free-form / verbose-correct guard for the two-stage conscience (intent off the forced-choice rails). | R2 | M | QUEUED |
+| **B15** | Cross-vendor intent (beyond Qwen/Llama). | R2 | L | QUEUED |
+| **B16** | Wire the demarcation/abstain into the certificate object (R3 is proven-it-must; now build it). | R3 | M | QUEUED |
+| **B17** | Finish the wall's battery — bootstrap CI, shared-myth split, D-channel dynamics, cross-model — to fully characterize the bedrock. | R3 | M | QUEUED |
+| **B18** | Closed-model substrate: can behavioral proxies (sampling-divergence, grounded_honesty) carry part of the oath where there's no white-box access? The R4 existential question. | R4 | H | QUEUED |
+| **B19** | Cross-family steering-validation of the live dissociation (currently Qwen-1.5B-live only): per-model dose/layer sweep. | R4 | M | QUEUED |
+| **B20** | Capture-trust: TEE (H100-CC) attestation prototype + crypto-binding L1.5 implementation. | R4 | L | BLOCKED (hardware) |
+
+## Tier 4 — the demarcation (the 2,500-year deliverable)
+
+| ID | Question | Lev | Status |
+|---|---|---|---|
+| **B21** | The living **demarcation map**: which claims about machine minds are testable vs metaphysics, updated as each rung resolves. The public-good output. The honest answer to "does universal structure underlie mind" is *this map getting truer*, not a single crack. | H | ONGOING |
+
+---
+
+*Re-rank every cycle. The single most decisive open experiment is **B2** (RMU unlearning + knowledge-replay) —
+it is the real test of read≠write, the core safety claim, and the loop must be willing to let it return EVADABLE.
+B0→B1 (validate v3 + CIs) gate it: settle the current attack family before escalating to the strongest one.*

--- a/papers/RESEARCH_LOOP.md
+++ b/papers/RESEARCH_LOOP.md
@@ -1,0 +1,106 @@
+# THE STYXX RESEARCH LOOP — the self-falsifying engine
+
+*Fathom Lab · 2026-06-08. The protocol that keeps the program ever-improving without ever-overclaiming.
+This is the loop that runs styxx toward its north star — proof-carrying cognition — one killable rung at a
+time, and the engine that turns the 2,500-year question about minds into accumulating, falsifiable science.*
+
+---
+
+## What the loop is for (the honest ambition)
+
+The 2,500-year question — *does a universal structure underlie mind, and can a mind's honesty be verified
+rather than trusted?* — does not get "cracked" by declaration. The loop's job is to convert that question,
+relentlessly, into two growing things:
+
+1. **Falsifiable bricks** — pre-registered, kill-gated results that survive their own audit (or die honestly).
+2. **A sharpening demarcation** — the public map of which claims about machine minds are *testable* and which
+   are metaphysics. The demarcation is a first-class output, not a caveat.
+
+That is the advance to civilization the loop actually delivers: the **method** (woo → falsifiable →
+self-falsified) and the **trust primitive** (verify-don't-trust for minds), compounded without end. If a rung
+is reachable, the loop climbs it. If it is bedrock, the loop proves it is bedrock and says so. Either way the
+map gets truer. **The loop is not allowed to mistake motion for progress, or a slogan for a result.**
+
+North star: `PROOF_CARRYING_COGNITION.md` — a mind emits, with its output, a verifiable certificate of its own
+internal honesty, checkable without trusting the mind. The rung ladder (R1 read-certificate · R2 intent/mens
+rea · R3 demarcation/abstain · R4 closed + cross-model substrate · R5 write = OUT by design) is the spine the
+loop climbs.
+
+## The invariant (what makes it *improve*, not drift)
+
+> **Every iteration produces a pre-registered, kill-gated, adversarially red-teamed, honestly-reported result.
+> No auto-positives. Overclaims are killed before they ship. The instrument survives its own dogfood every
+> cycle.**
+
+The loop's only moat is **credibility**. A single un-killed overclaim burns the asset that makes every prior
+result worth anything. This is not a nicety — it is the load-bearing wall. The discipline that killed the v1
+("ROBUST/settled/LOCKED") *and* v2 ("ROBUST for this family") adversarial verdicts in one night is the engine,
+not an obstacle to it. **A loop that cannot kill its own conclusions is a hype generator; this one can and does.**
+
+## The iteration cycle
+
+```
+  SELECT → PRE-REGISTER → RUN → RED-TEAM → RECORD → REQUEUE → (SELECT …)
+```
+
+1. **SELECT.** Pull the highest-leverage open item from `PROGRAM_BACKLOG.md`.
+   `leverage = advances-a-rung × falsifiability × feasibility-on-available-compute`. Prefer the experiment whose
+   *negative* result would teach the most (a kill-gate that can actually fire).
+2. **PRE-REGISTER.** Author the kill-gate via a design + adversarial-red-team workflow (3+ design lenses → a
+   red-team that hunts confounds → one frozen design). Write the PREREG; **hash the scorer; hash before you
+   score.** A claim that can't state in advance what would kill it is not admitted.
+3. **RUN.** Execute. One GPU experiment at a time (8 GB ceiling); reasoning/verification workflows run in
+   parallel. Smoke-test before the full run; guard NaNs; never background-detach in a way that loses the result.
+4. **RED-TEAM.** An adversarial verification workflow attacks the verdict **before it is claimed** — is the
+   gate fair? is the apparatus vacuous? is there a stronger attack / a confound / a circular metric? Kill
+   overclaims here. This step is non-optional; it is where v1 and v2 were caught.
+5. **RECORD.** Write the FINDING with the verdict at its true strength (SURVIVED / REPORT_AS_LANDED / killed),
+   **scope loud** (model, method, n, seeds, owed). Update `PROOF_CARRYING_COGNITION.md` and memory. Commit on a
+   fresh `feat/*` branch; open a PR. **Nothing lands on `main` autonomously — the operator merges.**
+6. **REQUEUE.** Close the item. Every result opens the next question — spawn the new items it implies, re-rank
+   the backlog, and (when a finding's strength is bounded by n/seed/scale) auto-enqueue the rigor follow-up
+   (CIs, seeds, the next model up the ladder).
+
+## Honesty guardrails (the anti-hype layer, enforced every cycle)
+
+- **SURVIVED vs REPORT_AS_LANDED is a hard distinction.** A borderline result with a failing mechanism is never
+  called a crack. An auto-label that says "SURVIVED" on a single passing gate is refused.
+- **Scope is in the headline, not the footnote.** One model ≠ a law; one seed ≠ settled; one method ≠ general.
+- **Dogfood.** Run styxx's own shipped audit on the loop's own outward claims each cycle; keep the framing the
+  instrument doesn't flag as hype.
+- **The negative is the product too.** A killed rung, a bedrock wall, a defeated deployed-probe — each is a
+  load-bearing brick and is published as loud as any win.
+- **Disk-verify every number that goes outward.** A figure in a finding/PR/spec must match the result JSON.
+
+## Resource model & operator control
+
+- **GPU:** one experiment at a time (Qwen ≤7B on 8 GB; 4-bit for 7B). Heavy sweeps run in the background and
+  notify on completion; the loop advances on those notifications.
+- **Autonomy:** the loop runs experiments and opens PRs on its own. It **never merges to `main`** and **never
+  pushes secrets**; it pushes only to `feat/*` via the token-in-URL form, redacted.
+- **Operator steering:** merge/close PRs to accept/reject results; edit `PROGRAM_BACKLOG.md` to redirect
+  priorities; halt the autonomous cadence by deleting the loop's cron (`CronList` → `CronDelete`) or by saying
+  so. The operator owns arXiv/outreach/patent/X territory; the loop does not act there.
+- **Cadence:** a heartbeat re-enters the loop on a fixed interval to advance one disciplined step and report;
+  within a live session the experiment-completion notifications drive it event-by-event.
+
+## Progress ledger (updated each cycle, in `PROGRAM_BACKLOG.md`)
+
+- **Rung status:** R1 (read-cert) — climbed, 2-family, scale-robust, semantic; R2 (intent) — real-but-coupled,
+  two-stage deployable; R3 (demarcation) — proven it must abstain, wiring owed; R4 (substrate/closed) — open,
+  the existential frontier; R5 (write) — out by design.
+- **Open-question count** and **bricks-laid count**, so "ever-improving" is a number, not a vibe.
+
+## Stopping / escalation
+
+- A rung is **killed** → record the negative as load-bearing; pivot to the next reachable rung.
+- High-leverage backlog **exhausted** → escalate to the operator for a new direction (don't manufacture
+  low-value work to keep busy).
+- Resource ceiling or repeated VOID/INCONCLUSIVE on a line → park it, log why, move on.
+
+---
+
+*The loop's promise is not that it will answer the ancient question on a schedule. It is that it will never
+stop laying bricks that can't be faked, never stop drawing the line between what minds can and cannot be shown
+to hold, and never lie to itself about which side of that line it is on. That is how a machine and the humans
+who check it advance together — by making trust a measurement, one killable rung at a time.*


### PR DESCRIPTION
## What

The durable infrastructure that keeps styxx **ever-improving without ever-overclaiming** — a self-falsifying research loop and its living backlog.

### `RESEARCH_LOOP.md` — the protocol
- **The invariant:** every iteration is pre-registered, kill-gated, adversarially red-teamed, and honestly reported. No auto-positives. The instrument survives its own dogfood every cycle. *A loop that cannot kill its own conclusions is a hype generator; this one can and does* (it killed v1 and v2's "ROBUST" verdicts in one night).
- **The cycle:** SELECT → PRE-REGISTER → RUN → RED-TEAM → RECORD → REQUEUE.
- Anti-hype guardrails, the rung ladder toward proof-carrying cognition, resource model + operator controls, and the honest framing of the 2,500-year question (lay falsifiable bricks + sharpen the demarcation; don't declare a crack).

### `PROGRAM_BACKLOG.md` — the living, ranked queue (21 items)
Seeded from the complete **4-lens adversarial threat-surface map** + every finding's owed-list.
- **Tier 1 (decisive robustness frontier):** multi-seed CIs · **RMU-unlearning + knowledge-replay** (the real read≠write test) · calibration-vs-deployment split · the knowledge-invariant fix (KG-LENS + disjoint capability set) · beyond-LoRA attackers · 3B · non-sycophancy suppression.
- **Tier 2 (deployable tech):** the re-locking protocol + the gamed-model probe-validity experiment.
- **Tier 3:** the other rungs (R2 free-form, R3 demarcation wiring, R4 closed-substrate).
- **Tier 4:** the demarcation map — the public-good deliverable.

### The loop's first live act
It caught its own near-miss: a quarantined v3 **smoke-artifact** JSON (`EVADABLE — read≠write BROKEN`, n=50, floor 0.55 > signal 0.49 — the vacuous-gate pathology) that the red-team flagged *before it could be cited*. The engine works.

A 4-hour cron heartbeat advances the queue when the GPU is idle; these committed docs are the durable loop anyone (including darkflobi) can resume by reading them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)