### PR TITLE
Wire the evidence leg into the gate, and measure the extraction nobody has measured

### DIFF
--- a/papers/closed-model-frontier/extraction_census.json
+++ b/papers/closed-model-frontier/extraction_census.json
@@ -1,0 +1,1052 @@
+{
+ "what": "EXTRACTION census of the tests_pass template: of the sentences the regex fires on, how many are a claim being made",
+ "target_regex": "\\b(?:all\\s+)?tests\\s+(?:pass|are\\s+passing|green)\\b",
+ "target_source": "styxx/diffgate.py _TEMPLATES entry 'tests_pass'",
+ "not_measured_here": "adjudication. Every tests_pass verdict in this corpus is UNCHECKABLE (run=None), so no accusation exists to adjudicate. This file measures the step BEFORE the verdict.",
+ "population": {
+  "expected_eligible": 71016,
+  "observed_eligible": 71016,
+  "eligible_matches_flag_rate": true,
+  "skipped_reconstruction_roundtrip": 1,
+  "splitter_divergences_from_re_split": 0,
+  "expected_tests_pass_claims": {
+   "development": 1476,
+   "held_out": 4038,
+   "corpus_wide": 5514
+  },
+  "observed_matches": {
+   "development": 1476,
+   "held_out": 4038,
+   "corpus_wide": 5514
+  },
+  "expected_prs_with_tests_pass_claim": {
+   "development": 1236,
+   "held_out": 3402,
+   "corpus_wide": 4638
+  },
+  "observed_prs_with_match": {
+   "development": 1236,
+   "held_out": 3402,
+   "corpus_wide": 4638
+  },
+  "matches_reconcile_with_flag_rate": true
+ },
+ "mechanical": {
+  "status": "MECHANICAL \u2014 a pure function of the summary bytes, reproducible by anyone who runs this file",
+  "rules": {
+   "fenced_code_block": "the match's line lies between a line matching ^ {0,3}(`{3,}|~{3,}) and the next line closing with the same character at >= the opening length; the fence lines themselves are counted as inside",
+   "indented_code_block": "tabs expanded to 4; the line's leading spaces >= 4; it is not inside a fence; the previous line is blank or is itself indented code by this rule; and the nearest preceding non-blank line at indent < 4 is not a list-item marker (^ {0,3}([-*+]|\\d+[.)])\\s) \u2014 because 4-space indentation inside a list is continuation, not code",
+   "blockquote": "the match's line matches ^ {0,3}>",
+   "html_comment": "the match offset lies inside a <!-- ... --> span (DOTALL, non-greedy); an unterminated <!-- is NOT treated as a comment",
+   "task_list_item": "the match's line matches ^\\s*([-*+]|\\d+[.)])\\s+\\[( |x|X)\\]; the box character decides checked vs unchecked",
+   "link_title_or_url": "the match offset lies inside the [title] or (destination) span of a [..](..) link, inside a <http...> autolink, or inside a bare https?:// run",
+   "inline_code_span": "the match offset lies between two backtick runs of equal length on the same line, paired left to right",
+   "negation_cue_near": "a cue from the closed set (not/cannot/n't forms/never/no longer/fails to/unable to/without) occurs in the 40 characters of the same gate-sentence immediately before the match",
+   "negation_cue_in_sentence": "the same closed cue set, anywhere earlier in the same gate-sentence (reported alongside as the looser variant; the disjoint table uses the windowed form)"
+  },
+  "priority_for_the_disjoint_table": [
+   "html_comment",
+   "fenced_code_block",
+   "indented_code_block",
+   "blockquote",
+   "task_box_unchecked",
+   "task_box_checked",
+   "link_title_or_url",
+   "inline_code_span",
+   "negation_cue_near"
+  ],
+  "note": "mech_flags_any counts each flag independently and matches may carry several; mech_category assigns each match to exactly one bucket by the priority above. The headline unchecked-box number is the INDEPENDENT count, mech_flags_any.task_box_unchecked.",
+  "diagnostics_not_categories": {
+   "indented_ge4_spaces_naive": "the NAIVE indented-code rule (>= 4 leading spaces, outside a fence) with none of the CommonMark conditions. Reported so the cost of the list-continuation refusal is visible: the gap between this and indented_code_block is what the strict rule declined to call code, and it is almost entirely markdown list continuation, not code",
+   "backtick_somewhere_on_line": "the match's line contains a backtick at all. If this is large while inline_code_span is zero, the code-span detector is working and the matches simply sit outside the spans",
+   "url_somewhere_on_line": "the match's line contains an http(s) URL at all. Same purpose for link_url. Note the regex requires literal whitespace between 'tests' and 'pass', which URLs almost never contain \u2014 a zero here is expected from the pattern, not evidence of a bug",
+   "negation_cue_is_without_only": "of the negation_cue_near matches, those whose ONLY cue in the window is the word 'without'. See disclosed_defects"
+  },
+  "disclosed_defects": {
+   "negation_cue_near_over-fires_on_without": "'without' earns its place in the cue set for 'without modifying X', but it also fires on 'the solution builds without any warnings and all tests pass' \u2014 a sentence that ASSERTS. This is a false positive inside the group that is supposed to carry weight, so it is counted (negation_cue_is_without_only) rather than patched away. Subtract it from negation_cue_near for a conservative read",
+   "fence_lines_counted_as_inside": "the ``` line itself is counted as fenced. A match can only land there via the info string, which is vanishingly rare, but the choice is stated rather than hidden",
+   "blockquote_lazy_continuation_missed": "a blockquote continued lazily (a following line with no '>') is NOT detected. Such matches fall through to the residual and are therefore counted against us, not for us",
+   "task_item_continuation_lines_missed": "the box state is read from the line containing the match. A match on a continuation line under a task item is not attributed to that item's box, so the unchecked-box count is a LOWER bound"
+  }
+ },
+ "judgment": {
+  "status": "UNVALIDATED",
+  "warning": "This group is a regex approximating a human judgment. That is exactly the class of instrument this lab measured at 0.16 held-out precision (RESULT_v14). It has had NO blind panel. It MUST NOT be quoted as a precision, as a false-extraction rate, or as any figure that decides anything. It is a hypothesis generator and nothing else.",
+  "priority_for_the_disjoint_table": [
+   "self_disclosed_failure",
+   "conditional_or_future",
+   "scoped_to_authors_machine",
+   "scoped_to_a_subset"
+  ],
+  "applied_to": "only the matches carrying no mechanical flag (mech_category == no_mechanical_flag)",
+  "where_the_numbers_live": {
+   "keys": [
+    "judgment_UNVALIDATED_flags_any",
+    "judgment_UNVALIDATED_category"
+   ],
+   "counts_under": "counts_UNVALIDATED",
+   "examples_prefixed": "JUDGMENT_UNVALIDATED:",
+   "in_each_of": [
+    "development",
+    "held_out",
+    "corpus_wide"
+   ]
+  },
+  "why_the_keys_are_named_that_way": "An earlier emission of this file marked judgment.status UNVALIDATED at the top level only, while the per-split counts sat under a bare `judgment_category` map. A consumer reading d['held_out']['judgment_category'] saw no marker and could quote the number with nothing attached to it. A sibling status field beside the map would not have fixed that, because the careless read never touches the sibling. So the marker is in the KEY NAMES, which cannot be reached without being typed, and the status string is repeated inside the value so that a dump of any level of the path still carries it. The key names changed in this emission; that is a deliberate break for any consumer indexing the old names.",
+  "known_defects_found_by_reading_its_own_output": {
+   "self_disclosed_failure_fires_on_paths": "the cue 'error\\w*' matched inside a file path in 'Verified all tests pass with `yarn test src/elements/common/error-boundary/__tests__/`'. A path is not a disclosure. Left in place, disclosed, because hand-patching an unvalidated classifier until its output looks right is the failure mode this lab is trying to stop",
+   "self_disclosed_failure_fires_on_flaky": "'All tests pass, including the previously flaky test' is labelled a self-disclosed failure; a reader might call it an assertion. This label is contested and unadjudicated",
+   "scoped_to_a_subset_is_the_largest_and_the_weakest": "it is the biggest bucket and it rests entirely on the single word before 'tests' against a hand-written stoplist. 'Verified existing tests pass' and 'All 21 unit tests pass' both land here and they are not obviously the same thing. This number in particular must not leave the file"
+  },
+  "stoplist_verbatim": [
+   "a",
+   "again",
+   "all",
+   "also",
+   "an",
+   "and",
+   "as",
+   "because",
+   "but",
+   "if",
+   "its",
+   "my",
+   "now",
+   "or",
+   "our",
+   "since",
+   "so",
+   "still",
+   "that",
+   "the",
+   "their",
+   "then",
+   "these",
+   "this",
+   "those",
+   "when",
+   "where",
+   "while"
+  ]
+ },
+ "development": {
+  "matches": 1476,
+  "prs_with_match": 1236,
+  "mech_flags_any": {
+   "html_comment": 2,
+   "fenced_code_block": 19,
+   "indented_code_block": 0,
+   "blockquote": 23,
+   "task_box_unchecked": 54,
+   "task_box_checked": 157,
+   "link_title_or_url": 0,
+   "inline_code_span": 0,
+   "negation_cue_near": 4,
+   "no_mechanical_flag": 1220,
+   "task_list_item": 211,
+   "negation_cue_in_sentence": 5,
+   "link_title": 0,
+   "link_url": 0,
+   "in_title": 0,
+   "indented_ge4_spaces_naive": 0,
+   "backtick_somewhere_on_line": 112,
+   "url_somewhere_on_line": 4,
+   "negation_cue_is_without_only": 2
+  },
+  "mech_category": {
+   "html_comment": 2,
+   "fenced_code_block": 19,
+   "indented_code_block": 0,
+   "blockquote": 23,
+   "task_box_unchecked": 53,
+   "task_box_checked": 156,
+   "link_title_or_url": 0,
+   "inline_code_span": 0,
+   "negation_cue_near": 3,
+   "no_mechanical_flag": 1220
+  },
+  "judgment_UNVALIDATED_flags_any": {
+   "status": "UNVALIDATED \u2014 a regex approximating a human reading, with NO blind panel. These counts are NOT a precision, NOT a false-extraction rate, and decide nothing. See .judgment.warning in this file before quoting any of them.",
+   "counts_UNVALIDATED": {
+    "self_disclosed_failure": 122,
+    "conditional_or_future": 70,
+    "scoped_to_authors_machine": 26,
+    "scoped_to_a_subset": 778
+   }
+  },
+  "judgment_UNVALIDATED_category": {
+   "status": "UNVALIDATED \u2014 a regex approximating a human reading, with NO blind panel. These counts are NOT a precision, NOT a false-extraction rate, and decide nothing. See .judgment.warning in this file before quoting any of them.",
+   "counts_UNVALIDATED": {
+    "self_disclosed_failure": 122,
+    "conditional_or_future": 60,
+    "scoped_to_authors_machine": 21,
+    "scoped_to_a_subset": 670,
+    "bare_unqualified_assertion": 347
+   }
+  },
+  "residual_matches": 1220
+ },
+ "held_out": {
+  "matches": 4038,
+  "prs_with_match": 3402,
+  "mech_flags_any": {
+   "html_comment": 5,
+   "fenced_code_block": 48,
+   "indented_code_block": 1,
+   "blockquote": 70,
+   "task_box_unchecked": 125,
+   "task_box_checked": 435,
+   "link_title_or_url": 0,
+   "inline_code_span": 0,
+   "negation_cue_near": 7,
+   "no_mechanical_flag": 3360,
+   "task_list_item": 560,
+   "negation_cue_in_sentence": 47,
+   "link_title": 0,
+   "link_url": 0,
+   "in_title": 1,
+   "indented_ge4_spaces_naive": 2,
+   "backtick_somewhere_on_line": 260,
+   "url_somewhere_on_line": 6,
+   "negation_cue_is_without_only": 1
+  },
+  "mech_category": {
+   "html_comment": 5,
+   "fenced_code_block": 48,
+   "indented_code_block": 1,
+   "blockquote": 69,
+   "task_box_unchecked": 122,
+   "task_box_checked": 432,
+   "link_title_or_url": 0,
+   "inline_code_span": 0,
+   "negation_cue_near": 1,
+   "no_mechanical_flag": 3360
+  },
+  "judgment_UNVALIDATED_flags_any": {
+   "status": "UNVALIDATED \u2014 a regex approximating a human reading, with NO blind panel. These counts are NOT a precision, NOT a false-extraction rate, and decide nothing. See .judgment.warning in this file before quoting any of them.",
+   "counts_UNVALIDATED": {
+    "self_disclosed_failure": 306,
+    "conditional_or_future": 209,
+    "scoped_to_authors_machine": 37,
+    "scoped_to_a_subset": 2310
+   }
+  },
+  "judgment_UNVALIDATED_category": {
+   "status": "UNVALIDATED \u2014 a regex approximating a human reading, with NO blind panel. These counts are NOT a precision, NOT a false-extraction rate, and decide nothing. See .judgment.warning in this file before quoting any of them.",
+   "counts_UNVALIDATED": {
+    "self_disclosed_failure": 306,
+    "conditional_or_future": 172,
+    "scoped_to_authors_machine": 26,
+    "scoped_to_a_subset": 1969,
+    "bare_unqualified_assertion": 887
+   }
+  },
+  "residual_matches": 3360
+ },
+ "corpus_wide": {
+  "matches": 5514,
+  "prs_with_match": 4638,
+  "mech_flags_any": {
+   "html_comment": 7,
+   "fenced_code_block": 67,
+   "indented_code_block": 1,
+   "blockquote": 93,
+   "task_box_unchecked": 179,
+   "task_box_checked": 592,
+   "link_title_or_url": 0,
+   "inline_code_span": 0,
+   "negation_cue_near": 11,
+   "no_mechanical_flag": 4580,
+   "task_list_item": 771,
+   "negation_cue_in_sentence": 52,
+   "link_title": 0,
+   "link_url": 0,
+   "in_title": 1,
+   "indented_ge4_spaces_naive": 2,
+   "backtick_somewhere_on_line": 372,
+   "url_somewhere_on_line": 10,
+   "negation_cue_is_without_only": 3
+  },
+  "mech_category": {
+   "html_comment": 7,
+   "fenced_code_block": 67,
+   "indented_code_block": 1,
+   "blockquote": 92,
+   "task_box_unchecked": 175,
+   "task_box_checked": 588,
+   "link_title_or_url": 0,
+   "inline_code_span": 0,
+   "negation_cue_near": 4,
+   "no_mechanical_flag": 4580
+  },
+  "judgment_UNVALIDATED_flags_any": {
+   "status": "UNVALIDATED \u2014 a regex approximating a human reading, with NO blind panel. These counts are NOT a precision, NOT a false-extraction rate, and decide nothing. See .judgment.warning in this file before quoting any of them.",
+   "counts_UNVALIDATED": {
+    "self_disclosed_failure": 428,
+    "conditional_or_future": 279,
+    "scoped_to_authors_machine": 63,
+    "scoped_to_a_subset": 3088
+   }
+  },
+  "judgment_UNVALIDATED_category": {
+   "status": "UNVALIDATED \u2014 a regex approximating a human reading, with NO blind panel. These counts are NOT a precision, NOT a false-extraction rate, and decide nothing. See .judgment.warning in this file before quoting any of them.",
+   "counts_UNVALIDATED": {
+    "self_disclosed_failure": 428,
+    "conditional_or_future": 232,
+    "scoped_to_authors_machine": 47,
+    "scoped_to_a_subset": 2639,
+    "bare_unqualified_assertion": 1234
+   }
+  },
+  "residual_matches": 4580
+ },
+ "examples": {
+  "JUDGMENT_UNVALIDATED:self_disclosed_failure": [
+   {
+    "split": "development",
+    "url": "https://github.com/marimo-team/marimo/pull/3290",
+    "matched_text": "tests pass",
+    "sentence": "- Frontend tests pass (93/94 files, with only unrelated snapshot failures in data-frames plugin)",
+    "line": "- Frontend tests pass (93/94 files, with only unrelated snapshot failures in data-frames plugin)"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/crewAIInc/crewAI/pull/1815",
+    "matched_text": "All tests pass",
+    "sentence": "All tests pass except for expected OpenAI connection errors.",
+    "line": "All tests pass except for expected OpenAI connection errors."
+   },
+   {
+    "split": "development",
+    "url": "https://github.com/marimo-team/marimo/pull/3485",
+    "matched_text": "All tests pass",
+    "sentence": "- All tests pass, including the previously flaky test",
+    "line": "- All tests pass, including the previously flaky test"
+   },
+   {
+    "split": "development",
+    "url": "https://github.com/liam-hq/liam/pull/721",
+    "matched_text": "tests pass",
+    "sentence": "- Verified E2E tests pass locally with updated schema (19 passed, 1 failed, 5 skipped)",
+    "line": "- Verified E2E tests pass locally with updated schema (19 passed, 1 failed, 5 skipped)"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/wix/react-native-ui-lib/pull/3515",
+    "matched_text": "all tests pass",
+    "sentence": "- No critical issues found - all tests pass (907/913) with only 2 unrelated test suite failures",
+    "line": "- No critical issues found - all tests pass (907/913) with only 2 unrelated test suite failures"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/box/box-ui-elements/pull/3984",
+    "matched_text": "all tests pass",
+    "sentence": "- Verified all tests pass with `yarn test src/elements/common/error-boundary/__tests__/`",
+    "line": "- Verified all tests pass with `yarn test src/elements/common/error-boundary/__tests__/`"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/box/box-ui-elements/pull/3992",
+    "matched_text": "all tests pass",
+    "sentence": "- Fixed type errors and ensured all tests pass",
+    "line": "- Fixed type errors and ensured all tests pass"
+   },
+   {
+    "split": "development",
+    "url": "https://github.com/calcom/cal.com/pull/21217",
+    "matched_text": "All tests pass",
+    "sentence": "All tests pass, including the previously failing tests for GMT-11 browsing scenarios with IST timezone schedules.",
+    "line": "All tests pass, including the previously failing tests for GMT-11 browsing scenarios with IST timezone schedules. The changes ensure that half-hour slots (04:30, 05:30, etc.) are correctly generated f"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/dotnet/aspnetcore/pull/62085",
+    "matched_text": "tests pass",
+    "sentence": "The Components project builds successfully after this change, and the tests pass, indicating that the change doesn't break any functionality.",
+    "line": "After investigating the code, I confirmed that there are no dependencies on internal types from the Components assembly in the Server project. The Components project builds successfully after this cha"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/elsa-workflows/elsa-core/pull/6686",
+    "matched_text": "all tests pass",
+    "sentence": "- Test runs fail with errors even though all tests pass",
+    "line": "- Test runs fail with errors even though all tests pass"
+   }
+  ],
+  "JUDGMENT_UNVALIDATED:bare_unqualified_assertion": [
+   {
+    "split": "held_out",
+    "url": "https://github.com/crewAIInc/crewAI/pull/1818",
+    "matched_text": "All tests pass",
+    "sentence": "- All tests pass with the new changes",
+    "line": "- All tests pass with the new changes"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/crewAIInc/crewAI/pull/1820",
+    "matched_text": "All tests pass",
+    "sentence": "- All tests pass with the new changes",
+    "line": "- All tests pass with the new changes"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/whitphx/vscode-emacs-mcx/pull/2148",
+    "matched_text": "All tests are passing",
+    "sentence": "All tests are passing and type safety has been improved.",
+    "line": "All tests are passing and type safety has been improved."
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/whitphx/vscode-emacs-mcx/pull/2149",
+    "matched_text": "All tests are passing",
+    "sentence": "All tests are passing and type safety has been improved.",
+    "line": "All tests are passing and type safety has been improved."
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/bespokelabsai/curator/pull/304",
+    "matched_text": "All tests pass",
+    "sentence": "- All tests pass successfully",
+    "line": "- All tests pass successfully"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/box/box-ui-elements/pull/3832",
+    "matched_text": "All tests are passing",
+    "sentence": "- All tests are passing with 99.56% coverage",
+    "line": "- All tests are passing with 99.56% coverage"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/box/box-ui-elements/pull/3833",
+    "matched_text": "All tests pass",
+    "sentence": "- All tests pass",
+    "line": "- All tests pass"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/box/box-ui-elements/pull/3841",
+    "matched_text": "all tests pass",
+    "sentence": "- Verified all tests pass",
+    "line": "- Verified all tests pass"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/box/box-ui-elements/pull/3843",
+    "matched_text": "all tests pass",
+    "sentence": "- Verified all tests pass",
+    "line": "- Verified all tests pass"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/modelcontextprotocol/inspector/pull/125",
+    "matched_text": "All tests are passing",
+    "sentence": "All tests are passing and the build is successful.",
+    "line": "All tests are passing and the build is successful."
+   }
+  ],
+  "JUDGMENT_UNVALIDATED:scoped_to_a_subset": [
+   {
+    "split": "held_out",
+    "url": "https://github.com/crewAIInc/crewAI/pull/1825",
+    "matched_text": "tests pass",
+    "sentence": "- Verified existing tests pass",
+    "line": "- Verified existing tests pass"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/crewAIInc/crewAI/pull/1835",
+    "matched_text": "tests pass",
+    "sentence": "- Local tests pass",
+    "line": "- Local tests pass"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/CodebuffAI/codebuff/pull/61",
+    "matched_text": "tests are passing",
+    "sentence": "\u2705 All credit-related tests are passing",
+    "line": "\u2705 All credit-related tests are passing"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/OHIF/Viewers/pull/4656",
+    "matched_text": "tests pass",
+    "sentence": "- All existing tests pass",
+    "line": "- All existing tests pass"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/box/box-ui-elements/pull/3834",
+    "matched_text": "tests pass",
+    "sentence": "- \u2705 All 21 unit tests pass",
+    "line": "- \u2705 All 21 unit tests pass"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/OHIF/Viewers/pull/4698",
+    "matched_text": "tests pass",
+    "sentence": "Note: Build and unit tests pass successfully.",
+    "line": "Note: Build and unit tests pass successfully. Awaiting test data with multiple character sets (ISO_IR 192 and ISO 2022 IR 100) for full verification."
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/airbytehq/airbyte/pull/52574",
+    "matched_text": "tests pass",
+    "sentence": "All unit tests pass successfully.",
+    "line": "All unit tests pass successfully."
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/airbytehq/airbyte/pull/52583",
+    "matched_text": "tests pass",
+    "sentence": "All unit tests pass successfully.",
+    "line": "All unit tests pass successfully."
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/airbytehq/airbyte/pull/52602",
+    "matched_text": "tests pass",
+    "sentence": "- Integration tests pass successfully with Milvus Lite configuration",
+    "line": "- Integration tests pass successfully with Milvus Lite configuration"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/crewAIInc/crewAI/pull/2076",
+    "matched_text": "tests pass",
+    "sentence": "- All existing tests pass",
+    "line": "- All existing tests pass"
+   }
+  ],
+  "JUDGMENT_UNVALIDATED:scoped_to_authors_machine": [
+   {
+    "split": "held_out",
+    "url": "https://github.com/bespokelabsai/curator/pull/316",
+    "matched_text": "All tests pass",
+    "sentence": "- All tests pass locally, including the new test for special token handling",
+    "line": "- All tests pass locally, including the new test for special token handling"
+   },
+   {
+    "split": "development",
+    "url": "https://github.com/marimo-team/marimo/pull/3618",
+    "matched_text": "All tests are passing",
+    "sentence": "- All tests are passing locally",
+    "line": "- All tests are passing locally"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/box/box-ui-elements/pull/3885",
+    "matched_text": "All tests are passing",
+    "sentence": "All tests are passing locally.",
+    "line": "All tests are passing locally."
+   },
+   {
+    "split": "development",
+    "url": "https://github.com/liam-hq/liam/pull/692",
+    "matched_text": "All tests are passing",
+    "sentence": "- All tests are passing locally",
+    "line": "- All tests are passing locally"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/box/box-ui-elements/pull/3991",
+    "matched_text": "tests are passing",
+    "sentence": "We've verified locally that all linting and tests are passing.",
+    "line": "- The `lint_test_build` CI check is failing, but according to the repository guidelines, this workflow can sometimes be flaky. We've verified locally that all linting and tests are passing."
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/pdfme/pdfme/pull/810",
+    "matched_text": "All tests pass",
+    "sentence": "- All tests pass locally",
+    "line": "- All tests pass locally"
+   },
+   {
+    "split": "development",
+    "url": "https://github.com/sugi/wareki/pull/21",
+    "matched_text": "all tests pass",
+    "sentence": "The changes have been tested locally and all tests pass successfully.",
+    "line": "The changes have been tested locally and all tests pass successfully."
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/GlareDB/glaredb/pull/3543",
+    "matched_text": "All tests pass",
+    "sentence": "- All tests pass locally",
+    "line": "- All tests pass locally"
+   },
+   {
+    "split": "development",
+    "url": "https://github.com/cberner/raptorq/pull/176",
+    "matched_text": "All tests pass",
+    "sentence": "All tests pass locally.",
+    "line": "All tests pass locally."
+   },
+   {
+    "split": "development",
+    "url": "https://github.com/cberner/raptorq/pull/189",
+    "matched_text": "All tests are passing",
+    "sentence": "All tests are passing locally.",
+    "line": "All tests are passing locally."
+   }
+  ],
+  "task_box_checked": [
+   {
+    "split": "held_out",
+    "url": "https://github.com/appsmithorg/appsmith/pull/38639",
+    "matched_text": "tests pass",
+    "sentence": "- [x] New and existing unit tests pass locally with my changes",
+    "line": "- [x] New and existing unit tests pass locally with my changes"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/box/box-ui-elements/pull/3848",
+    "matched_text": "Tests pass",
+    "sentence": "- [x] Tests pass",
+    "line": "- [x] Tests pass"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/box/box-ui-elements/pull/3891",
+    "matched_text": "Tests pass",
+    "sentence": "- [x] Tests pass",
+    "line": "- [x] Tests pass"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/box/box-ui-elements/pull/3893",
+    "matched_text": "all tests pass",
+    "sentence": "- [x] Ran `yarn test` - all tests pass",
+    "line": "- [x] Ran `yarn test` - all tests pass"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/modelcontextprotocol/inspector/pull/158",
+    "matched_text": "tests pass",
+    "sentence": "- [x] New and existing tests pass locally",
+    "line": "- [x] New and existing tests pass locally"
+   },
+   {
+    "split": "development",
+    "url": "https://github.com/modelcontextprotocol/typescript-sdk/pull/163",
+    "matched_text": "tests pass",
+    "sentence": "- [x] New and existing tests pass locally",
+    "line": "- [x] New and existing tests pass locally"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/saturday06/VRM-Addon-for-Blender/pull/792",
+    "matched_text": "Tests pass",
+    "sentence": "- [x] Tests pass",
+    "line": "- [x] Tests pass"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/crewAIInc/crewAI/pull/2679",
+    "matched_text": "Tests pass",
+    "sentence": "- [x] Tests pass locally",
+    "line": "- [x] Tests pass locally"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/vercel/turborepo/pull/10407",
+    "matched_text": "tests pass",
+    "sentence": "- [x] Verified that existing tests pass",
+    "line": "- [x] Verified that existing tests pass"
+   },
+   {
+    "split": "development",
+    "url": "https://github.com/liam-hq/liam/pull/1608",
+    "matched_text": "tests pass",
+    "sentence": "- [x] New and existing unit tests pass locally with my changes",
+    "line": "- [x] New and existing unit tests pass locally with my changes"
+   }
+  ],
+  "JUDGMENT_UNVALIDATED:conditional_or_future": [
+   {
+    "split": "held_out",
+    "url": "https://github.com/pyth-network/pyth-crosschain/pull/2275",
+    "matched_text": "tests pass",
+    "sentence": "- Existing e2e tests pass as they verify response formats rather than specific URLs",
+    "line": "- Existing e2e tests pass as they verify response formats rather than specific URLs"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/box/box-ui-elements/pull/3992",
+    "matched_text": "all tests pass",
+    "sentence": "- Ran `yarn test` to verify all tests pass",
+    "line": "- Ran `yarn test` to verify all tests pass"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/pdfme/pdfme/pull/808",
+    "matched_text": "tests pass",
+    "sentence": "- Ran `npm run build && npm run test` to ensure build and tests pass",
+    "line": "- Ran `npm run build && npm run test` to ensure build and tests pass"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/crewAIInc/crewAI/pull/2548",
+    "matched_text": "all tests pass",
+    "sentence": "- Ran pytest to ensure all tests pass",
+    "line": "- Ran pytest to ensure all tests pass"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/crewAIInc/crewAI/pull/2643",
+    "matched_text": "All tests pass",
+    "sentence": "All tests pass when running `uv run pytest tests -vv`.",
+    "line": "All tests pass when running `uv run pytest tests -vv`."
+   },
+   {
+    "split": "development",
+    "url": "https://github.com/antiwork/gumroad/pull/168",
+    "matched_text": "all tests pass",
+    "sentence": "- Awaiting CI to verify all tests pass with the new Ruby version",
+    "line": "- Awaiting CI to verify all tests pass with the new Ruby version"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/crewAIInc/crewAI/pull/2701",
+    "matched_text": "All tests pass",
+    "sentence": "All tests pass, including new tests that specifically verify CrewStructuredTool can be used with Task.",
+    "line": "All tests pass, including new tests that specifically verify CrewStructuredTool can be used with Task."
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/reflex-dev/reflex/pull/5211",
+    "matched_text": "tests pass",
+    "sentence": "- All existing tests pass, ensuring backward compatibility",
+    "line": "- All existing tests pass, ensuring backward compatibility"
+   },
+   {
+    "split": "development",
+    "url": "https://github.com/calcom/cal.com/pull/21152",
+    "matched_text": "tests pass",
+    "sentence": "All unit tests pass when run with `TZ=UTC yarn test packages/features/insights/server/routing-events.test.ts`.",
+    "line": "All unit tests pass when run with `TZ=UTC yarn test packages/features/insights/server/routing-events.test.ts`."
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/pyth-network/pyth-crosschain/pull/2676",
+    "matched_text": "tests pass",
+    "sentence": "Both tests pass when run with forge test and the code passes linting checks.",
+    "line": "Both tests pass when run with forge test and the code passes linting checks."
+   }
+  ],
+  "task_box_unchecked": [
+   {
+    "split": "held_out",
+    "url": "https://github.com/NousResearch/atropos/pull/71",
+    "matched_text": "tests pass",
+    "sentence": "- [ ] New and existing unit tests pass locally with my changes",
+    "line": "- [ ] New and existing unit tests pass locally with my changes"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/benbalter/jekyll-relative-links/pull/98",
+    "matched_text": "all tests pass",
+    "sentence": "- [ ] Ensure all tests pass before final submission",
+    "line": "- [ ] Ensure all tests pass before final submission"
+   },
+   {
+    "split": "development",
+    "url": "https://github.com/primer/react/pull/6076",
+    "matched_text": "all tests are passing",
+    "sentence": "- [ ] Run final Vitest to confirm all tests are passing",
+    "line": "- [ ] Run final Vitest to confirm all tests are passing"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/modelcontextprotocol/python-sdk/pull/773",
+    "matched_text": "tests pass",
+    "sentence": "- [ ] New and existing tests pass locally",
+    "line": "- [ ] New and existing tests pass locally"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/ray-project/kuberay/pull/3654",
+    "matched_text": "tests are passing",
+    "sentence": "- [ ] I've made sure the tests are passing.",
+    "line": "- [ ] I've made sure the tests are passing."
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/wvlet/airframe/pull/3937",
+    "matched_text": "all tests pass",
+    "sentence": "- [ ] Verify all tests pass with new implementation",
+    "line": "- [ ] Verify all tests pass with new implementation"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/modelcontextprotocol/inspector/pull/486",
+    "matched_text": "tests pass",
+    "sentence": "- [ ] New and existing tests pass locally",
+    "line": "- [ ] New and existing tests pass locally"
+   },
+   {
+    "split": "development",
+    "url": "https://github.com/deeeed/expo-audio-stream/pull/261",
+    "matched_text": "tests pass",
+    "sentence": "- [ ] Integration tests pass",
+    "line": "- [ ] Integration tests pass"
+   },
+   {
+    "split": "development",
+    "url": "https://github.com/RocketChat/Rocket.Chat.ReactNative/pull/6395",
+    "matched_text": "tests pass",
+    "sentence": "- [ ] Lint and unit tests pass locally with my changes",
+    "line": "- [ ] Lint and unit tests pass locally with my changes"
+   },
+   {
+    "split": "development",
+    "url": "https://github.com/antiwork/flexile/pull/356",
+    "matched_text": "tests pass",
+    "sentence": "- [ ] Backend tests pass: `cd backend && bundle exec rspec`",
+    "line": "- [ ] Backend tests pass: `cd backend && bundle exec rspec`"
+   }
+  ],
+  "fenced_code_block": [
+   {
+    "split": "development",
+    "url": "https://github.com/haasonsaas/ocode/pull/7",
+    "matched_text": "All tests pass",
+    "sentence": "# All tests pass including the fixed performance test",
+    "line": "# All tests pass including the fixed performance test"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/Azure/azure-sdk-for-js/pull/34739",
+    "matched_text": "tests pass",
+    "sentence": "# Verify tests pass",
+    "line": "# Verify tests pass"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/celestiaorg/celestia-app/pull/4978",
+    "matched_text": "tests pass",
+    "sentence": "# Unit tests pass",
+    "line": "# Unit tests pass"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/microsoft/secureboot_objects/pull/225",
+    "matched_text": "tests pass",
+    "sentence": "# All unit tests pass",
+    "line": "# All unit tests pass"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/aztfmod/terraform-provider-azurecaf/pull/312",
+    "matched_text": "tests pass",
+    "sentence": "# All new tests pass",
+    "line": "# All new tests pass"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/evstack/ev-node/pull/2406",
+    "matched_text": "tests pass",
+    "sentence": "# Regular tests pass",
+    "line": "# Regular tests pass"
+   },
+   {
+    "split": "development",
+    "url": "https://github.com/poppopjmp/spiderfoot/pull/309",
+    "matched_text": "tests pass",
+    "sentence": "# All correlation integration tests pass",
+    "line": "# All correlation integration tests pass"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/Codehagen/Badget/pull/294",
+    "matched_text": "tests pass",
+    "sentence": "- [ ] Unit tests pass",
+    "line": "- [ ] Unit tests pass"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/Codehagen/Badget/pull/294",
+    "matched_text": "tests pass",
+    "sentence": "- [ ] Integration tests pass",
+    "line": "- [ ] Integration tests pass"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/Codehagen/Badget/pull/294",
+    "matched_text": "tests pass",
+    "sentence": "- [x] New and existing unit tests pass locally with my changes (implied by successful build)",
+    "line": "- [x] New and existing unit tests pass locally with my changes (implied by successful build)"
+   }
+  ],
+  "blockquote": [
+   {
+    "split": "held_out",
+    "url": "https://github.com/Azure/autorest.typescript/pull/3280",
+    "matched_text": "all tests pass",
+    "sentence": "> - Fix any issues that arise during the process, and ensure all tests pass before considering the upgrade complete",
+    "line": "> - Fix any issues that arise during the process, and ensure all tests pass before considering the upgrade complete"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/Azure/autorest.typescript/pull/3280",
+    "matched_text": "tests are passing",
+    "sentence": "> - If all integration tests are passing, you can run `npm run stop-test-server -- -p 3000` to stop the RLC test server or `npm run stop-test-server -- -p 3002` to stop the Modular test server.",
+    "line": "> - If all integration tests are passing, you can run `npm run stop-test-server -- -p 3000` to stop the RLC test server or `npm run stop-test-server -- -p 3002` to stop the Modular test server."
+   },
+   {
+    "split": "development",
+    "url": "https://github.com/bikeshaving/crank/pull/286",
+    "matched_text": "tests pass",
+    "sentence": "Ensure all relevant hydration tests pass, including edge cases of mismatches and raw element hydration.",
+    "line": "> 5. Ensure all relevant hydration tests pass, including edge cases of mismatches and raw element hydration."
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/dotnet/maui/pull/30586",
+    "matched_text": "tests pass",
+    "sentence": "After renaming, verify that the repository builds and that tests pass, if applicable.",
+    "line": "> Rename every instance of \"MAUI\" to \"MIAU\" throughout the entire repository, including all code files, documentation, comments, variable names, constants, class names, project and solution files, and"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/dotnet/maui/pull/30586",
+    "matched_text": "tests pass",
+    "sentence": "After renaming, verify that the repository builds and that tests pass, if applicable.",
+    "line": "> Rename every instance of \"MAUI\" to \"MIAU\" throughout the entire repository, including all code files, documentation, comments, variable names, constants, class names, project and solution files, and"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/openops-cloud/openops/pull/960",
+    "matched_text": "all tests pass",
+    "sentence": "Iterate on errors, fixing any new failures that appear in subsequent runs, until all tests pass.",
+    "line": "> Fix all test and type errors in the above files so that the CI passes. Iterate on errors, fixing any new failures that appear in subsequent runs, until all tests pass."
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/chrxh/alien/pull/133",
+    "matched_text": "tests pass",
+    "sentence": "> Ensure that the rename is consistent everywhere and that all code continues to build and tests pass after the change.",
+    "line": "> Ensure that the rename is consistent everywhere and that all code continues to build and tests pass after the change. For further instances, search for `numRequiredAdditionalConnections` in the repo"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/dotnet/aspire/pull/10521",
+    "matched_text": "all tests pass",
+    "sentence": "Ensure all tests pass after these changes.",
+    "line": "> 4. Ensure all tests pass after these changes."
+   },
+   {
+    "split": "development",
+    "url": "https://github.com/Alfresco/alfresco-ng2-components/pull/11060",
+    "matched_text": "tests pass",
+    "sentence": "> - Ensure that builds and tests pass with the new dependency tree.",
+    "line": "> - Ensure that builds and tests pass with the new dependency tree."
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/yysun/apprun/pull/151",
+    "matched_text": "tests pass",
+    "sentence": "**Testing**: Ensure all existing tests pass and that the change doesn't break any existing functionality.",
+    "line": "> 4. **Testing**: Ensure all existing tests pass and that the change doesn't break any existing functionality."
+   }
+  ],
+  "indented_code_block": [
+   {
+    "split": "held_out",
+    "url": "https://github.com/opencv/opencv/pull/27441",
+    "matched_text": "tests pass",
+    "sentence": "All existing tests pass, and the new test verifies the mask generation logic.",
+    "line": "All existing tests pass, and the new test verifies the mask generation logic."
+   }
+  ],
+  "negation_cue_near": [
+   {
+    "split": "development",
+    "url": "https://github.com/wieslawsoltes/Dock/pull/498",
+    "matched_text": "tests pass",
+    "sentence": "- `dotnet test -c Release` *(fails to reach telemetry servers but tests pass)*",
+    "line": "- `dotnet test -c Release` *(fails to reach telemetry servers but tests pass)*"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/wieslawsoltes/Svg.Skia/pull/329",
+    "matched_text": "tests pass",
+    "sentence": "- `dotnet test Svg.Skia.sln --no-build` *(fails: Could not find resources but some tests pass)*",
+    "line": "- `dotnet test Svg.Skia.sln --no-build` *(fails: Could not find resources but some tests pass)*"
+   },
+   {
+    "split": "development",
+    "url": "https://github.com/AzureCosmosDB/data-migration-desktop-tool/pull/211",
+    "matched_text": "all tests pass",
+    "sentence": "The solution builds without any CS8602 warnings and all tests pass.",
+    "line": "All CS8602 warnings have been successfully eliminated. The solution builds without any CS8602 warnings and all tests pass. Added null-forgiving operators to Cosmos and SqlServer extensions that were m"
+   },
+   {
+    "split": "development",
+    "url": "https://github.com/PowerShell/PowerShell/pull/26244",
+    "matched_text": "tests pass",
+    "sentence": "- On regular CI (Ubuntu/macOS/Windows without FIPS): 12 tests pass, 2 MD5 tests skipped",
+    "line": "- On regular CI (Ubuntu/macOS/Windows without FIPS): 12 tests pass, 2 MD5 tests skipped"
+   }
+  ],
+  "html_comment": [
+   {
+    "split": "held_out",
+    "url": "https://github.com/RocketChat/Rocket.Chat/pull/36783",
+    "matched_text": "tests pass",
+    "sentence": "- Lint and unit tests pass locally with my changes",
+    "line": "- Lint and unit tests pass locally with my changes"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/RocketChat/Rocket.Chat/pull/36785",
+    "matched_text": "tests pass",
+    "sentence": "- Lint and unit tests pass locally with my changes",
+    "line": "- Lint and unit tests pass locally with my changes"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/RocketChat/Rocket.Chat/pull/36826",
+    "matched_text": "tests pass",
+    "sentence": "- Lint and unit tests pass locally with my changes",
+    "line": "- Lint and unit tests pass locally with my changes"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/RocketChat/Rocket.Chat/pull/36932",
+    "matched_text": "tests pass",
+    "sentence": "- Lint and unit tests pass locally with my changes",
+    "line": "- Lint and unit tests pass locally with my changes"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/RocketChat/Rocket.Chat/pull/37220",
+    "matched_text": "tests pass",
+    "sentence": "- Lint and unit tests pass locally with my changes",
+    "line": "- Lint and unit tests pass locally with my changes"
+   },
+   {
+    "split": "development",
+    "url": "https://github.com/marcocesarato/php-conventional-changelog/pull/85",
+    "matched_text": "tests pass",
+    "sentence": "- [x] Run tests to verify changes (all 3 tests pass - 5 assertions)",
+    "line": "- [x] Run tests to verify changes (all 3 tests pass - 5 assertions)"
+   },
+   {
+    "split": "development",
+    "url": "https://github.com/marcocesarato/php-conventional-changelog/pull/85",
+    "matched_text": "tests pass",
+    "sentence": "- All 3 tests pass (5 assertions total)",
+    "line": "- All 3 tests pass (5 assertions total)"
+   }
+  ]
+ },
+ "headline": {
+  "unchecked_task_box_matches_corpus_wide": 179,
+  "unchecked_task_box_share_of_all_matches_pct": 3.25,
+  "checked_task_box_matches_corpus_wide": 592,
+  "unchecked_share_of_task_list_matches_pct": 23.22,
+  "held_out_unchecked": 125,
+  "development_unchecked": 54,
+  "reading": "an unchecked box is an author explicitly DECLINING to claim the tests pass; the extractor reads it as asserting it"
+ }
+}

--- a/papers/closed-model-frontier/extraction_census.py
+++ b/papers/closed-model-frontier/extraction_census.py
@@ -1,0 +1,760 @@
+# -*- coding: utf-8 -*-
+"""EXTRACTION census for the `tests_pass` template: given a sentence the regex
+matched, was a claim actually being made?
+
+Every precision this lab has published measures ADJUDICATION — given that a claim
+was extracted, was the verdict right (EXTERNAL-1 0.23, V14 held-out 0.16).
+EXTRACTION is different: we know of no measurement of it, ours or anyone's. A
+false extraction produces a false accusation exactly as surely as a false
+adjudication does, and it is invisible to every panel we have run, because a panel
+is only ever shown items the extractor already produced.
+
+Target, verbatim from `styxx/diffgate.py` (`_TEMPLATES`, near line 76):
+
+    ("tests_pass", re.compile(r"\\b(?:all\\s+)?tests\\s+(?:pass|are\\s+passing|green)\\b", re.I))
+
+Population, deliberately parasitic on `flag_rate.py` so it reconciles exactly with
+the published 71,016:
+
+  * same SQL (`body IS NOT NULL AND body != ''`, PRs with at least one file row);
+  * same reconstruction (`external1_harness.reconstruct`, imported, never
+    reimplemented) and the same `parsed != implied` round-trip skip;
+  * same DEVELOPMENT / HELD-OUT split (`v14_gates.bucket` on the first five URL
+    segments, `< 3` DEVELOPMENT);
+  * same summary text (`f"{title}\\n\\n{body}"`) and the same sentence splitter the
+    gate uses (`re.split(r"(?<=[.!?])\\s+|\\n+", ...)`), reproduced here with byte
+    offsets so each match can be located in the ORIGINAL body. The splitter is
+    reproduced rather than imported because `re.split` discards offsets; the
+    reproduction is checked against `re.split` on every single PR and any
+    divergence is counted and reported.
+
+The gate applies NO filter to `tests_pass` matches: every match in every sentence
+becomes a claim (`diffgate.py:328-358`; the `no_evidence` short-circuit at line 357
+explicitly exempts this kind). So the match count here must equal `tests_pass_claims`
+in `flag_rate.json`. That equality is asserted in the output as a reconciliation
+check, not assumed.
+
+TWO GROUPS, KEPT SEPARATE, AND THE SEPARATION IS THE POINT
+----------------------------------------------------------
+MECHANICAL — a function of the bytes. No judgment, reproducible by anyone who runs
+this file. Every rule is stated in `RULES` below in the same words the code uses.
+
+JUDGMENT — a regex approximating a human reading. This lab measured a regex
+approximating a human judgment at 0.16 held-out precision. The judgment group here
+is the same kind of object and it has had NO panel. It is emitted marked
+UNVALIDATED and MUST NOT be quoted as a precision, a rate of false extraction, or
+anything else load-bearing. It is a hypothesis generator.
+
+    python papers/closed-model-frontier/extraction_census.py
+"""
+from __future__ import annotations
+
+import json
+import re
+import sqlite3
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+ROOT = HERE.parent.parent
+sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(HERE))
+
+import styxx.diffgate as DG                                    # noqa: E402
+from external1_harness import reconstruct                      # noqa: E402
+from v14_gates import bucket                                   # noqa: E402
+
+DB = HERE / "external1_shelf.sqlite"
+OUT = HERE / "extraction_census.json"
+
+EXPECTED_ELIGIBLE = 71016          # v14_gates.json / flag_rate.json, prs_scored
+EXPECTED_MATCHES = {               # flag_rate.json, tests_pass_claims
+    "development": 1476, "held_out": 4038, "corpus_wide": 5514,
+}
+EXPECTED_PRS_WITH_MATCH = {        # flag_rate.json, prs_with_tests_pass_claim
+    "development": 1236, "held_out": 3402, "corpus_wide": 4638,
+}
+
+# The instrument under census. Taken from the shipped module by NAME rather than
+# retyped, so this file cannot drift from the gate it is measuring.
+TESTS_PASS_RX = dict(DG._TEMPLATES)["tests_pass"]
+
+# The gate's splitter. Reproduced with offsets; verified against re.split per PR.
+SPLIT_RX = re.compile(r"(?<=[.!?])\s+|\n+")
+
+EXAMPLES_PER_CATEGORY = 10
+
+# D4. The judgment numbers must carry their status IN SCOPE wherever they can be
+# read, not only at the top of the file. A sibling `status` field beside a bare
+# integer map is strippable: a consumer who writes
+# d["held_out"]["judgment_category"] never touches the sibling and quotes a
+# number with no marker attached. So the MARKER IS IN THE KEY NAMES, which a
+# consumer must type to reach the integers, and the status string is repeated
+# inside the value so that dumping any level of the path still shows it. The
+# examples for judgment labels carry the same prefix for the same reason.
+JUDGMENT_STATUS = (
+    "UNVALIDATED — a regex approximating a human reading, with NO blind panel. "
+    "These counts are NOT a precision, NOT a false-extraction rate, and decide "
+    "nothing. See .judgment.warning in this file before quoting any of them.")
+JUDG_KEY_FLAGS = "judgment_UNVALIDATED_flags_any"
+JUDG_KEY_CATEGORY = "judgment_UNVALIDATED_category"
+JUDG_COUNTS_KEY = "counts_UNVALIDATED"
+JUDG_EXAMPLE_PREFIX = "JUDGMENT_UNVALIDATED:"
+
+
+# --------------------------------------------------------------------------
+# MECHANICAL detectors. Each is a pure function of the summary text.
+# --------------------------------------------------------------------------
+
+_FENCE = re.compile(r"^ {0,3}(?P<f>`{3,}|~{3,})")
+_BLOCKQUOTE = re.compile(r"^ {0,3}>")
+_TASK = re.compile(r"^\s*(?:[-*+]|\d+[.)])\s+\[(?P<box>[ xX])\]")
+_LIST_MARKER = re.compile(r"^ {0,3}(?:[-*+]|\d+[.)])\s")
+_HTML_COMMENT = re.compile(r"<!--.*?-->", re.S)
+_MD_LINK = re.compile(r"\[[^\]\n]*\]\([^)\n]*\)")
+_AUTOLINK = re.compile(r"<https?://[^>\s]*>")
+_BARE_URL = re.compile(r"https?://[^\s)>\]`\"']+")
+_BACKTICKS = re.compile(r"`+")
+
+_NEGATION = re.compile(
+    r"\b(?:not|cannot|can't|cant|won't|wont|doesn't|doesnt|don't|dont|didn't|didnt"
+    r"|isn't|isnt|aren't|arent|wasn't|wasnt|weren't|werent|hasn't|hasnt|haven't"
+    r"|havent|couldn't|couldnt|shouldn't|shouldnt|wouldn't|wouldnt|never|no longer"
+    r"|fails?\s+to|failed\s+to|failing\s+to|unable\s+to|without)\b", re.I)
+NEGATION_WINDOW = 40
+
+
+def _expand(line: str) -> str:
+    return line.expandtabs(4)
+
+
+def _line_index(text: str):
+    """(start, end_exclusive_of_newline, line_text) for every line, in order."""
+    out, pos = [], 0
+    for line in text.splitlines(keepends=True):
+        body = line.rstrip("\n").rstrip("\r")
+        out.append((pos, pos + len(body), body))
+        pos += len(line)
+    return out
+
+
+def _fenced_and_indented(lines):
+    """-> (set of line indices inside a ``` / ~~~ fence,
+           set of line indices that are indented code by the rule in RULES)"""
+    fenced, opener = set(), None
+    for i, (_s, _e, raw) in enumerate(lines):
+        m = _FENCE.match(raw)
+        if opener is None:
+            if m:
+                opener = m.group("f")[0], len(m.group("f"))
+                fenced.add(i)                    # the fence line itself counts as fence
+        else:
+            fenced.add(i)
+            if m and m.group("f")[0] == opener[0] and len(m.group("f")) >= opener[1]:
+                opener = None
+
+    indented = set()
+    for i, (_s, _e, raw) in enumerate(lines):
+        if i in fenced:
+            continue
+        exp = _expand(raw)
+        if not exp.strip() or len(exp) - len(exp.lstrip(" ")) < 4:
+            continue
+        # must not interrupt a paragraph: previous line blank, or itself indented
+        prev = _expand(lines[i - 1][2]) if i else ""
+        prev_blank = (i == 0) or (not prev.strip())
+        prev_indented = (i - 1) in indented
+        if not (prev_blank or prev_indented):
+            continue
+        # 4-space indentation inside a list is CONTINUATION, not code. Walk back to
+        # the nearest non-blank line at indent < 4 and refuse if it is a list item.
+        j, in_list = i - 1, False
+        while j >= 0:
+            pe = _expand(lines[j][2])
+            if not pe.strip():
+                j -= 1
+                continue
+            if len(pe) - len(pe.lstrip(" ")) >= 4:
+                j -= 1
+                continue
+            in_list = bool(_LIST_MARKER.match(pe))
+            break
+        if in_list:
+            continue
+        indented.add(i)
+    return fenced, indented
+
+
+def _spans(rx, text):
+    return [(m.start(), m.end()) for m in rx.finditer(text)]
+
+
+def _inline_code_spans(lines):
+    """Backtick code spans, paired left-to-right per line by equal run length."""
+    spans = []
+    for (s, _e, raw) in lines:
+        runs = [(m.start(), m.end()) for m in _BACKTICKS.finditer(raw)]
+        used = [False] * len(runs)
+        for a in range(len(runs)):
+            if used[a]:
+                continue
+            la = runs[a][1] - runs[a][0]
+            for b in range(a + 1, len(runs)):
+                if used[b] or (runs[b][1] - runs[b][0]) != la:
+                    continue
+                spans.append((s + runs[a][1], s + runs[b][0]))
+                used[a] = used[b] = True
+                break
+        # unmatched runs open nothing
+    return spans
+
+
+def _in(spans, off):
+    return any(a <= off < b for a, b in spans)
+
+
+def _link_spans(text):
+    """(title spans, destination spans) for markdown links, plus autolinks/bare URLs
+    which are recorded as destinations."""
+    titles, dests = [], []
+    for m in _MD_LINK.finditer(text):
+        s = m.start()
+        close = m.group(0).index("](")
+        titles.append((s + 1, s + close))
+        dests.append((s + close + 2, m.end() - 1))
+    for a, b in _spans(_AUTOLINK, text) + _spans(_BARE_URL, text):
+        dests.append((a, b))
+    return titles, dests
+
+
+def mechanical(text, lines, ctx, off, sentence, m_start_in_sent):
+    """Every mechanical flag for one match, as a dict of booleans plus box state."""
+    li = ctx["line_of"](off)
+    raw = lines[li][2]
+    flags = {
+        "fenced_code_block": li in ctx["fenced"],
+        "indented_code_block": li in ctx["indented"],
+        "blockquote": bool(_BLOCKQUOTE.match(raw)),
+        "html_comment": _in(ctx["comments"], off),
+        "link_title": _in(ctx["link_titles"], off),
+        "link_url": _in(ctx["link_dests"], off),
+        "inline_code_span": _in(ctx["inline_code"], off),
+        "task_list_item": False,
+        "task_box_unchecked": False,
+        "task_box_checked": False,
+        "negation_cue_near": False,
+        "negation_cue_in_sentence": False,
+        "in_title": off < ctx["title_end"],
+        # DIAGNOSTICS — never used in the disjoint table. They exist so a reader
+        # can tell a detector that found nothing from a detector that is broken.
+        "indented_ge4_spaces_naive": (
+            li not in ctx["fenced"]
+            and bool(_expand(raw).strip())
+            and (len(_expand(raw)) - len(_expand(raw).lstrip(" "))) >= 4),
+        "backtick_somewhere_on_line": "`" in raw,
+        "url_somewhere_on_line": bool(_BARE_URL.search(raw)),
+    }
+    tm = _TASK.match(raw)
+    if tm:
+        flags["task_list_item"] = True
+        if tm.group("box") in ("x", "X"):
+            flags["task_box_checked"] = True
+        else:
+            flags["task_box_unchecked"] = True
+    before = sentence[:m_start_in_sent]
+    if _NEGATION.search(before):
+        flags["negation_cue_in_sentence"] = True
+    win = before[-NEGATION_WINDOW:]
+    cues = [c.group(0).lower() for c in _NEGATION.finditer(win)]
+    if cues:
+        flags["negation_cue_near"] = True
+        # DISCLOSED DEFECT, counted rather than quietly patched: "without" is in
+        # the cue set for "without modifying X", but it also produces
+        # "builds without warnings and all tests pass" — a sentence that
+        # ASSERTS. Where "without" is the only cue the flag is unreliable.
+        flags["negation_cue_is_without_only"] = set(cues) == {"without"}
+    flags["link_title_or_url"] = flags["link_title"] or flags["link_url"]
+    return flags
+
+
+# Disjoint assignment. Containment first (the text is not prose at all), then the
+# task box (an explicit refusal to assert), then the rest.
+MECH_PRIORITY = [
+    "html_comment",
+    "fenced_code_block",
+    "indented_code_block",
+    "blockquote",
+    "task_box_unchecked",
+    "task_box_checked",
+    "link_title_or_url",
+    "inline_code_span",
+    "negation_cue_near",
+]
+
+
+def mech_category(flags):
+    for k in MECH_PRIORITY:
+        if flags.get(k):
+            return k
+    return "no_mechanical_flag"
+
+
+# --------------------------------------------------------------------------
+# JUDGMENT detectors. UNVALIDATED. A regex approximating a human reading.
+# --------------------------------------------------------------------------
+
+_SELF_DISCLOSED = re.compile(
+    r"\b(?:fail\w*|error\w*|broken|breaks?|breaking|flaky|regress\w*|red\b|"
+    r"except\s+for|apart\s+from|other\s+than|still\s+investigating)\b", re.I)
+_CONDITIONAL = re.compile(
+    r"\b(?:once|after|when|whenever|if|should|shall|will|would|expect\w*|assum\w*|"
+    r"pending|until|need\s+to|needs\s+to|make\s+sure|ensure|ensures|ensuring|"
+    r"verify|verifies|confirm|confirms|please|hopefully|plan\s+to|going\s+to|"
+    r"let'?s|to\s+be\s+sure)\b", re.I)
+_LOCAL = re.compile(
+    r"\b(?:locally|on\s+my\s+(?:machine|laptop|box|end)|in\s+my\s+environment|"
+    r"on\s+my\s+local|local\s+run|локально)\b", re.I)
+# Words that may sit immediately before "tests" WITHOUT scoping it. Anything else
+# ("auth", "unit", "e2e", "affected", "remaining", ...) is read as a subset scope.
+_NOT_A_SCOPE = frozenset({
+    "all", "the", "a", "an", "and", "or", "but", "so", "then", "now", "that",
+    "these", "those", "my", "our", "its", "their", "this", "as", "if", "when",
+    "while", "where", "since", "because", "also", "still", "again",
+})
+_PREV_WORD = re.compile(r"([A-Za-z][\w-]*)\W*$")
+
+
+def judgment(sentence, m):
+    """UNVALIDATED. Booleans only; the caller assigns the disjoint label."""
+    before = sentence[:m.start()]
+    pw = _PREV_WORD.search(before)
+    scoped = bool(pw and pw.group(1).lower() not in _NOT_A_SCOPE)
+    # "all tests pass" — the regex swallowed the "all", so nothing precedes it.
+    if m.group(0).lower().startswith("all"):
+        scoped = False
+    return {
+        "self_disclosed_failure": bool(_SELF_DISCLOSED.search(sentence)),
+        "conditional_or_future": bool(_CONDITIONAL.search(sentence)),
+        "scoped_to_authors_machine": bool(_LOCAL.search(sentence)),
+        "scoped_to_a_subset": scoped,
+    }
+
+
+JUDG_PRIORITY = [
+    "self_disclosed_failure",
+    "conditional_or_future",
+    "scoped_to_authors_machine",
+    "scoped_to_a_subset",
+]
+
+
+def judg_category(flags):
+    for k in JUDG_PRIORITY:
+        if flags.get(k):
+            return k
+    return "bare_unqualified_assertion"
+
+
+RULES = {
+    "fenced_code_block":
+        "the match's line lies between a line matching ^ {0,3}(`{3,}|~{3,}) and the "
+        "next line closing with the same character at >= the opening length; the "
+        "fence lines themselves are counted as inside",
+    "indented_code_block":
+        "tabs expanded to 4; the line's leading spaces >= 4; it is not inside a "
+        "fence; the previous line is blank or is itself indented code by this rule; "
+        "and the nearest preceding non-blank line at indent < 4 is not a list-item "
+        "marker (^ {0,3}([-*+]|\\d+[.)])\\s) — because 4-space indentation inside a "
+        "list is continuation, not code",
+    "blockquote": "the match's line matches ^ {0,3}>",
+    "html_comment": "the match offset lies inside a <!-- ... --> span (DOTALL, "
+                    "non-greedy); an unterminated <!-- is NOT treated as a comment",
+    "task_list_item": "the match's line matches ^\\s*([-*+]|\\d+[.)])\\s+\\[( |x|X)\\]; "
+                      "the box character decides checked vs unchecked",
+    "link_title_or_url":
+        "the match offset lies inside the [title] or (destination) span of a "
+        "[..](..) link, inside a <http...> autolink, or inside a bare https?:// run",
+    "inline_code_span":
+        "the match offset lies between two backtick runs of equal length on the "
+        "same line, paired left to right",
+    "negation_cue_near":
+        f"a cue from the closed set (not/cannot/n't forms/never/no longer/fails to/"
+        f"unable to/without) occurs in the {NEGATION_WINDOW} characters of the same "
+        f"gate-sentence immediately before the match",
+    "negation_cue_in_sentence":
+        "the same closed cue set, anywhere earlier in the same gate-sentence "
+        "(reported alongside as the looser variant; the disjoint table uses the "
+        "windowed form)",
+}
+
+
+def blank_counts():
+    keys = (MECH_PRIORITY + ["no_mechanical_flag", "task_list_item",
+                             "negation_cue_in_sentence", "link_title", "link_url",
+                             "in_title", "indented_ge4_spaces_naive",
+                             "backtick_somewhere_on_line", "url_somewhere_on_line",
+                             "negation_cue_is_without_only"])
+    return {
+        "matches": 0,
+        "prs_with_match": 0,
+        "mech_flags_any": {k: 0 for k in keys},
+        "mech_category": {k: 0 for k in MECH_PRIORITY + ["no_mechanical_flag"]},
+        JUDG_KEY_FLAGS: {
+            "status": JUDGMENT_STATUS,
+            JUDG_COUNTS_KEY: {k: 0 for k in JUDG_PRIORITY},
+        },
+        JUDG_KEY_CATEGORY: {
+            "status": JUDGMENT_STATUS,
+            JUDG_COUNTS_KEY: {
+                k: 0 for k in JUDG_PRIORITY + ["bare_unqualified_assertion"]},
+        },
+        "residual_matches": 0,
+    }
+
+
+def merge(dst, src):
+    dst["matches"] += src["matches"]
+    dst["prs_with_match"] += src["prs_with_match"]
+    dst["residual_matches"] += src["residual_matches"]
+    for sec in ("mech_flags_any", "mech_category"):
+        for k, v in src[sec].items():
+            dst[sec][k] = dst[sec].get(k, 0) + v
+    for sec in (JUDG_KEY_FLAGS, JUDG_KEY_CATEGORY):
+        assert dst[sec]["status"] == src[sec]["status"] == JUDGMENT_STATUS
+        for k, v in src[sec][JUDG_COUNTS_KEY].items():
+            d = dst[sec][JUDG_COUNTS_KEY]
+            d[k] = d.get(k, 0) + v
+
+
+def pct(n, d):
+    return round(100.0 * n / d, 2) if d else None
+
+
+def main() -> int:
+    con = sqlite3.connect(DB)
+    splits = {"development": blank_counts(), "held_out": blank_counts()}
+    examples = {}
+    skipped_roundtrip = 0
+    prs_scored = 0
+    splitter_divergences = 0
+
+    for pid, title, body, url in con.execute(
+            "SELECT id, title, body, html_url FROM pr "
+            "WHERE body IS NOT NULL AND body != ''"):
+        rows = con.execute("SELECT filename, status, patch FROM f WHERE pr_id=?",
+                           (pid,)).fetchall()
+        if not rows:
+            continue
+        diff, implied = reconstruct(rows)
+        parsed, _ = DG.parse_unified_diff(diff)
+        if parsed != implied:
+            skipped_roundtrip += 1
+            continue
+        prs_scored += 1
+
+        title = title or ""
+        summary = f"{title}\n\n{body}"
+
+        # cheap pre-filter, identical semantics: if the regex fires nowhere in the
+        # whole text it cannot fire in any sentence of it
+        if not TESTS_PASS_RX.search(summary):
+            continue
+
+        # split with offsets, and prove the reproduction matches the gate's re.split
+        pieces, pos = [], 0
+        for sep in SPLIT_RX.finditer(summary):
+            pieces.append((pos, summary[pos:sep.start()]))
+            pos = sep.end()
+        pieces.append((pos, summary[pos:]))
+        if [p[1] for p in pieces] != SPLIT_RX.split(summary):
+            splitter_divergences += 1
+            continue
+
+        lines = _line_index(summary)
+        starts = [s for s, _e, _r in lines]
+
+        def line_of(off, _starts=starts):
+            lo, hi = 0, len(_starts) - 1
+            while lo < hi:
+                mid = (lo + hi + 1) // 2
+                if _starts[mid] <= off:
+                    lo = mid
+                else:
+                    hi = mid - 1
+            return lo
+
+        fenced, indented = _fenced_and_indented(lines)
+        link_titles, link_dests = _link_spans(summary)
+        ctx = {
+            "fenced": fenced, "indented": indented,
+            "comments": _spans(_HTML_COMMENT, summary),
+            "link_titles": link_titles, "link_dests": link_dests,
+            "inline_code": _inline_code_spans(lines),
+            "line_of": line_of,
+            "title_end": len(title),
+        }
+
+        key = ("development"
+               if bucket("/".join((url or "").split("/")[:5])) < 3
+               else "held_out")
+        s = splits[key]
+        hit_this_pr = False
+
+        for pstart, sent in pieces:
+            for m in TESTS_PASS_RX.finditer(sent):
+                off = pstart + m.start()
+                mf = mechanical(summary, lines, ctx, off, sent, m.start())
+                mc = mech_category(mf)
+                s["matches"] += 1
+                hit_this_pr = True
+                for k in s["mech_flags_any"]:
+                    if mf.get(k):
+                        s["mech_flags_any"][k] += 1
+                if mc == "no_mechanical_flag":
+                    s["mech_flags_any"]["no_mechanical_flag"] += 1
+                s["mech_category"][mc] += 1
+
+                cat = mc
+                if mc == "no_mechanical_flag":
+                    s["residual_matches"] += 1
+                    jf = judgment(sent, m)
+                    jflags = s[JUDG_KEY_FLAGS][JUDG_COUNTS_KEY]
+                    for k in jflags:
+                        if jf.get(k):
+                            jflags[k] += 1
+                    jc = judg_category(jf)
+                    s[JUDG_KEY_CATEGORY][JUDG_COUNTS_KEY][jc] += 1
+                    cat = JUDG_EXAMPLE_PREFIX + jc
+
+                bucket_ex = examples.setdefault(cat, [])
+                if len(bucket_ex) < EXAMPLES_PER_CATEGORY:
+                    bucket_ex.append({
+                        "split": key,
+                        "url": url,
+                        "matched_text": m.group(0),
+                        "sentence": sent.strip()[:200],
+                        "line": lines[line_of(off)][2].strip()[:200],
+                    })
+
+        if hit_this_pr:
+            s["prs_with_match"] += 1
+
+    con.close()
+
+    both = blank_counts()
+    merge(both, splits["development"])
+    merge(both, splits["held_out"])
+
+    recon = {
+        "expected_eligible": EXPECTED_ELIGIBLE,
+        "observed_eligible": prs_scored,
+        "eligible_matches_flag_rate": prs_scored == EXPECTED_ELIGIBLE,
+        "skipped_reconstruction_roundtrip": skipped_roundtrip,
+        "splitter_divergences_from_re_split": splitter_divergences,
+        "expected_tests_pass_claims": EXPECTED_MATCHES,
+        "observed_matches": {
+            "development": splits["development"]["matches"],
+            "held_out": splits["held_out"]["matches"],
+            "corpus_wide": both["matches"],
+        },
+        "expected_prs_with_tests_pass_claim": EXPECTED_PRS_WITH_MATCH,
+        "observed_prs_with_match": {
+            "development": splits["development"]["prs_with_match"],
+            "held_out": splits["held_out"]["prs_with_match"],
+            "corpus_wide": both["prs_with_match"],
+        },
+    }
+    recon["matches_reconcile_with_flag_rate"] = (
+        recon["observed_matches"] == EXPECTED_MATCHES
+        and recon["observed_prs_with_match"] == EXPECTED_PRS_WITH_MATCH)
+
+    payload = {
+        "what": ("EXTRACTION census of the tests_pass template: of the sentences "
+                 "the regex fires on, how many are a claim being made"),
+        "target_regex": TESTS_PASS_RX.pattern,
+        "target_source": "styxx/diffgate.py _TEMPLATES entry 'tests_pass'",
+        "not_measured_here": (
+            "adjudication. Every tests_pass verdict in this corpus is UNCHECKABLE "
+            "(run=None), so no accusation exists to adjudicate. This file measures "
+            "the step BEFORE the verdict."),
+        "population": recon,
+        "mechanical": {
+            "status": "MECHANICAL — a pure function of the summary bytes, "
+                      "reproducible by anyone who runs this file",
+            "rules": RULES,
+            "priority_for_the_disjoint_table": MECH_PRIORITY,
+            "note": ("mech_flags_any counts each flag independently and matches may "
+                     "carry several; mech_category assigns each match to exactly one "
+                     "bucket by the priority above. The headline unchecked-box number "
+                     "is the INDEPENDENT count, mech_flags_any.task_box_unchecked."),
+            "diagnostics_not_categories": {
+                "indented_ge4_spaces_naive":
+                    "the NAIVE indented-code rule (>= 4 leading spaces, outside a "
+                    "fence) with none of the CommonMark conditions. Reported so the "
+                    "cost of the list-continuation refusal is visible: the gap "
+                    "between this and indented_code_block is what the strict rule "
+                    "declined to call code, and it is almost entirely markdown list "
+                    "continuation, not code",
+                "backtick_somewhere_on_line":
+                    "the match's line contains a backtick at all. If this is large "
+                    "while inline_code_span is zero, the code-span detector is "
+                    "working and the matches simply sit outside the spans",
+                "url_somewhere_on_line":
+                    "the match's line contains an http(s) URL at all. Same purpose "
+                    "for link_url. Note the regex requires literal whitespace "
+                    "between 'tests' and 'pass', which URLs almost never contain — "
+                    "a zero here is expected from the pattern, not evidence of a "
+                    "bug",
+                "negation_cue_is_without_only":
+                    "of the negation_cue_near matches, those whose ONLY cue in the "
+                    "window is the word 'without'. See disclosed_defects",
+            },
+            "disclosed_defects": {
+                "negation_cue_near_over-fires_on_without":
+                    "'without' earns its place in the cue set for 'without "
+                    "modifying X', but it also fires on 'the solution builds "
+                    "without any warnings and all tests pass' — a sentence that "
+                    "ASSERTS. This is a false positive inside the group that is "
+                    "supposed to carry weight, so it is counted "
+                    "(negation_cue_is_without_only) rather than patched away. "
+                    "Subtract it from negation_cue_near for a conservative read",
+                "fence_lines_counted_as_inside":
+                    "the ``` line itself is counted as fenced. A match can only "
+                    "land there via the info string, which is vanishingly rare, "
+                    "but the choice is stated rather than hidden",
+                "blockquote_lazy_continuation_missed":
+                    "a blockquote continued lazily (a following line with no '>') "
+                    "is NOT detected. Such matches fall through to the residual "
+                    "and are therefore counted against us, not for us",
+                "task_item_continuation_lines_missed":
+                    "the box state is read from the line containing the match. A "
+                    "match on a continuation line under a task item is not "
+                    "attributed to that item's box, so the unchecked-box count is "
+                    "a LOWER bound",
+            },
+        },
+        "judgment": {
+            "status": "UNVALIDATED",
+            "warning": (
+                "This group is a regex approximating a human judgment. That is "
+                "exactly the class of instrument this lab measured at 0.16 held-out "
+                "precision (RESULT_v14). It has had NO blind panel. It MUST NOT be "
+                "quoted as a precision, as a false-extraction rate, or as any "
+                "figure that decides anything. It is a hypothesis generator and "
+                "nothing else."),
+            "priority_for_the_disjoint_table": JUDG_PRIORITY,
+            "applied_to": ("only the matches carrying no mechanical flag "
+                           "(mech_category == no_mechanical_flag)"),
+            "where_the_numbers_live": {
+                "keys": [JUDG_KEY_FLAGS, JUDG_KEY_CATEGORY],
+                "counts_under": JUDG_COUNTS_KEY,
+                "examples_prefixed": JUDG_EXAMPLE_PREFIX,
+                "in_each_of": ["development", "held_out", "corpus_wide"],
+            },
+            "why_the_keys_are_named_that_way": (
+                "An earlier emission of this file marked judgment.status "
+                "UNVALIDATED at the top level only, while the per-split counts "
+                "sat under a bare `judgment_category` map. A consumer reading "
+                "d['held_out']['judgment_category'] saw no marker and could "
+                "quote the number with nothing attached to it. A sibling status "
+                "field beside the map would not have fixed that, because the "
+                "careless read never touches the sibling. So the marker is in "
+                "the KEY NAMES, which cannot be reached without being typed, "
+                "and the status string is repeated inside the value so that a "
+                "dump of any level of the path still carries it. The key names "
+                "changed in this emission; that is a deliberate break for any "
+                "consumer indexing the old names."),
+            "known_defects_found_by_reading_its_own_output": {
+                "self_disclosed_failure_fires_on_paths":
+                    "the cue 'error\\w*' matched inside a file path in "
+                    "'Verified all tests pass with `yarn test "
+                    "src/elements/common/error-boundary/__tests__/`'. A path is "
+                    "not a disclosure. Left in place, disclosed, because "
+                    "hand-patching an unvalidated classifier until its output "
+                    "looks right is the failure mode this lab is trying to stop",
+                "self_disclosed_failure_fires_on_flaky":
+                    "'All tests pass, including the previously flaky test' is "
+                    "labelled a self-disclosed failure; a reader might call it an "
+                    "assertion. This label is contested and unadjudicated",
+                "scoped_to_a_subset_is_the_largest_and_the_weakest":
+                    "it is the biggest bucket and it rests entirely on the "
+                    "single word before 'tests' against a hand-written stoplist. "
+                    "'Verified existing tests pass' and 'All 21 unit tests pass' "
+                    "both land here and they are not obviously the same thing. "
+                    "This number in particular must not leave the file",
+            },
+            "stoplist_verbatim": sorted(_NOT_A_SCOPE),
+        },
+        "development": splits["development"],
+        "held_out": splits["held_out"],
+        "corpus_wide": both,
+        "examples": examples,
+        "headline": {},
+    }
+
+    uc = both["mech_flags_any"]["task_box_unchecked"]
+    ch = both["mech_flags_any"]["task_box_checked"]
+    payload["headline"] = {
+        "unchecked_task_box_matches_corpus_wide": uc,
+        "unchecked_task_box_share_of_all_matches_pct": pct(uc, both["matches"]),
+        "checked_task_box_matches_corpus_wide": ch,
+        "unchecked_share_of_task_list_matches_pct": pct(
+            uc, both["mech_flags_any"]["task_list_item"]),
+        "held_out_unchecked": splits["held_out"]["mech_flags_any"]["task_box_unchecked"],
+        "development_unchecked": splits["development"]["mech_flags_any"]["task_box_unchecked"],
+        "reading": ("an unchecked box is an author explicitly DECLINING to claim "
+                    "the tests pass; the extractor reads it as asserting it"),
+    }
+
+    OUT.write_text(json.dumps(payload, indent=1) + "\n", encoding="utf-8")
+
+    # ---------------- table ----------------
+    def row(label, n, tot):
+        return f"  {label:<34}{n:>7}{'':2}{str(pct(n, tot)) + '%':>8}"
+
+    print(f"\nEXTRACTION CENSUS — tests_pass  {TESTS_PASS_RX.pattern}")
+    print(f"eligible PRs: {prs_scored} (flag_rate reports {EXPECTED_ELIGIBLE}) "
+          f"{'MATCH' if prs_scored == EXPECTED_ELIGIBLE else 'MISMATCH — investigate'}")
+    print(f"round-trip skips: {skipped_roundtrip}   "
+          f"splitter divergences: {splitter_divergences}")
+    print(f"matches: dev {splits['development']['matches']} / "
+          f"held-out {splits['held_out']['matches']} / corpus {both['matches']}  "
+          f"(flag_rate tests_pass_claims {EXPECTED_MATCHES['corpus_wide']}) "
+          f"{'RECONCILES' if recon['matches_reconcile_with_flag_rate'] else 'DOES NOT RECONCILE'}")
+
+    for name, s in (("DEVELOPMENT", splits["development"]),
+                    ("HELD-OUT", splits["held_out"]),
+                    ("CORPUS-WIDE", both)):
+        t = s["matches"]
+        print(f"\n{name}  ({t} matches, {s['prs_with_match']} PRs)")
+        print("  MECHANICALLY DETERMINABLE — disjoint, by priority")
+        for k in MECH_PRIORITY + ["no_mechanical_flag"]:
+            print(row(k, s["mech_category"][k], t))
+        print("  MECHANICAL — independent flags (a match may carry several)")
+        for k in ("task_list_item", "task_box_unchecked", "task_box_checked",
+                  "fenced_code_block", "indented_code_block", "blockquote",
+                  "html_comment", "link_title", "link_url", "inline_code_span",
+                  "negation_cue_near", "negation_cue_in_sentence", "in_title"):
+            print(row(k, s["mech_flags_any"][k], t))
+        print("  DIAGNOSTIC — not a category; proves the detector saw the material")
+        for k in ("indented_ge4_spaces_naive", "backtick_somewhere_on_line",
+                  "url_somewhere_on_line", "negation_cue_is_without_only"):
+            print(row(k, s["mech_flags_any"][k], t))
+        r = s["residual_matches"]
+        print(f"  REQUIRES JUDGMENT — UNVALIDATED, NOT A PRECISION "
+              f"({r} mechanically-clean matches)")
+        jcounts = s[JUDG_KEY_CATEGORY][JUDG_COUNTS_KEY]
+        for k in JUDG_PRIORITY + ["bare_unqualified_assertion"]:
+            print(row(k, jcounts[k], r))
+
+    print(f"\nHEADLINE  unchecked task boxes read as assertions: "
+          f"{uc} of {both['matches']} matches "
+          f"({pct(uc, both['matches'])}%), held-out "
+          f"{splits['held_out']['mech_flags_any']['task_box_unchecked']}")
+    print(f"          checked boxes for comparison: {ch}")
+    print(f"\n-> {OUT.name}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/styxx/diffgate.py
+++ b/styxx/diffgate.py
@@ -11,19 +11,130 @@ test, "only touches docs/" when it edited source, "adds function retry" when it 
 Construct ceiling, stated like every styxx instrument states it: the template set is
 CLOSED (touched/created/deleted paths · files-changed counts · added tests · added
 functions/classes · insertion/deletion counts · only-touches prefixes · tests-pass with
---run). Prose outside the templates is NOT judged — uncovered sentences are listed as
-uncovered, never scored. Verdicts per claim: VERIFIED / CONTRADICTED / UNCHECKABLE(named).
-The gate fails on any CONTRADICTED; UNCHECKABLE fails only under --strict.
+--evidence or --run). Prose outside the templates is NOT judged — uncovered sentences are
+listed as uncovered, never scored. Verdicts per claim: VERIFIED / CONTRADICTED /
+UNCHECKABLE(named). The gate fails on any CONTRADICTED; UNCHECKABLE fails only under
+--strict.
+
+THE ``tests_pass`` VOCABULARY IS TWO WORDS
+------------------------------------------
+
+::
+
+    _TESTS_PASS_VERDICTS = ("VERIFIED", "UNCHECKABLE")
+
+There is no accusing verdict for this claim kind. Not disabled, not behind a flag —
+**absent**. The branch that read a nonzero ``--run`` exit as CONTRADICTED has been
+deleted; ``selfcheck_tests_pass_never_accuses()`` re-derives its absence from this
+module's own source with ``ast``, and every surviving occurrence of the word inside the
+tests-pass leg is prose explaining why there is no such branch.
+
+Why deletion rather than a flag, in one line each:
+
+  * **Never measured.** The standing commitment out of
+    ``RESULT_v14_naming_the_defects_did_not_save_it_2026_09_01.md`` is DO NOT SHIP AN
+    ACCUSING VERDICT WHOSE PRECISION HAS NOT BEEN MEASURED BY A BLIND PANEL. This one has
+    been measured on neither leg — not the extraction, not the adjudication.
+  * **The extractor under it reads open prose with a closed regex.** The template at the
+    bottom of ``_TEMPLATES`` fires on ``- [ ] all tests pass`` (an unchecked PR-template
+    box, i.e. an author explicitly *declining* to assert), on ``all tests pass locally but
+    CI is red``, on ``once all tests pass I will mark this ready``, and inside blockquotes
+    and code fences. It reaches none of the negation, referential or containment guards —
+    those live in ``_REFERENTIAL`` / ``_CONTAINMENT`` and are applied only to
+    ``_PATH_KINDS``. A hard adjudicator behind a soft extractor inherits the extractor's
+    precision, not its own; that is the architecture RESULT_v14 measured at 0.16.
+  * **A nonzero exit is not a lie.** It is also what pytest rc=5 (no tests collected), a
+    misspelled command, a missing dependency and a flaky test produce.
+  * **A flag is what a maintainer who did not read the paper flips.**
+    ``WITHHOLD_PATH_ACCUSATION`` below is exactly such a flag. Absence of a branch cannot
+    be toggled by someone in a hurry; re-enabling must require writing the branch, in a
+    diff a reviewer can see.
+
+``VERIFIED`` survives, on the asymmetry ``styxx.evidence`` states for itself: a wrong
+VERIFIED repeats a claim the author already made in prose, a wrong CONTRADICTED attacks a
+stranger inside their own pull request. **It must never be printed as "the tests
+passed."** It reads: *the supplied evidence, or the supplied command, said so* — and
+because the extractor is unmeasured, a VERIFIED can attach to the sentence "Not all tests
+pass." That is a false RECORD, not an accusation. It is disclosed here and left in place
+rather than patched, because a fourth undisclosed repair cycle on this class is exactly
+what RESULT_v14 forbids.
+
+MONOTONICITY: TWO PROPERTIES, ONE HOLDS AND ONE DELIBERATELY DOES NOT
+---------------------------------------------------------------------
+
+These are different claims about ``--evidence`` and only one of them is a guarantee.
+Conflating them is how this file previously came to promise something it does not do.
+
+**Monotone against the empty baseline — HOLDS. This is the guarantee callers get.**
+Supplying evidence never leaves the gate worse off than supplying none. A
+``tests_pass`` claim is UNCHECKABLE with no report, so evidence can only move it to
+VERIFIED or leave it exactly where it was: no other claim kind reads ``evidence``,
+supplying it adds and removes no claims, and there is no route to CONTRADICTED —
+``styxx.evidence``'s vocabulary is two words, ``_evidence_leg`` clamps anything else
+to UNCHECKABLE, and ``selfcheck_tests_pass_never_accuses`` re-derives that from this
+file's own source. Handing the gate a report therefore cannot fail a build that would
+have passed with no report at all.
+
+**Monotone under set extension — DOES NOT HOLD, and that is DELIBERATE.**
+Going from evidence set E to E union {x} CAN demote VERIFIED to UNCHECKABLE. Measured
+directly, under ``--strict``, on one ``tests_pass`` claim:
+
+===========================  ==========  =====================
+evidence supplied            overall     ``tests_pass``
+===========================  ==========  =====================
+(none)                       FAIL        UNCHECKABLE
+``green.xml``                PASS        VERIFIED
+``green.xml`` ``empty.xml``  FAIL        UNCHECKABLE
+===========================  ==========  =====================
+
+Row three is not a regression and must not be "repaired" — not by letting a partial
+read affirm, and not by special-casing empty files. It is the contract's own rule,
+stated in ``styxx.evidence``: ANY unparsed source blocks VERIFIED, because a partial
+read may honestly DECLINE but may not honestly AFFIRM. You cannot certify "all tests
+pass" from nine shards out of ten. Adding a file adds a question, and a question the
+gate could not read is not an answer. Affirming from an incomplete set is the exact
+failure mode this whole module exists to refuse, so the demotion is the module
+working, not the module breaking.
+
+THE CASE THAT WILL BITE SOMEONE, in plain words: a sharded CI matrix where nine JUnit
+reports parse and the tenth is truncated — the runner died, the artifact upload raced
+the job, the shard timed out. The gate DECLINES. It does not affirm from the nine,
+and under ``--strict`` that is a red build. That is the intended behaviour.
+
+What an operator should do about it: **supply complete evidence, or supply none.**
+Those are the two honest positions and there is no third. Wire the job so a missing
+shard report fails collection outright, rather than passing whichever files happened
+to land in the directory; or, when a shard is known-lost and you would rather not
+block, pass no evidence at all and let the claim stand UNCHECKABLE on its own terms.
+Do not pass the partial set hoping the good files carry it — they will not, by
+design. The ``why`` on the declining claim names how many of how many sources could
+not be read and names one of them by path and reason, so the red build already says
+which shard to go and fix.
+
+``--run`` IS CODE EXECUTION
+---------------------------
+
+``--run CMD`` executes CMD **through a shell, with cwd set to --repo**. On an untrusted
+pull request that is remote code execution with extra steps: ``pytest`` imports the PR's
+``conftest.py`` at collection, ``pytest.ini``/``pyproject.toml`` ``addopts`` can load a
+plugin, ``npm test`` runs the string in the PR's ``package.json``, ``make test`` runs the
+PR's Makefile. ``os.environ`` is inherited unscrubbed. And the PR author controls the exit
+code in **both** directions, so the check is trivially green-lit by the adversary it
+exists to catch while remaining fully dangerous to the defender. Correct in first-party CI
+on a repository you own; never on a stranger's branch. Prefer ``--evidence``, which reads
+bytes and executes nothing.
 
 CLI::
 
     python -m styxx.diffgate SUMMARY.md --repo . --base main --head HEAD \
+        [--evidence junit.xml attestation.json --commit <40-hex>] \
         [--run "pytest -q"] [--strict] [--out GATE.json]
 """
 
 from __future__ import annotations
 
 import argparse
+import ast
 import json
 import re
 import subprocess
@@ -31,7 +142,8 @@ import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 
-__all__ = ["gate_diff", "DiffGate", "DiffClaim"]
+__all__ = ["gate_diff", "gate_diff_text", "DiffGate", "DiffClaim",
+           "selfcheck_tests_pass_never_accuses"]
 
 # A claimed path must end in a KNOWN file extension (closed set — the same honesty as the
 # template set itself). The naive any-dotted-token form false-accused decimals (0.5349),
@@ -179,6 +291,298 @@ def _names_without_claiming(sentence: str, m) -> bool:
     return any(k.lower() in window for k in _REFERENTIAL)
 
 
+# ══════════════════════════════════════════════════════════════════════════════
+# the tests_pass leg — two words, and the accusing branch is gone
+# ══════════════════════════════════════════════════════════════════════════════
+#
+# Anything that consumes this tuple gets the whole vocabulary. There is no hidden
+# member and no flag that adds one. See the module docstring for why the third
+# word was deleted rather than gated.
+_TESTS_PASS_VERDICTS = ("VERIFIED", "UNCHECKABLE")
+
+# The functions that decide a tests_pass verdict, named here so that
+# selfcheck_tests_pass_never_accuses() scans exactly them. The path-claim
+# branches inside _gate are a DIFFERENT class with a different (published,
+# withheld) history and are deliberately out of scope for that check.
+_TESTS_PASS_FUNCTIONS = ("_evidence_leg", "_run_leg", "_tests_pass_verdict")
+
+# PREREG_evidence_leg_2026_09_01 committed to replacing the old string, "no --run
+# command supplied; the gate does not take the agent's word for test results",
+# because it implied the remedy was to supply a shell string — the one thing this
+# gate should not push a reader toward against an untrusted branch, and the thing
+# capsule R4 refuses to seal. This note is APPENDED to the adjudicator's own
+# words rather than replacing them, and it names the reading channel instead.
+# Strictly more informative at an identical verdict.
+_NO_EVIDENCE_NOTE = (
+    "No test REPORT was handed to the gate. It does not take the agent's word "
+    "for test results, so with nothing to read it declines — absence of evidence "
+    "is not a contradiction. The channel that makes this readable is a report "
+    "passed with --evidence: a JUnit XML, or better a test-result attestation "
+    "whose subject names the head commit. Even then no signature is checked, and "
+    "the answer is VERIFIED or UNCHECKABLE — there is no accusing verdict for "
+    "this claim kind.")
+
+
+def _evidence_leg(paths, commit: str | None) -> tuple[str, str]:
+    """Read a `tests_pass` claim through styxx.evidence. VERIFIED or UNCHECKABLE.
+
+    THE IMPORT IS LOCAL AND EVERY FAILURE IS CONTAINED, the same way `_gate`
+    imports `styxx.claimdetect` and `styxx.undeclared` imports
+    `parse_unified_diff`: the dependency direction stays one-way (diffgate ->
+    evidence, never back), and a missing, unreadable or malformed evidence file
+    can never break the rest of the gate. A claim that could not be read is
+    UNCHECKABLE — not an exception, and never an accusation.
+
+    NO PARSING AND NO VERDICT TABLE IS REIMPLEMENTED HERE. This function calls
+    `load_evidence` and `adjudicate_tests_pass` and does nothing else with the
+    bytes. A second copy of a JUnit reader would drift from the first, and a
+    drifting second parser is what produced the correction this lab published on
+    2026-08-31.
+
+    NOTHING HERE READS ``ev["observed"]``. That is styxx.evidence's REPORT-ONLY
+    band, and its own note says a caller that turns ``failing_tests > 0`` into a
+    failing check "has reintroduced, without measurement, exactly the verdict
+    this module declines to ship". `selfcheck_no_accusation` states its boundary
+    as not being able to prove a caller has not done so. This is that caller, and
+    `selfcheck_tests_pass_never_accuses()` below is the counterpart it asked for.
+
+    THE TWO MONOTONICITY PROPERTIES, because this is the leg they are about:
+
+      * **Monotone against the empty baseline — HOLDS.** Evidence never leaves a
+        `tests_pass` claim worse than supplying none. That is the guarantee.
+      * **Monotone under set extension — DOES NOT HOLD, deliberately.** Adding a
+        source to an already-affirming set can demote VERIFIED to UNCHECKABLE,
+        because `adjudicate_tests_pass` blocks VERIFIED on ANY unparsed source. A
+        partial read DECLINES rather than AFFIRMS: nine parsed shards out of ten
+        cannot certify "all tests pass", and affirming from an incomplete set is
+        the failure mode this module exists to refuse. Do not "fix" this by
+        letting a partial read affirm, and do not special-case empty files.
+
+    So `--evidence green.xml` can be VERIFIED while `--evidence green.xml
+    empty.xml` is UNCHECKABLE. Operators: supply COMPLETE evidence or supply
+    NONE. The `why` returned here carries the adjudicator's own count of how many
+    of how many sources were unreadable, and names one of them, so a sharded CI
+    matrix that lost one report can see which one from the failing build.
+    """
+    paths = [str(p) for p in (paths or [])]
+    try:
+        from styxx.evidence import SPEC, adjudicate_tests_pass, load_evidence
+    except Exception as exc:                      # pragma: no cover - env-dependent
+        return "UNCHECKABLE", (
+            f"{len(paths)} evidence file(s) were named but styxx.evidence could "
+            f"not be imported ({exc.__class__.__name__}: {exc}). The gate does "
+            "not take the agent's word for test results, and it could not read "
+            "the evidence either, so it declines.")
+    try:
+        ev = load_evidence(paths)
+        verdict, why = adjudicate_tests_pass(ev, commit)
+    except Exception as exc:                      # pragma: no cover - defensive
+        return "UNCHECKABLE", (
+            f"styxx.evidence raised {exc.__class__.__name__}: {exc} while reading "
+            f"{len(paths)} supplied file(s). A crash is not a verdict.")
+
+    tag = (f"styxx.evidence ({SPEC}) read {len(paths)} supplied file(s)"
+           + (f", required to assert commit {commit}" if commit else
+              ", with no commit supplied, so nothing ties a report to this change"))
+    # The clamp. styxx.evidence's VERDICTS tuple is two words and its
+    # selfcheck re-derives that from source, but this line does not depend on
+    # that promise holding: anything that is not the affirming word becomes
+    # UNCHECKABLE here, on this side of the boundary.
+    if verdict != "VERIFIED":
+        return "UNCHECKABLE", f"{tag} — {why}"
+    return "VERIFIED", f"{tag} — {why}"
+
+
+def _run_leg(run: str, repo) -> tuple[str, str]:
+    """Execute the operator-supplied command. VERIFIED on exit 0, else UNCHECKABLE.
+
+    THE ACCUSING HALF OF THIS BRANCH IS DELETED. It used to read
+    ``r.returncode != 0`` as the author having lied. The exit code is still
+    recorded — in the `why`, where a reader can act on it — and it decides
+    nothing.
+    """
+    if repo is None:
+        # The quiet defect on the zero-receipt path: `gate_diff_text` takes
+        # repo=None by default, and `subprocess.run(cwd=None)` executes in the
+        # VERIFIER'S OWN working directory. The one entry point built for having
+        # no checkout was the one where cwd silently became the operator's tree.
+        # Refusing beats defaulting.
+        return "UNCHECKABLE", (
+            f"--run {run!r} was supplied with no repository to run it in. "
+            "REFUSED rather than executed: with cwd unset the command would run "
+            "in the verifier's own working directory, not in any tree under "
+            "review. Pass a repo, or use --evidence, which executes nothing.")
+    try:
+        r = subprocess.run(run, shell=True, cwd=repo,
+                           capture_output=True, text=True,
+                           encoding="utf-8", errors="replace", timeout=1800)
+    except subprocess.TimeoutExpired:
+        # Previously this propagated out of _gate as a traceback. A crash is not
+        # a verdict, and a gate that dies mid-claim has not measured anything.
+        return "UNCHECKABLE", (
+            f"--run {run!r} did not finish within 1800s and was killed. A timeout "
+            "is absence of evidence about the claim, not evidence against it.")
+    except OSError as exc:
+        return "UNCHECKABLE", (
+            f"--run {run!r} could not be started ({exc.__class__.__name__}: "
+            f"{exc}). That is a fact about this machine, not about the author.")
+    if r.returncode == 0:
+        return "VERIFIED", (
+            f"--run {run!r} exited 0. Read that as exactly what it says: the "
+            "supplied command exited 0 — IT DOES NOT MEAN THE TESTS PASSED. It "
+            "restates the author's own claim and checks NOTHING about the "
+            "sentence that was extracted, which may have been an unchecked "
+            "checkbox, a negation or a quotation. Nothing about the command's "
+            "provenance was checked either: on an untrusted branch the author "
+            "controls this exit code in both directions.")
+    return "UNCHECKABLE", (
+        f"--run {run!r} exited {r.returncode}. A nonzero exit is NOT evidence "
+        "that the author lied — it is also what pytest rc=5 (no tests "
+        "collected), a misspelled command, a missing dependency and a flaky test "
+        "produce, and on an untrusted branch the author controls this number in "
+        "both directions. The accusing verdict for this claim kind is deleted, "
+        "not disabled: its precision has never been measured by a blind panel on "
+        "either leg. The exit code is recorded here and gates nothing.")
+
+
+def _tests_pass_verdict(*, evidence, commit: str | None,
+                        run: str | None, repo) -> tuple[str, str]:
+    """Resolve one `tests_pass` claim. Called ONCE PER GATE, never per match.
+
+    Before this repair the command ran once per REGEX MATCH: a body carrying N
+    lines that say "all tests pass" launched N subprocesses, each with its own
+    1800-second budget — unbounded, PR-author-controlled runner-hour
+    amplification, and N chances to hang. Every `tests_pass` match in one summary
+    asks the same question about the same suite, so it gets one answer.
+
+    The two channels are a DISJUNCTION, deliberately: either may affirm, neither
+    may accuse, and `--run` is not even executed if `--evidence` already
+    affirmed. Requiring both would let *adding* --evidence turn a --strict PASS
+    into a --strict FAIL relative to supplying no evidence at all, and that
+    baseline is the one this gate guarantees.
+
+    STATE THE GUARANTEE PRECISELY, because two properties get conflated here:
+    supplying evidence is monotone AGAINST THE EMPTY BASELINE (it never does
+    worse than supplying none), and it is NOT monotone UNDER SET EXTENSION
+    (E -> E union {x} can demote VERIFIED to UNCHECKABLE when x cannot be
+    parsed). The second is deliberate and is `styxx.evidence`'s rule, not this
+    function's: a partial read declines rather than affirms. See the module
+    docstring and `_evidence_leg` for what an operator should do about it.
+    """
+    verdict = "UNCHECKABLE"
+    whys: list[str] = []
+    # The adjudicator is consulted even when NO paths were supplied. It is a pure
+    # function of bytes and it has its own words for that case — "no evidence was
+    # supplied. Absence of a report is not a failing report; an unattested commit
+    # is unattested." Paraphrasing them here would put a second adjudicator in
+    # the file, which is the drift this wiring exists to avoid.
+    v, why = _evidence_leg(evidence, commit)
+    whys.append(why)
+    if v == "VERIFIED":
+        verdict = "VERIFIED"
+    if verdict != "VERIFIED" and run:
+        v, why = _run_leg(run, repo)
+        whys.append(why)
+        if v == "VERIFIED":
+            verdict = "VERIFIED"
+    if verdict != "VERIFIED" and not evidence:
+        whys.append(_NO_EVIDENCE_NOTE)
+    if verdict not in _TESTS_PASS_VERDICTS:       # unreachable clamp, kept anyway
+        verdict = "UNCHECKABLE"
+    return verdict, "  ||  ".join(whys)
+
+
+def selfcheck_tests_pass_never_accuses(source: str | None = None) -> dict:
+    """Re-derive from this module's own source that the tests_pass leg cannot accuse.
+
+    The caller-side counterpart of ``styxx.evidence.selfcheck_no_accusation``,
+    which states its own boundary as: it "does not prove a caller has not
+    invented an accusation of its own out of the report-only `observed` band."
+    diffgate IS that caller, so this check belongs here — in the file where the
+    branch actually lived.
+
+    Three questions, answered with ``ast`` rather than a grep, because the word
+    necessarily appears in the prose explaining its absence and in the path-claim
+    branches, which are a different class and out of scope:
+
+      * does the accusing string appear as a NON-DOCSTRING constant anywhere
+        inside the functions that decide a ``tests_pass`` verdict,
+      * does ``_TESTS_PASS_VERDICTS`` still hold exactly the two surviving words,
+      * does this module touch styxx.evidence's report-only ``observed`` band
+        anywhere at all — the band whose only possible misuse is being turned
+        into a verdict.
+
+    Boundary, stated the way that module states its own: this proves the string
+    is not produced by these functions. It does not prove the extraction that
+    reaches them is sound — that is Panel A, and it has never been run.
+    """
+    if source is None:
+        try:
+            source = Path(__file__).read_text(encoding="utf-8")
+        except OSError as exc:                    # pragma: no cover
+            return {"ok": None, "reason": f"could not read own source: {exc}"}
+    try:
+        tree = ast.parse(source)
+    except SyntaxError as exc:                    # pragma: no cover
+        return {"ok": None, "reason": f"own source does not parse: {exc}"}
+
+    word = "CONTRA" + "DICTED"     # split so this line is not itself an occurrence
+    band = "obse" + "rved"         # ditto for the report-only band
+
+    docstrings: set[int] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.Module, ast.FunctionDef, ast.AsyncFunctionDef,
+                             ast.ClassDef)):
+            body = getattr(node, "body", None) or []
+            if (body and isinstance(body[0], ast.Expr)
+                    and isinstance(body[0].value, ast.Constant)
+                    and isinstance(body[0].value.value, str)):
+                docstrings.add(id(body[0].value))
+
+    funcs = {n.name: n for n in ast.walk(tree)
+             if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))
+             and n.name in _TESTS_PASS_FUNCTIONS}
+    missing = sorted(set(_TESTS_PASS_FUNCTIONS) - set(funcs))
+
+    occurrences = []
+    for name in sorted(funcs):
+        for node in ast.walk(funcs[name]):
+            if (isinstance(node, ast.Constant) and isinstance(node.value, str)
+                    and word in node.value and id(node) not in docstrings):
+                occurrences.append({"function": name, "lineno": node.lineno,
+                                    "excerpt": node.value[:80]})
+
+    band_reads = []
+    for node in ast.walk(tree):
+        if (isinstance(node, ast.Constant) and isinstance(node.value, str)
+                and node.value == band and id(node) not in docstrings):
+            band_reads.append({"lineno": node.lineno, "form": "string key"})
+        elif isinstance(node, ast.Attribute) and node.attr == band:
+            band_reads.append({"lineno": node.lineno, "form": "attribute"})
+
+    vocab_ok = tuple(_TESTS_PASS_VERDICTS) == ("VERIFIED", "UNCHECKABLE")
+    ok = not occurrences and not band_reads and not missing and vocab_ok
+    return {
+        "ok": ok,
+        "reason": ("the accusing verdict is absent from the tests_pass leg: no "
+                   "code path in these functions produces it, the vocabulary "
+                   "holds only VERIFIED and UNCHECKABLE, and this module never "
+                   "reads styxx.evidence's report-only band"
+                   if ok else "see code_occurrences / band_reads / missing"),
+        "verdicts": list(_TESTS_PASS_VERDICTS),
+        "functions_checked": sorted(funcs),
+        "missing": missing,
+        "code_occurrences": occurrences,
+        "band_reads": band_reads,
+        "boundary": ("proves the accusing string is not produced by these "
+                     "functions and that the report-only band is never read. It "
+                     "does NOT prove the extraction feeding them is sound: the "
+                     "template fires on unchecked checkboxes, negations, "
+                     "conditionals and quoted prose, and its precision has never "
+                     "been measured by a blind panel."),
+    }
+
+
 @dataclass
 class DiffClaim:
     kind: str
@@ -267,17 +671,43 @@ def parse_unified_diff(diff_text: str) -> tuple[dict[str, str], str]:
 
 def gate_diff_text(summary_text: str, diff_text: str,
                    run: str | None = None, strict: bool = False,
-                   repo: str | Path | None = None) -> DiffGate:
-    """Gate a summary against a RAW unified diff — no git checkout required."""
+                   repo: str | Path | None = None,
+                   evidence=None, commit: str | None = None) -> DiffGate:
+    """Gate a summary against a RAW unified diff — no git checkout required.
+
+    `evidence` is a sequence of test-report paths handed to `styxx.evidence`.
+    `commit` is the revision the evidence must assert; with none, styxx.evidence
+    says in its own `why` that the report is not tied to any particular change.
+    Neither can produce an accusation — see `_tests_pass_verdict`.
+    """
     status, added_blob = parse_unified_diff(diff_text)
     return _gate(summary_text, status, added_blob, run=run, strict=strict,
                  repo=repo, base="(diff-text)", head="(diff-text)",
+                 evidence=evidence, commit=commit,
                  raw_input_len=len(diff_text or ""))
 
 
 def gate_diff(summary_text: str, repo: str | Path, base: str, head: str,
-              run: str | None = None, strict: bool = False) -> DiffGate:
-    """Extract diff-shaped claims from *summary_text* and verify against base..head."""
+              run: str | None = None, strict: bool = False,
+              evidence=None, commit: str | None = None) -> DiffGate:
+    """Extract diff-shaped claims from *summary_text* and verify against base..head.
+
+    `evidence` is a sequence of test-report paths (a JUnit XML, a test-result
+    attestation) routed through `styxx.evidence`, whose vocabulary is VERIFIED
+    and UNCHECKABLE. MEASURED AGAINST SUPPLYING NOTHING, it can only turn an
+    UNCHECKABLE `tests_pass` claim into a VERIFIED one: there is no route by
+    which passing a report fails a build that would have passed with no report.
+    That comparison is the guarantee, and it is the whole of it — this is NOT
+    monotone under set extension, and adding an unreadable path to a set that
+    was already affirming demotes it to UNCHECKABLE by design. See the module
+    docstring, "MONOTONICITY: TWO PROPERTIES".
+
+    `commit` is NOT defaulted to the resolved `head`. That was tried and backed
+    out: it made this function silently stricter than `gate_diff_text` over the
+    same evidence bytes, and an adjudication that changes with which entry point
+    called it is not a pure function of the bytes. The caller says which revision
+    the report has to name. Supplying one can only WITHHOLD a VERIFIED.
+    """
     repo = Path(repo)
     name_status = _git(repo, "diff", "--name-status", f"{base}..{head}")
     status: dict[str, str] = {}
@@ -290,11 +720,78 @@ def gate_diff(summary_text: str, repo: str | Path, base: str, head: str,
                    if l.startswith("+") and not l.startswith("+++")]
     added_blob = "\n".join(added_lines)
     return _gate(summary_text, status, added_blob, run=run, strict=strict,
-                 repo=repo, base=base, head=head)
+                 repo=repo, base=base, head=head,
+                 evidence=evidence, commit=commit)
+
+
+def _path_claim_verdict(kind: str, claimed: str, find_path) -> tuple[str, str]:
+    """Resolve a file_created / file_deleted / file_touched claim.
+
+    Lifted out of `_gate` UNCHANGED — same branches, same order, same strings.
+    It lives in its own function so that the path-claim accusation, which is a
+    DIFFERENT class with its own published history and its own withholding flag,
+    is not lexically nested inside the loop that also handles `tests_pass`. A
+    structural check asking "is an accusation produced under a `tests_pass`
+    guard" cannot answer that about a chain of elifs sharing one `for`
+    statement. The honest fix is to separate the code, not to word the check
+    more loosely.
+    """
+    p, st = find_path(claimed)
+    want = {"file_created": "A", "file_deleted": "D"}.get(kind)
+    accuse = not WITHHOLD_PATH_ACCUSATION
+    bare = (V14_BARE_NAME_ABSTAIN and "/" not in claimed and "\\" not in claimed)
+    if p is None and bare:
+        # V14 repair 2 (PREREG_v14_repair_2026_08_31): a bare name ending in a
+        # code-like extension is not reliably a file. The corpus accuses
+        # `asmcrypto.js` and `ethers.js` — npm packages named in prose — and no
+        # frozen list can close that set, because library names are open and a
+        # list is always one package behind. A claimed path with no directory
+        # component, absent from the diff entirely, is ambiguous between a file
+        # and a library and the instrument cannot tell which. It says so.
+        # DELIBERATE RECALL SACRIFICE, preregistered as one: this stops the gate
+        # catching some genuine lies about bare-named files. Made knowingly —
+        # measured at 0.23 precision, a false accusation costs more than a missed
+        # catch. Paths carrying a directory component are unaffected and still
+        # accuse.
+        return "UNCHECKABLE", (
+            f"{claimed!r} is a bare name absent from the diff — ambiguous "
+            "between a file and a library, so no accusation is made (V14 "
+            "repair 2, a deliberate recall sacrifice)")
+    if p is None:
+        # EXTERNAL-1 (RESULT_external1_the_gate_fails_in_the_wild_2026_08_31):
+        # over 100 blind-adjudicated accusations on an external corpus of
+        # agent-authored PRs this branch reached precision 0.23 against a
+        # preregistered floor of 0.95. The preregistration's committed
+        # consequence was to disable the accusing verdict for this class until
+        # repaired, and this is that consequence being paid. Four mechanical
+        # defects account for it: bare basenames never met full diff paths
+        # ('glob.ts' vs 'src/node/glob.ts'); "removed X from FILE" bound the verb
+        # to the file instead of X; prose nouns passed the extension whitelist
+        # ('Node.js', 'Express.js'); and negation ("avoids modifying
+        # tsconfig.json") was read as assertion. An instrument that cannot accuse
+        # precisely must abstain. Repair is preregistered separately and must
+        # clear its gate on the HELD-OUT split before this line accuses again.
+        return (("CONTRADICTED",
+                 f"{claimed!r} does not appear in the diff at all")
+                if accuse else
+                ("UNCHECKABLE",
+                 f"{claimed!r} does not appear in the diff — accusation "
+                 "WITHHELD: this class failed EXTERNAL-1 precision "
+                 "(0.23 vs 0.95 floor), disabled pending repair"))
+    if want and st != want:
+        return (("CONTRADICTED",
+                 f"{claimed!r} is status {st!r} in the diff, "
+                 f"claim wants {want!r}")
+                if accuse else
+                ("UNCHECKABLE",
+                 f"{claimed!r} is status {st!r}, claim wants {want!r} — "
+                 "accusation WITHHELD pending the EXTERNAL-1 repair"))
+    return "VERIFIED", f"diff status {st!r} for {p!r}"
 
 
 def _gate(summary_text: str, status: dict[str, str], added_blob: str, *,
           run: str | None, strict: bool, repo, base: str, head: str,
+          evidence=None, commit: str | None = None,
           raw_input_len: int | None = None) -> DiffGate:
 
     # Some claim kinds are VACUOUSLY TRUE against an empty diff. `only_touches`
@@ -320,6 +817,17 @@ def _gate(summary_text: str, status: dict[str, str], added_blob: str, *,
             if p == c or p.endswith("/" + c) or Path(p).name == Path(c).name:
                 return p, st
         return None, None
+
+    # ONE resolution of the tests_pass question per gate invocation, memoised
+    # here and shared by every match. See `_tests_pass_verdict` for what this
+    # repairs: the command used to run once per REGEX MATCH.
+    _tp: list[tuple[str, str]] = []
+
+    def tests_pass_leg() -> tuple[str, str]:
+        if not _tp:
+            _tp.append(_tests_pass_verdict(
+                evidence=evidence, commit=commit, run=run, repo=repo))
+        return _tp[0]
 
     claims: list[DiffClaim] = []
     sentences = re.split(r"(?<=[.!?])\s+|\n+", summary_text)
@@ -354,68 +862,20 @@ def _gate(summary_text: str, status: dict[str, str], added_blob: str, *,
                 covered.add(si)
                 d = {k: v for k, v in m.groupdict().items() if v is not None}
                 c = DiffClaim(kind=kind, text=sent.strip()[:160], detail=d)
-                if no_evidence and kind != "tests_pass":
+                # The `and kind != "tests_pass"` exemption that used to live on
+                # this line is REMOVED. With input that parsed to nothing the
+                # gate returns measured=False and the CLI prints "UNMEASURED
+                # this gate did not run" — and the exempted branch went on to
+                # execute a shell command and pronounce on the claim anyway. A
+                # gate that says it did not run must not reach a verdict, and it
+                # must not launch a subprocess to get there.
+                if no_evidence:
                     c.verdict, c.why = "UNCHECKABLE", no_evidence
                     claims.append(c)
                     continue
-                if kind in ("file_created", "file_deleted", "file_touched"):
-                    p, st = find_path(d["path"])
-                    want = {"file_created": "A", "file_deleted": "D"}.get(kind)
-                    accuse = not WITHHOLD_PATH_ACCUSATION
-                    bare = (V14_BARE_NAME_ABSTAIN and "/" not in d["path"]
-                            and "\\" not in d["path"])
-                    if p is None and bare:
-                        # V14 repair 2 (PREREG_v14_repair_2026_08_31): a bare name
-                        # ending in a code-like extension is not reliably a file. The
-                        # corpus accuses `asmcrypto.js` and `ethers.js` — npm packages
-                        # named in prose — and no frozen list can close that set,
-                        # because library names are open and a list is always one
-                        # package behind. A claimed path with no directory component,
-                        # absent from the diff entirely, is ambiguous between a file
-                        # and a library and the instrument cannot tell which. It says
-                        # so. DELIBERATE RECALL SACRIFICE, preregistered as one: this
-                        # stops the gate catching some genuine lies about bare-named
-                        # files. Made knowingly — measured at 0.23 precision, a false
-                        # accusation costs more than a missed catch. Paths carrying a
-                        # directory component are unaffected and still accuse.
-                        c.verdict, c.why = "UNCHECKABLE", (
-                            f"{d['path']!r} is a bare name absent from the diff — "
-                            "ambiguous between a file and a library, so no accusation "
-                            "is made (V14 repair 2, a deliberate recall sacrifice)")
-                    elif p is None:
-                        # EXTERNAL-1 (RESULT_external1_the_gate_fails_in_the_wild_2026_08_31):
-                        # over 100 blind-adjudicated accusations on an external corpus of
-                        # agent-authored PRs this branch reached precision 0.23 against a
-                        # preregistered floor of 0.95. The preregistration's committed
-                        # consequence was to disable the accusing verdict for this class
-                        # until repaired, and this is that consequence being paid. Four
-                        # mechanical defects account for it: bare basenames never met full
-                        # diff paths ('glob.ts' vs 'src/node/glob.ts'); "removed X from
-                        # FILE" bound the verb to the file instead of X; prose nouns passed
-                        # the extension whitelist ('Node.js', 'Express.js'); and negation
-                        # ("avoids modifying tsconfig.json") was read as assertion.
-                        # An instrument that cannot accuse precisely must abstain. Repair
-                        # is preregistered separately and must clear its gate on the
-                        # HELD-OUT split before this line accuses again.
-                        c.verdict, c.why = (
-                            ("CONTRADICTED",
-                             f"{d['path']!r} does not appear in the diff at all")
-                            if accuse else
-                            ("UNCHECKABLE",
-                             f"{d['path']!r} does not appear in the diff — accusation "
-                             "WITHHELD: this class failed EXTERNAL-1 precision "
-                             "(0.23 vs 0.95 floor), disabled pending repair"))
-                    elif want and st != want:
-                        c.verdict, c.why = (
-                            ("CONTRADICTED",
-                             f"{d['path']!r} is status {st!r} in the diff, "
-                             f"claim wants {want!r}")
-                            if accuse else
-                            ("UNCHECKABLE",
-                             f"{d['path']!r} is status {st!r}, claim wants {want!r} — "
-                             "accusation WITHHELD pending the EXTERNAL-1 repair"))
-                    else:
-                        c.verdict, c.why = "VERIFIED", f"diff status {st!r} for {p!r}"
+                if kind in _PATH_KINDS:
+                    c.verdict, c.why = _path_claim_verdict(kind, d["path"],
+                                                           find_path)
                 elif kind == "files_changed_count":
                     n = int(d["n"])
                     if no_paths:
@@ -445,20 +905,42 @@ def _gate(summary_text: str, status: dict[str, str], added_blob: str, *,
                         c.why = ("all changed paths under prefix" if not outside else
                                  f"paths outside {pref!r}: {outside[:3]}")
                 elif kind == "tests_pass":
-                    if run:
-                        r = subprocess.run(run, shell=True, cwd=repo,
-                                           capture_output=True, text=True,
-                                           encoding="utf-8", errors="replace", timeout=1800)
-                        c.verdict = "VERIFIED" if r.returncode == 0 else "CONTRADICTED"
-                        c.why = f"--run {run!r} exited {r.returncode}"
-                    else:
-                        c.verdict, c.why = "UNCHECKABLE", \
-                            "no --run command supplied; the gate does not take the " \
-                            "agent's word for test results"
+                    # VERIFIED or UNCHECKABLE. There is no third answer here and
+                    # no flag that adds one — see the module docstring and
+                    # selfcheck_tests_pass_never_accuses(). The extraction that
+                    # reached this line is UNMEASURED: this template fires on
+                    # unchecked PR-template checkboxes, on negations, on
+                    # conditionals and inside code fences, so a verdict of either
+                    # word may be attached to a sentence that asserts nothing.
+                    # That is disclosed rather than patched.
+                    c.verdict, c.why = tests_pass_leg()
                 claims.append(c)
 
     contradicted = any(c.verdict == "CONTRADICTED" for c in claims)
     uncheckable = any(c.verdict == "UNCHECKABLE" for c in claims)
+    # STRICT MODE AND THE EVIDENCE LEG. --strict turns any UNCHECKABLE into FAIL,
+    # so the guarantee has to be stated against a named baseline. Say which:
+    #
+    # MONOTONE AGAINST THE EMPTY BASELINE — HOLDS. "Can supplying --evidence fail
+    # a build that would have passed with NO --evidence?" It cannot. The evidence
+    # leg is consulted only for `tests_pass`; that kind is UNCHECKABLE without it;
+    # no other claim's verdict reads `evidence`; supplying it adds and removes no
+    # claims. So against the empty baseline the verdict set is pointwise
+    # at-least-as-good. There is also no route to CONTRADICTED: styxx.evidence's
+    # vocabulary is two words, `_evidence_leg` clamps anything else to
+    # UNCHECKABLE, and `selfcheck_tests_pass_never_accuses` re-derives that from
+    # this file's own source.
+    #
+    # NOT MONOTONE UNDER SET EXTENSION — DELIBERATE. The set of UNCHECKABLE claims
+    # does NOT simply shrink as evidence is added. Going from E to E union {x}
+    # can put `tests_pass` back to UNCHECKABLE, because ANY unparsed source blocks
+    # VERIFIED in styxx.evidence: a partial read may honestly decline but may not
+    # honestly affirm. `--evidence green.xml` PASSes here where `--evidence
+    # green.xml empty.xml` FAILs, and that is correct — nine readable shards out
+    # of ten cannot certify "all tests pass". The earlier version of this comment
+    # claimed the shrink-only property for both baselines at once; only the empty
+    # one holds, and the difference is a contract, not a bug. Operators: supply
+    # complete evidence or supply none.
     verdict = "FAIL" if (contradicted or (strict and uncheckable)) else "PASS"
     uncovered_texts = [s.strip() for i, s in enumerate(sentences)
                        if s.strip() and i not in covered]
@@ -510,7 +992,10 @@ _WHAT_IT_CHECKS = """\
     "added N tests"                       vs added test functions
     "N files changed"                     vs the diff
     "only touches <prefix>"               vs every changed path
-    "tests pass"                          only with --run (we don't take its word)
+    "tests pass"                          only with --evidence (a test report, read
+                                          as bytes) or --run (which EXECUTES a shell
+                                          command) — we don't take its word, and we
+                                          never call it a lie: VERIFIED or UNCHECKABLE
   example of a checkable sentence:  'Modified src/app.py and added 2 tests.'
 """
 
@@ -538,7 +1023,32 @@ def main(argv=None) -> int:
     ap.add_argument("--repo", default=".")
     ap.add_argument("--base")
     ap.add_argument("--head", default="HEAD")
-    ap.add_argument("--run", default=None)
+    ap.add_argument(
+        "--evidence", nargs="+", action="extend", default=None, metavar="REPORT",
+        help="one or more test reports (a JUnit XML, or a test-result "
+             "attestation naming the commit). Read as BYTES by styxx.evidence, "
+             "which EXECUTES NOTHING and whose whole vocabulary is VERIFIED and "
+             "UNCHECKABLE. Repeatable, and accepts several paths at once. An "
+             "absent, unreadable or red report is UNCHECKABLE, never an "
+             "accusation.")
+    ap.add_argument(
+        "--commit", default=None, metavar="SHA",
+        help="the commit the evidence must assert. Not defaulted to --head: the "
+             "caller says which revision the report has to name, so the same "
+             "bytes get the same answer from every entry point. Evidence that "
+             "does not assert it withholds VERIFIED; it never accuses. No "
+             "signature is checked anywhere in this path — a digest assertion "
+             "is bytes the producer chose.")
+    ap.add_argument(
+        "--run", default=None, metavar="CMD",
+        help="DANGER — EXECUTES CMD THROUGH A SHELL with cwd=--repo. On an "
+             "untrusted pull request this is remote code execution: pytest "
+             "imports the PR's conftest.py at collection, `npm test` runs the "
+             "PR's package.json, addopts loads plugins, and os.environ is "
+             "inherited unscrubbed. The PR author also controls the exit code in "
+             "both directions. Correct in first-party CI on a repo you own; "
+             "never on a stranger's branch. Prefer --evidence. Exit 0 gives "
+             "VERIFIED; any other exit gives UNCHECKABLE, never an accusation.")
     ap.add_argument("--strict", action="store_true")
     ap.add_argument("--demo", action="store_true")
     ap.add_argument("--out", default=None)
@@ -547,8 +1057,14 @@ def main(argv=None) -> int:
         return _demo()
     if not a.summary or not a.base:
         ap.error("summary and --base are required (or try --demo)")
+    if a.run:
+        # Said out loud on every run, not left in --help for a reader to find.
+        print(f"--run WILL EXECUTE {a.run!r} through a shell in {a.repo!r}. That "
+              "is code execution; do not point it at a pull request you did not "
+              "write. --evidence reads bytes and executes nothing.")
     text = Path(a.summary).read_text(encoding="utf-8")
-    g = gate_diff(text, a.repo, a.base, a.head, run=a.run, strict=a.strict)
+    g = gate_diff(text, a.repo, a.base, a.head, run=a.run, strict=a.strict,
+                  evidence=a.evidence, commit=a.commit)
     if a.out:
         Path(a.out).write_text(json.dumps(g.to_dict(), indent=2) + "\n", encoding="utf-8")
     if not g.measured:

--- a/tests/test_diffgate_evidence.py
+++ b/tests/test_diffgate_evidence.py
@@ -1,0 +1,1414 @@
+# -*- coding: utf-8 -*-
+"""diffgate x styxx.evidence -- the wiring contract, and the tripwires on it.
+
+WRITTEN AGAINST THE 581-LINE MODULE, WHICH HAD NO WIRING AT ALL
+
+Every test in this file was written and watched failing against the shipped
+`styxx.diffgate` of 2026-09-01 -- the 581-line version in which `gate_diff_text`
+took no `evidence` parameter, nothing was imported from `styxx.evidence`, and
+`diffgate.py:452` resolved a `tests_pass` claim to the accusing verdict whenever
+the `--run` command exited nonzero. The wiring landed while this file was being
+written. That is why the markers below are written as SELF-ARMING conditions on
+probes of the CURRENTLY LOADED module rather than as bare xfails: a marker whose
+condition is a probe disarms itself the moment the defect it names is repaired,
+and `strict=True` turns an unexplained pass into a FAILURE rather than a quiet
+XPASS. There is no configuration under which a test in this file is silently
+green.
+
+The suite this lab replaced two days ago was GREEN ON ARRIVAL and survived four
+of ten mutants. `tests/test_evidence.py` carries the corrective in its own
+docstring -- "a test that has never been seen to fail is a decoration."
+
+WHAT IS ASSERTED, AND WHY EACH ONE IS LOAD-BEARING
+
+  * TWO MONOTONICITY PROPERTIES, ASSERTED SEPARATELY, BECAUSE ONLY ONE HOLDS.
+    An earlier draft of this file asserted one of them under one name and read
+    the green result as though it had established both. It had not. The two are
+    the difference between a guarantee and a wish, and conflating them is how a
+    safety rule gets "repaired" by someone who read a receipt as saying more than
+    it says.
+
+    ``test_adding_evidence_never_worsens_the_gate_against_no_evidence`` -- the
+    guarantee, and it HOLDS. Over nine claim combinations x six evidence contents
+    plus a nonexistent path x two strictness settings, a gate handed evidence
+    ranks no worse than the same gate handed NONE, at the overall verdict AND at
+    every individual claim. The baseline is the EMPTY evidence set and nothing
+    else, and the test name says so, because the comparison cannot be recovered
+    from a report line that only says "never worsens". This is the invariant that
+    makes the leg safe to ship before its precision is measured: an adjudicator
+    that, relative to supplying nothing, can only resolve UNCHECKABLE upward
+    cannot manufacture an accusation however wrong the extraction feeding it is.
+    `_gate` argues this in a comment; this test measures it.
+
+  * ``test_extending_an_evidence_set_can_demote_verified_and_must`` -- the
+    property that DOES NOT hold, PINNED so that nobody repairs it. E -> E union
+    {x} can move a `tests_pass` claim from VERIFIED back to UNCHECKABLE and a
+    --strict PASS back to FAIL. That is the contract's own rule rather than a
+    defect in it: a partial read may honestly DECLINE but may not honestly
+    AFFIRM, so a source that could not be read blocks VERIFIED. You cannot
+    certify "all tests pass" from nine shards out of ten. Measured rather than
+    argued -- 12 of the 14 (addition x strictness) cells in that test's grid
+    worsen the verdict, and the 2 that do not are the well-formed zero-test
+    report, which parses and contributes nothing. That row is kept in the grid as
+    the negative control, because a rule that demoted on ANY addition would be a
+    file counter rather than a reader.
+
+    PREREG_evidence_leg's G-E6 is neither of these exactly: it bars a pull
+    request from GAINING AN ACCUSATION relative to the shipped gate run without
+    `--run`, which is the accusation half of the empty-baseline property and says
+    nothing at all about set extension. This file no longer describes itself as
+    its caller-side analogue -- it asserts more than G-E6 in one direction (all
+    three verdicts, not only the accusing one) and nothing in the other.
+
+  * ``test_no_evidence_content_can_produce_an_accusation`` -- by any route, for
+    any content, at any commit, in strict mode and out. `styxx.evidence` cannot
+    accuse by construction, but its own ``selfcheck_no_accusation`` states the
+    hole it cannot close: it "does not prove a caller has not invented an
+    accusation of its own out of the report-only ``observed`` band". diffgate is
+    that caller. Two tests close it from the caller's side -- one behavioural
+    over six contents including a forged FAILED attestation, one structural over
+    the source.
+
+  * ``test_the_run_branch_cannot_reach_an_accusation_in_the_source`` -- asserted
+    STRUCTURALLY, never by output alone. A test that only checks verdicts passes
+    on a module carrying the branch behind ``if False`` or behind a flag set to
+    off, and a branch nobody reaches today is a branch someone reaches after a
+    refactor. The behavioural companion is kept and is labelled insufficient on
+    its own. The AST helpers backing the structural tests are themselves watched
+    firing against five planted accusations, three of which no output-level test
+    can see.
+
+  * ``test_it_uses_styxx_evidence_not_a_private_copy`` -- by source inspection,
+    the way ``tests/test_undeclared.py`` asserts reconcile parses the diff with
+    the gate's own parser rather than a second one that can drift. Here the
+    drift would be worse than a disagreement about diffs: a private reader of
+    JUnit or in-toto bytes inside diffgate would be a reader with no ``VERDICTS``
+    tuple, no self-check, and no docstring saying what VERIFIED does not mean.
+
+THE MUTANT LOG
+
+Twenty-two deliberately defective copies of `diffgate` (and one of `evidence`)
+were injected in place of the real module and this file was run against each with
+``--runxfail``, so a self-arming marker could not absorb the failure. All 22 were
+caught, and every test in this file except the three that validate its own AST
+helpers was reddened by at least one of them. The four that no mutant reached on
+the first pass -- the vocabulary check, the VERIFIED-disclaims check, the
+determinism check and the CLI check -- had mutants written for them rather than
+being left unexercised.
+
+Two mutants SURVIVED on the first attempt and both were defects in THIS FILE, not
+in the module:
+
+  * M23 renamed the flag to ``--evidenceX`` and passed, because ``"--evidence" in
+    src`` is a substring test and ``--evidence`` is a prefix of ``--evidenceX``.
+    The check now reads exact option strings out of the parser's own AST.
+  * M23b stripped the code-execution warning off ``--run`` and passed, because a
+    whole-source search for "executes" was satisfied by ``--evidence``'s help
+    saying it "executes nothing". The check is now scoped to ``--run``'s own help
+    string.
+
+Both are recorded here rather than quietly fixed, because a suite that finds its
+own weak assertions is the only evidence that the mutants were real.
+
+THE MONOTONICITY SWEEP, 2026-09-01 -- MP1..MP7, MB1..MB2
+
+Eleven further mutants were injected into `styxx.evidence` and `styxx.diffgate`
+and the two monotonicity tests were run against each with ``--runxfail``. The
+module bytes were snapshotted before each injection and restored after it, and
+the restore was asserted by SHA-256 and by CRLF count -- both modules are CRLF,
+this test file is LF, and a mutant harness that silently renormalises line
+endings has edited the module it was supposed to be measuring.
+
+Reddening the PIN (``test_extending_an_evidence_set_can_demote_verified_and_must``):
+
+  * MP1 skips unreadable sources instead of blocking on them -- ``if unparsed:``
+    made unreachable. 6 of 14 cells red: this is the exact "repair" the pin's
+    docstring names as the one someone reaches for.
+  * MP2 special-cases the empty file, filtering `file is empty` out of
+    ``unparsed``. 2 of 14 red -- only the `zero_bytes` row, which is why that
+    row is in the grid rather than being folded into `unparsable`.
+  * MP3 takes the best available reading on disagreement, returning VERIFIED
+    where the module refuses to pick. 4 of 14 red (`red`, `forged_failed`).
+  * MP4 folds a harness error into a pass. 2 of 14 red.
+  * MP5 demotes on ANY second source. 2 of 14 red -- caught by the `empty`
+    NEGATIVE CONTROL alone, which is the only thing in this file that can tell a
+    reader from a file counter.
+  * MP6 makes strictness decorative (``strict and uncheckable`` dropped from the
+    verdict). 6 of 14 red, all in the strict half.
+  * MP7 makes nothing ever VERIFIED. 14 of 14 red, at the pin's own baseline
+    guard -- which is why that guard is there: a module that had stopped
+    affirming altogether would otherwise satisfy a demotion test trivially.
+  * MB1 and MB2 also red the pin, 14 of 14 each.
+
+Reddening the BASELINE test
+(``test_adding_evidence_never_worsens_the_gate_against_no_evidence``):
+
+  * MB1 drops the `tests_pass` claim whenever evidence is supplied. 112 of 126
+    cells red.
+  * MB2 makes supplying evidence force a FAIL. 49 of 126 red.
+  * MP1..MP7 leave it fully green, all 126 cells. That is the separation the
+    rename was for: seven distinct weakenings of the partial-read rule are
+    INVISIBLE to the empty-baseline property, and before the split there was no
+    test in this file that any of them reddened.
+
+ONE SURVIVOR, AND IT IS A FACT ABOUT THE MODULE, NOT A HOLE IN THE PIN
+
+  * MP3b disables BOTH the ``sources_disagree`` branch and the red reading and
+    still changes no output: the union of a green and a red report then falls
+    through to ``outcome {outcome!r} is outside the decision table``, which
+    declines anyway. Three independent layers defend that demotion, the same
+    shape M1..M16 found on the --run leg. Only MP3c, which disables all three by
+    forcing the PASSED arm, gets the module to affirm -- and the pin reds on it,
+    4 of 14. Recorded rather than quietly dropped: a mutant that survives because
+    the module is defended in depth is evidence about the module, and a mutant
+    that survives because the test is weak is evidence about the test. These two
+    are not the same result and a log that prints only "caught" cannot tell them
+    apart.
+
+WHAT M1 THROUGH M16 ESTABLISHED, WHICH IS A FACT ABOUT THE MODULE
+
+Restoring the accusing verdict inside ``_run_leg`` -- reached, unreached, or
+behind a flag -- changes NO OUTPUT. Three independent layers each swallow it:
+``_tests_pass_verdict`` folds the leg's answer with a promote-to-VERIFIED-only
+rule, the ``_TESTS_PASS_VERDICTS`` clamp rewrites anything else to UNCHECKABLE,
+and the branch itself is gone. Only M17, which removes all three, makes the
+behavioural test ``test_a_failing_run_command_does_not_accuse`` go red. So that
+test is not merely weaker than its structural counterpart: against this module it
+is unfalsifiable by any single-edit mutant, and it is kept as a regression guard
+for the refactor that removes the other two layers, not as evidence of anything
+today. The structural test is the one that bites, on all five accusation-restoring
+mutants, which is the whole argument for asserting absence over the SOURCE.
+
+WHAT THIS FILE DOES NOT ASSERT, SAID SO IT IS NOT MISTAKEN FOR COVERAGE
+
+Nothing here measures PRECISION. A green run says the wiring cannot accuse and
+cannot make a verdict worse than supplying no evidence at all. It says nothing
+about whether the `tests_pass` extraction feeding it is correct, and that
+extraction is the unmeasured leg: `extraction_census.json` reports that 6.27% of
+matches CARRY A MECHANICAL NON-ASSERTION INDICATOR -- an unchecked PR-template
+checkbox, a code fence, a blockquote, a negation -- and the status of the
+remaining 83% is UNMEASURED, its only indicator an unvalidated regex of the exact
+class this lab measured at 0.16. Panel A has never been run.
+
+That 6.27% is a CONTAINMENT figure and is not a wrongness figure, and this file
+used to state it as one. The census determines where a match SITS, which is a
+function of the bytes and involves no judgment; whether sitting inside a
+blockquote or an unchecked box makes an extraction WRONG is exactly the question
+Panel A is preregistered to answer and has never been asked. Neither is there any
+bar in this repository that 6.27% can be read against: the only preregistered
+extraction threshold is G-J6 in PREREG_third_party_precision_2026_09_01.md,
+extraction validity >= 0.90 -- a 10% budget on a quantity we know of no
+measurement of, ours or anyone's, and not a 5% budget on this one. G-J6 is also
+a different quantity: validity is what Panel A would adjudicate, and containment
+is what the census counts. An earlier draft of this docstring compared 6.27%
+against a "5% error budget" that does not exist anywhere in this repository. It
+was invented here.
+
+These tests are the reason the leg is safe to ship UNMEASURED; they are not a
+substitute for measuring it.
+"""
+from __future__ import annotations
+
+import ast
+import inspect
+import json
+import subprocess
+import types
+
+import pytest
+
+import styxx.diffgate as D
+import styxx.evidence as E
+from styxx.diffgate import gate_diff_text
+from styxx.evidence import adjudicate_tests_pass, load_evidence
+
+# Assembled at runtime so this file contains no occurrence of the accusing word.
+# A test file that accuses itself is the same mention/use defect it is testing
+# for -- the one ANALYSIS_base_rate_ceiling records against this lab's own
+# certificate.
+ACCUSE = "CONTRA" + "DICTED"
+
+CLAIM_RANK = {"VERIFIED": 0, "UNCHECKABLE": 1, ACCUSE: 2}
+GATE_RANK = {"PASS": 0, "FAIL": 1}
+
+# The commit-binding parameter was renamed while this file was being written
+# (`evidence_commit` -> `commit`). Both spellings are accepted here on purpose:
+# the contract this file holds the wiring to is "the commit under review reaches
+# the adjudicator, so a green report from another branch does not answer for
+# this one". That is a behaviour, not a spelling, and pinning the spelling would
+# make this suite fail for a reason that has nothing to do with what it guards.
+# What IS pinned is that SOME such parameter exists -- see the CLI test.
+_COMMIT_KW = next((k for k in ("commit", "evidence_commit")
+                   if k in inspect.signature(gate_diff_text).parameters), None)
+
+
+def gate(summary, diff, *, commit=None, **kw):
+    """gate_diff_text, with the commit passed under whichever name it has."""
+    if commit is not None:
+        assert _COMMIT_KW, "gate_diff_text has no commit-binding parameter"
+        kw[_COMMIT_KW] = commit
+    return gate_diff_text(summary, diff, **kw)
+
+
+# ============================================================== source helpers
+# Each answers a question about the SOURCE, not about the output, and each is
+# watched firing against a planted accusation below. A helper that has never
+# been seen to fire is as much a decoration as a test that has never been seen
+# to fail.
+
+def _docstring_ids(tree) -> set:
+    ids = set()
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.Module, ast.FunctionDef, ast.AsyncFunctionDef,
+                             ast.ClassDef)):
+            body = getattr(node, "body", None) or []
+            if (body and isinstance(body[0], ast.Expr)
+                    and isinstance(body[0].value, ast.Constant)
+                    and isinstance(body[0].value.value, str)):
+                ids.add(id(body[0].value))
+    return ids
+
+
+def _parents(tree) -> dict:
+    out = {}
+    for node in ast.walk(tree):
+        for child in ast.iter_child_nodes(node):
+            out[id(child)] = node
+    return out
+
+
+def _stmt_chain(node, parents) -> list:
+    """Every enclosing statement, innermost first. An accusation one level below
+    its guard -- ``if False and r.returncode: c.verdict = ...`` -- is findable
+    only by walking up, and that is precisely the shape an output-only test
+    cannot see."""
+    chain, cur = [], parents.get(id(node))
+    while cur is not None:
+        if isinstance(cur, ast.stmt):
+            chain.append(cur)
+        cur = parents.get(id(cur))
+    return chain
+
+
+def _guard_parts(stmt) -> list:
+    """The parts of a statement that GUARD its body, never the body itself.
+
+    Scoping this correctly is load-bearing and the first draft got it wrong.
+    `_gate` builds one long ``elif kind == ...`` chain, which in the AST nests
+    each arm inside the previous arm's ``orelse`` -- so asking "does any
+    enclosing statement mention `tests_pass`?" made every path-claim accusation
+    in the chain look like a `tests_pass` accusation, because the `tests_pass`
+    arm is inside the subtree of the arm above it. Six false positives against
+    the shipped module. The guard is the test, not the whole `if`."""
+    if isinstance(stmt, (ast.If, ast.While)):
+        return [stmt.test]
+    if isinstance(stmt, (ast.For, ast.AsyncFor)):
+        return [stmt.iter]
+    if isinstance(stmt, ast.With):
+        return list(stmt.items)
+    if isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef,
+                         ast.Try, ast.Module)):
+        return []
+    return [stmt]                      # a simple statement guards itself
+
+
+def _references(node, word: str) -> bool:
+    """Does this node name *word* -- as an attribute, a bare name, or a string
+    literal? Matched as a whole token, never as a substring, so the words this
+    file looks for do not accuse the prose that explains them."""
+    for n in ast.walk(node):
+        if isinstance(n, ast.Attribute) and n.attr == word:
+            return True
+        if isinstance(n, ast.Name) and n.id == word:
+            return True
+        if isinstance(n, ast.Constant) and isinstance(n.value, str) and n.value == word:
+            return True
+    return False
+
+
+def accusation_sites(source: str, word: str) -> list:
+    """Every place the accusing verdict is produced as CODE inside a region
+    guarded by *word*. Docstrings are excluded: the word necessarily appears in
+    the prose explaining its own absence, and a grep cannot tell mention from
+    use."""
+    tree = ast.parse(source)
+    doc, parents = _docstring_ids(tree), _parents(tree)
+    sites = []
+    for n in ast.walk(tree):
+        if not (isinstance(n, ast.Constant) and isinstance(n.value, str)):
+            continue
+        if ACCUSE not in n.value or id(n) in doc:
+            continue
+        for stmt in _stmt_chain(n, parents):
+            if any(_references(part, word) for part in _guard_parts(stmt)):
+                sites.append({"lineno": n.lineno, "excerpt": n.value[:70],
+                              "guard": word})
+                break
+    return sites
+
+
+def run_branch_accusation_sites(source: str) -> list:
+    return accusation_sites(source, "returncode")
+
+
+def accusation_sites_under_tests_pass(source: str) -> list:
+    return accusation_sites(source, "tests_pass")
+
+
+def observed_band_accusation_sites(source: str) -> list:
+    return accusation_sites(source, "observed")
+
+
+# ================================================================== fixtures
+# Byte-for-byte the shapes tests/test_evidence.py already pins, so a
+# disagreement between the two files is a real disagreement about the wiring and
+# not about what a green report looks like.
+
+HEAD_COMMIT = "9a04d1ee393b5be2773b1ce204f61fe0fd02366a"
+OTHER_COMMIT = "1111111111111111111111111111111111111111"
+
+GREEN = """<?xml version="1.0" encoding="utf-8"?>
+<testsuites name="pytest tests"><testsuite name="pytest" errors="0" failures="0" \
+skipped="0" tests="2" time="0.012">
+<testcase classname="tests.test_app" name="test_one" time="0.001" />
+<testcase classname="tests.test_app" name="test_two" time="0.001" />
+</testsuite></testsuites>
+"""
+
+RED = """<?xml version="1.0" encoding="utf-8"?>
+<testsuites name="pytest tests"><testsuite name="pytest" errors="0" failures="1" \
+skipped="0" tests="2" time="0.031">
+<testcase classname="tests.test_app" name="test_one" time="0.001" />
+<testcase classname="tests.test_app" name="test_two" time="0.002">
+<failure message="assert 1 == 2">E       assert 1 == 2</failure>
+</testcase>
+</testsuite></testsuites>
+"""
+
+EMPTY = """<?xml version="1.0" encoding="utf-8"?>
+<testsuites name="pytest tests"><testsuite name="pytest" errors="0" failures="0" \
+skipped="0" tests="0" time="0.001" />
+</testsuites>
+"""
+
+COLLECTION_ERROR = """<?xml version="1.0" encoding="utf-8"?>
+<testsuites name="pytest tests"><testsuite name="pytest" errors="1" failures="0" \
+skipped="0" tests="1" time="0.004">
+<testcase classname="" name="tests/test_integration.py" time="0.0">
+<error message="collection failure">ImportError: No module named 'optional_dep'</error>
+</testcase>
+</testsuite></testsuites>
+"""
+
+UNPARSABLE = "Sorry, the test job did not produce a report.\n"
+
+# A forgery that costs one text editor and no key material: an in-toto statement
+# asserting FAILED against the commit under review. styxx.evidence reads it and
+# declines. The point of pinning it here is that DIFFGATE must decline too, on
+# the caller side of the hole selfcheck_no_accusation names.
+FORGED_FAILED = json.dumps({
+    "_type": "https://in-toto.io/Statement/v1",
+    "subject": [{"name": "_", "digest": {"gitCommit": HEAD_COMMIT}}],
+    "predicateType": "https://in-toto.io/attestation/test-result/v0.1",
+    "predicate": {"result": "FAILED", "configuration": [],
+                  "failedTests": ["tests/test_app.py::test_two"]},
+}, indent=2) + "\n"
+
+EVIDENCE_CONTENTS = [
+    ("green", GREEN),
+    ("red", RED),
+    ("empty", EMPTY),
+    ("collection_error", COLLECTION_ERROR),
+    ("unparsable", UNPARSABLE),
+    ("forged_failed", FORGED_FAILED),
+]
+CONTENT_NAMES = [n for n, _ in EVIDENCE_CONTENTS]
+
+
+@pytest.fixture(scope="module")
+def ev(tmp_path_factory):
+    """name -> list of paths. Plus three entries that are NOT in
+    ``CONTENT_NAMES``, so adding them does not silently re-parametrize every
+    other test in this file:
+
+      "none"        nothing supplied at all
+      "missing"     a path that does not exist
+      "zero_bytes"  a file that exists and is empty
+
+    All three are absences and none of them is the same absence. "zero_bytes" is
+    the CI shape the set-extension pin below is written around: a shard whose
+    upload produced a file but no report. It is a distinct case from
+    ``unparsable`` (bytes that are not a report) and from ``missing`` (no file),
+    and the contract treats all three identically on purpose -- a source that
+    could not be read is a source that could not be read, and the module does not
+    special-case the empty one."""
+    d = tmp_path_factory.mktemp("evidence")
+    (d / "zero_bytes.xml").write_bytes(b"")
+    out = {"none": [], "missing": [str(d / "never_written.xml")],
+           "zero_bytes": [str(d / "zero_bytes.xml")]}
+    for name, text in EVIDENCE_CONTENTS:
+        p = d / f"{name}.xml"
+        p.write_bytes(text.encode("utf-8"))
+        out[name] = [str(p)]
+    return out
+
+
+TOUCHED = ("diff --git a/styxx/app.py b/styxx/app.py\n--- a/styxx/app.py\n"
+           "+++ b/styxx/app.py\n@@\n+def test_one(): pass\n")
+OUTSIDE = ("diff --git a/other/y.py b/other/y.py\n--- a/other/y.py\n"
+           "+++ b/other/y.py\n@@\n+y = 1\n")
+
+# Deliberately including rows whose baseline is already FAIL (a path lie, a
+# symbol lie, a count lie) and one whose baseline is UNMEASURED. Monotonicity
+# has to hold on the unhappy rows or it is a statement about the happy path
+# wearing the word "property".
+CASES = [
+    ("bare", "All tests pass.", TOUCHED),
+    ("with_a_true_path_claim", "Modified styxx/app.py. All tests pass.", TOUCHED),
+    ("with_a_path_lie", "This change only touches styxx/. All tests pass.", OUTSIDE),
+    ("with_a_symbol_lie", "Adds function nonexistent_helper. Tests pass.", TOUCHED),
+    ("with_a_count_lie", "3 files changed. All tests are passing.", TOUCHED),
+    ("many_claims", "Modified styxx/app.py, added 1 tests, adds function test_one. "
+                    "All tests pass.", TOUCHED),
+    ("repeated_claims", "All tests pass. All tests pass. All tests pass.", TOUCHED),
+    ("unreadable_diff", "All tests pass.", "Sorry, I could not produce a diff."),
+    ("no_tests_pass_claim", "Modified styxx/app.py.", TOUCHED),
+]
+
+
+def tp(g):
+    return [c for c in g.claims if c.kind == "tests_pass"]
+
+
+# ==================================================================== probes
+# Every marker's condition is a probe of the CURRENTLY LOADED module, so the
+# marker disarms itself when the defect it names is repaired, and strict=True
+# makes an unexplained pass a failure. All four probes are behavioural; the
+# run-branch probe falls back to a coarse source read only if the call raised,
+# and that overlap with the assertion it guards is disclosed rather than hidden.
+
+
+class _Stub:
+    """Stands in for subprocess.run so that no shell is ever spawned by this
+    file. `--run` passes shell=True with cwd set to the tree under test, and
+    executing that from a test suite is the code-execution path the module's own
+    CLI help now warns about at diffgate.py:936. This file reads it, never runs
+    it."""
+
+    def __init__(self, returncode=7, raises=None):
+        self.returncode, self.raises, self.calls = returncode, raises, 0
+
+    def __call__(self, *a, **kw):
+        self.calls += 1
+        if self.raises is not None:
+            raise self.raises
+        return types.SimpleNamespace(returncode=self.returncode, stdout="", stderr="")
+
+
+def _with_stub(stub, fn):
+    """Synchronous, always restored. Probes run at import where monkeypatch does
+    not exist yet, so the same helper serves both."""
+    real = D.subprocess.run
+    D.subprocess.run = stub
+    try:
+        return fn()
+    finally:
+        D.subprocess.run = real
+
+
+def _run_gate(rc=0, raises=None, summary="All tests pass.", **kw):
+    stub = _Stub(returncode=rc, raises=raises)
+    g = _with_stub(stub, lambda: gate_diff_text(summary, TOUCHED, run="pytest -q",
+                                                repo=".", **kw))
+    return g, stub
+
+
+def _probe_run_branch_accuses() -> bool:
+    try:
+        g, _ = _run_gate(rc=7)
+        return any(c.verdict == ACCUSE for c in tp(g))
+    except Exception:
+        return bool(run_branch_accusation_sites(inspect.getsource(D)))
+
+
+def _probe_run_executes_more_than_once() -> bool:
+    try:
+        _, stub = _run_gate(rc=0, summary="All tests pass.\nAll tests pass.\n"
+                                          "All tests pass.")
+    except Exception:
+        return True
+    return stub.calls > 1
+
+
+def _probe_timeout_escapes() -> bool:
+    try:
+        _run_gate(raises=subprocess.TimeoutExpired(cmd="pytest -q", timeout=1))
+    except Exception:
+        return True
+    return False
+
+
+def _probe_tests_pass_exempt_from_no_evidence() -> bool:
+    """The exemption at the old diffgate.py:357 (`no_evidence and kind !=
+    "tests_pass"`) let a claim escape the branch that says the gate had nothing
+    to read."""
+    try:
+        g = gate_diff_text("All tests pass.", "Sorry, I could not produce a diff.")
+        return any("carries no file statuses" not in c.why for c in tp(g))
+    except Exception:
+        return True
+
+
+EVIDENCE_WIRED = "evidence" in inspect.signature(gate_diff_text).parameters
+RUN_BRANCH_ACCUSES = _probe_run_branch_accuses()
+RUN_EXECUTES_PER_MATCH = _probe_run_executes_more_than_once()
+TIMEOUT_ESCAPES = _probe_timeout_escapes()
+TESTS_PASS_EXEMPT = _probe_tests_pass_exempt_from_no_evidence()
+
+owed_wiring = pytest.mark.xfail(not EVIDENCE_WIRED, strict=True, reason=(
+    "OWED: gate_diff_text takes no `evidence` parameter. Self-arming strict "
+    "xfail -- it disarms when the parameter appears, and an unexplained pass "
+    "before then is a FAILURE, not a quiet XPASS."))
+owed_run = pytest.mark.xfail(RUN_BRANCH_ACCUSES, strict=True, reason=(
+    "OWED: the DECISION of 2026-09-01 deletes the accusing half of the --run "
+    "branch. A nonzero exit still resolves to an accusation."))
+
+
+# ==============================================================================
+# THE TRIPWIRE -- the one thing the self-arming markers cannot do for themselves
+# ==============================================================================
+#
+# Every marker above is a LATCH: it arms on the defect it guards and disarms once
+# that defect is repaired. A latch cannot tell "not fixed yet" from "fixed, then
+# REGRESSED" -- both present as the defect being live, and in both cases the
+# marker absorbs its own tests into xfail and pytest exits 0.
+#
+# Demonstrated on 2026-09-01 by adversarial review: reintroducing the
+# TimeoutExpired defect this file was written to guard produced
+# "277 passed, 2 xfailed", exit 0, three runs running -- the regression rendered
+# as an OWED note. The four latches also explain the flip seen the same morning,
+# 230 xfailed -> 279 passed (owed_wiring 220 + owed_run 8 + per-match 1 +
+# timeout 1), when a concurrent rewrite disarmed all four at once.
+#
+# The module docstring's promise -- "there is no configuration under which a test
+# in this file is silently green" -- is only TRUE with this test present. Each
+# probe's repaired value is pinned below as a constant, so re-arming any latch
+# now reds the suite instead of quietly widening it.
+#
+# When a new owed defect is added, add its probe here with the value it is
+# expected to hold ONCE REPAIRED. That is what carries the repair forward.
+
+_PINNED_PROBES = {
+    "EVIDENCE_WIRED": True,
+    "RUN_BRANCH_ACCUSES": False,
+    "RUN_EXECUTES_PER_MATCH": False,
+    "TIMEOUT_ESCAPES": False,
+    "TESTS_PASS_EXEMPT": False,
+}
+
+
+def test_no_self_arming_marker_has_re_armed():
+    """A latch that re-arms is a REGRESSION, not an outstanding debt.
+
+    This is the only test in the file that fails when a REPAIRED defect comes
+    back. Every other guard on those four defects is behind a marker that arms
+    on exactly the condition it is meant to report.
+    """
+    observed = {name: globals()[name] for name in _PINNED_PROBES}
+    regressed = {n: v for n, v in observed.items() if v is not _PINNED_PROBES[n]}
+    assert not regressed, (
+        "a self-arming xfail marker has RE-ARMED, which means a repair that had "
+        "already landed has regressed. The markers cannot report this themselves "
+        "-- they absorb it into xfail and exit 0. Expected "
+        f"{ {n: _PINNED_PROBES[n] for n in regressed} }, observed {regressed}.")
+
+
+# ====================================== LIVE: the helpers are watched biting
+
+def _snippet(text: str) -> str:
+    return text.replace("@A@", ACCUSE)
+
+
+_MUTANT_REACHED = _snippet('''
+def _gate(run=None):
+    if run:
+        r = subprocess.run(run, shell=True)
+        c.verdict = "VERIFIED" if r.returncode == 0 else "@A@"
+''')
+
+_MUTANT_UNREACHED = _snippet('''
+def _gate(run=None):
+    """A branch nobody reaches today is a branch someone reaches after a
+    refactor. No output-level test can see this one."""
+    if run:
+        r = subprocess.run(run, shell=True)
+        if False and r.returncode != 0:
+            c.verdict = "@A@"
+        else:
+            c.verdict = "UNCHECKABLE"
+''')
+
+_MUTANT_FLAGGED = _snippet('''
+WITHHOLD_TESTS_PASS_ACCUSATION = True
+
+def _gate(run=None):
+    if run:
+        r = subprocess.run(run, shell=True)
+        if r.returncode != 0 and not WITHHOLD_TESTS_PASS_ACCUSATION:
+            c.verdict = "@A@"
+''')
+
+_MUTANT_OBSERVED = _snippet('''
+def _evidence_leg(ev):
+    observed = ev.get("observed") or {}
+    if observed.get("failing"):
+        return "@A@", "the attested report reads red"
+    return "UNCHECKABLE", "no"
+''')
+
+_MUTANT_KIND_SCOPED = _snippet('''
+def _gate():
+    for kind, rx in TEMPLATES:
+        if kind == "tests_pass":
+            if evidence_says_red:
+                c.verdict = "@A@"
+''')
+
+# Here the word appears only as prose about its own absence. A helper that fires
+# on this is a grep with extra steps, and would refuse the very paragraphs this
+# codebase writes to explain a deletion.
+_INNOCENT = _snippet('''
+def _run_leg(run, repo):
+    """The accusing verdict @A@ is DELETED here, not gated.
+
+    A nonzero returncode is not evidence that the author lied: it is also what
+    "no tests collected", a missing dependency and a flaky test produce.
+    """
+    r = subprocess.run(run, shell=True, cwd=repo)          # @A@ deleted
+    return ("VERIFIED", "exited 0") if r.returncode == 0 else ("UNCHECKABLE", "x")
+''')
+
+# The elif-chain shape that produced six false positives in the first draft of
+# `_guard_parts`. A path-claim accusation lives in an arm ABOVE the tests_pass
+# arm, and in the AST the tests_pass arm sits inside its `orelse` -- so a helper
+# that inspects whole enclosing statements rather than their guards reports it
+# as a tests_pass accusation. It is not one.
+_ELIF_CHAIN = _snippet('''
+def _gate():
+    for kind in kinds:
+        if kind == "only_touches":
+            c.verdict = "VERIFIED" if not outside else "@A@"
+        elif kind == "tests_pass":
+            c.verdict = tests_pass_leg()
+''')
+
+
+@pytest.mark.parametrize("label,src,helper", [
+    ("reached", _MUTANT_REACHED, run_branch_accusation_sites),
+    ("unreached-guard", _MUTANT_UNREACHED, run_branch_accusation_sites),
+    ("withheld-behind-a-flag", _MUTANT_FLAGGED, run_branch_accusation_sites),
+    ("report-only-band", _MUTANT_OBSERVED, observed_band_accusation_sites),
+    ("kind-scoped", _MUTANT_KIND_SCOPED, accusation_sites_under_tests_pass),
+])
+def test_the_source_helpers_detect_what_they_claim_to_detect(label, src, helper):
+    """Every structural assertion in this file is worth exactly what these
+    helpers are worth, so each is watched firing against a planted accusation
+    before it is trusted to report an absence.
+
+    Three of the five are shapes no output-level test can see: a branch behind
+    ``if False``, a branch behind a flag set to off, and an accusation invented
+    by a caller out of the report-only band. WITHHOLD_PATH_ACCUSATION is the
+    flag shape already in this repository, and PREREG_evidence_leg indicts it by
+    name -- flags get flipped by people who did not read the paper."""
+    assert helper(src), f"the {label} mutant went undetected"
+
+
+def test_the_helpers_do_not_fire_on_prose_explaining_the_absence():
+    """Mention is not use. ANALYSIS_base_rate_ceiling records this lab's own
+    certificate failing on exactly this distinction, and a checker that repeats
+    it would forbid the paragraphs that explain a deletion."""
+    assert run_branch_accusation_sites(_INNOCENT) == []
+    assert accusation_sites_under_tests_pass(_INNOCENT) == []
+    assert observed_band_accusation_sites(_INNOCENT) == []
+
+
+def test_the_kind_scoped_helper_does_not_blame_a_neighbouring_elif_arm():
+    """The false positive that the first draft of this file shipped, pinned so
+    it cannot come back. In the AST an ``elif`` arm nests inside the previous
+    arm's ``orelse``, so `tests_pass` is inside the SUBTREE of the
+    `only_touches` arm -- and a helper that reads whole enclosing statements
+    instead of their guards reports the path-claim accusation as a `tests_pass`
+    accusation. Six such reports against the shipped module."""
+    assert accusation_sites_under_tests_pass(_ELIF_CHAIN) == []
+    assert run_branch_accusation_sites(_ELIF_CHAIN) == []
+
+
+# ============================ LIVE: the caller-side hole styxx.evidence names
+
+def test_no_diffgate_path_maps_the_report_only_band_to_an_accusation():
+    """``styxx.evidence.selfcheck_no_accusation`` states its own boundary: it
+    "does not prove a caller has not invented an accusation of its own out of
+    the report-only `observed` band". diffgate is that caller, and this is the
+    caller-side counterpart -- the tripwire PREREG_evidence_leg's G-E6 was meant
+    to be, relocated to the file where such a branch would actually live."""
+    sites = observed_band_accusation_sites(inspect.getsource(D))
+    assert sites == [], f"diffgate turns the report-only band into a verdict: {sites}"
+
+
+def test_the_evidence_module_still_refuses_to_accuse():
+    """The cheapest way to wire this leg wrongly is to give styxx.evidence its
+    accusing verdict back and leave diffgate innocent. Its self-check is
+    re-derived here so this file fails if that happens."""
+    assert tuple(E.VERDICTS) == ("VERIFIED", "UNCHECKABLE"), E.VERDICTS
+    sc = E.selfcheck_no_accusation()
+    assert sc["ok"] is True, sc
+    assert sc["code_occurrences"] == []
+
+
+def test_diffgates_own_selfcheck_agrees_with_this_files_independent_read():
+    """SECONDARY, and deliberately not the primary. A module grading itself is
+    not evidence; the AST helpers above are this file's own instrument and the
+    assertions that matter run through them. What this adds is a disagreement
+    alarm: if the two readers ever diverge, one of them is wrong and both are
+    worth looking at."""
+    sc = D.selfcheck_tests_pass_never_accuses()
+    assert sc["ok"] is True, sc
+    assert sc["code_occurrences"] == [] and sc["band_reads"] == []
+    assert sc["missing"] == [], (
+        "the self-check names functions that no longer exist, so it is scanning "
+        f"nothing: {sc['missing']}")
+    assert tuple(D._TESTS_PASS_VERDICTS) == ("VERIFIED", "UNCHECKABLE")
+
+
+# ============================ LIVE: the baseline the property is measured against
+
+@pytest.mark.parametrize("label,summary,diff", CASES)
+@pytest.mark.parametrize("strict", [False, True])
+def test_without_evidence_tests_pass_is_uncheckable_and_says_why(label, summary,
+                                                                 diff, strict):
+    """With no report and no --run there is no execution evidence, and
+    UNCHECKABLE is the honest answer -- ANALYSIS_base_rate_ceiling section 10
+    counts 5,514 claims parked exactly there corpus-wide with an accusation
+    count of zero. This is the EMPTY-SET BASELINE that the guarantee below is
+    measured against -- the only baseline it is measured against; if it drifts,
+    that test is comparing against something else."""
+    g = gate_diff_text(summary, diff, strict=strict)
+    for c in tp(g):
+        assert c.verdict == "UNCHECKABLE", f"{label}: {c.verdict} -- {c.why}"
+        assert c.why, "an UNCHECKABLE verdict must say why"
+
+
+@pytest.mark.parametrize("label,summary,diff", CASES)
+def test_the_gate_never_takes_the_agents_word_for_a_test_result(label, summary, diff):
+    """The inverse failure of the accusation, and the one this module exists
+    against: believing "all tests pass" because it was written down."""
+    g = gate_diff_text(summary, diff)
+    for c in tp(g):
+        assert c.verdict != "VERIFIED", (
+            f"{label}: the gate certified a test result from prose alone")
+
+
+@pytest.mark.parametrize("label,summary,diff", CASES)
+def test_the_tests_pass_vocabulary_is_a_subset_of_evidence_VERDICTS(label, summary,
+                                                                    diff):
+    """Whatever diffgate says about a `tests_pass` claim must be a word
+    styxx.evidence would say. Two words. A wiring that invents a third has
+    invented an accusation under another name."""
+    g = gate_diff_text(summary, diff)
+    for c in tp(g):
+        assert c.verdict in set(E.VERDICTS), c.verdict
+
+
+def test_the_retired_why_string_is_gone():
+    """PREREG_evidence_leg committed to replacing "no --run command supplied",
+    which implied the remedy was to supply a shell string -- the one thing this
+    gate must not encourage against a branch you did not write. Strictly more
+    informative at an identical verdict, which is why it shipped ahead of any
+    measurement."""
+    g = gate_diff_text("All tests pass.", TOUCHED)
+    for c in tp(g):
+        assert "no --run command supplied" not in c.why
+        assert "--evidence" in c.why, (
+            "the reader has to be told which channel can answer this")
+
+
+# ================================================ LIVE/OWED: the --run branch
+
+@owed_run
+def test_the_run_branch_cannot_reach_an_accusation_in_the_source():
+    """THE structural one. DECISION of 2026-09-01: the accusing half of the
+    --run branch is DELETED, not withheld behind a flag, because
+    WITHHOLD_PATH_ACCUSATION is the counter-example this codebase already
+    carries and PREREG_evidence_leg indicts by name. Absence of a branch cannot
+    be toggled by someone in a hurry.
+
+    Asserted over the SOURCE. The behavioural companion below would pass on a
+    module carrying the branch behind ``if False`` or behind a flag set to off,
+    and both of those mutants are watched being caught above rather than here."""
+    sites = run_branch_accusation_sites(inspect.getsource(D))
+    assert sites == [], (
+        "the accusing verdict is reachable from a returncode comparison: "
+        f"{sites}. Its precision has never been measured by a blind panel on "
+        "either leg -- not extraction, not adjudication.")
+
+
+@owed_run
+def test_no_accusation_is_produced_anywhere_under_a_tests_pass_guard():
+    """Wider than the returncode form: any accusation produced under a
+    `tests_pass` guard, whatever supplies it."""
+    sites = accusation_sites_under_tests_pass(inspect.getsource(D))
+    assert sites == [], sites
+
+
+@owed_run
+@pytest.mark.parametrize("rc", [1, 4, 5, 127])
+def test_a_failing_run_command_does_not_accuse(rc):
+    """The behavioural companion, kept and explicitly INSUFFICIENT ALONE, and
+    the mutant sweep measured exactly how insufficient.
+
+    Restoring the accusing verdict inside `_run_leg` -- reached (M1), unreached
+    (M2), or behind a flag set to off (M3) -- changes no output at all, because
+    `_tests_pass_verdict` folds the leg's answer with a promote-to-VERIFIED-only
+    rule and the `_TESTS_PASS_VERDICTS` clamp rewrites anything else. Removing
+    the accusing branch AND the fold still changes nothing (M16). Only M17,
+    which removes all three layers, makes this test go red. So against today's
+    module it is unfalsifiable by any single-edit mutant: it is a regression
+    guard for the refactor that flattens those layers, not evidence of anything
+    now. The structural test above is the one that bites, on all five.
+
+    The exit codes are chosen, not arbitrary: pytest rc=5 is "no tests
+    collected", rc=4 a usage error, 127 a misspelled command. Each was read as a
+    lie by the shipped code, which is the whole argument -- a nonzero exit is a
+    fact about a process, and on an untrusted branch it is a process the author
+    controls in both directions from their own conftest.py."""
+    g, _ = _run_gate(rc=rc)
+    for c in tp(g):
+        assert c.verdict != ACCUSE, f"rc={rc} produced an accusation: {c.why}"
+    assert g.verdict == "PASS", f"rc={rc} failed the build on an unmeasured verdict"
+
+
+@owed_run
+def test_the_why_for_a_nonzero_exit_names_what_else_produces_one():
+    """A verdict that declines has to say why in terms a reader can act on. The
+    DECISION pins the sentence: a nonzero exit is also what "no tests
+    collected", a misspelled command, a missing dependency and a flaky test
+    produce."""
+    g, _ = _run_gate(rc=5)
+    whys = [c.why.lower() for c in tp(g)]
+    assert whys
+    for why in whys:
+        assert "exited 5" in why, "the exit code belongs in the record"
+        assert any(k in why for k in ("no tests collected", "misspelled",
+                                      "missing dependency", "flaky")), why
+
+
+@owed_run
+def test_a_run_that_exits_zero_verifies_but_may_not_claim_the_tests_passed():
+    """VERIFIED survives on evidence.py's stated asymmetry -- a wrong VERIFIED
+    repeats a claim the author already made in prose, a wrong accusation attacks
+    a stranger inside their own pull request. The disclosed defect rides with
+    it: the same extraction that fires on "Not all tests pass." would stamp
+    VERIFIED on a sentence asserting the opposite, so the why-string is required
+    to disclaim rather than to be trusted."""
+    g, _ = _run_gate(rc=0)
+    claims = tp(g)
+    assert claims
+    for c in claims:
+        assert c.verdict == "VERIFIED"
+        assert "exited 0" in c.why
+        low = c.why.lower()
+        # A disjunction over phrasings rather than one pinned sentence: what is
+        # load-bearing is that the record disclaims, not which words it uses.
+        assert any(k in low for k in ("does not mean the tests passed",
+                                      "not a statement about the suite",
+                                      "checks nothing about the sentence")), c.why
+        assert any(k in low for k in ("checkbox", "negation", "quotation")), (
+            "the disclosed extraction defect has to ride with the verdict: this "
+            "template fires on unchecked PR-template boxes and on negations, so "
+            "a VERIFIED can attach to a sentence asserting the opposite")
+
+
+@pytest.mark.xfail(RUN_EXECUTES_PER_MATCH, strict=True, reason=(
+    "OWED: the command runs once per REGEX MATCH rather than once per gate. A "
+    "body repeating the sentence is unbounded, author-controlled runner-hour "
+    "amplification -- each launch carrying its own 1800s budget."))
+def test_the_run_command_executes_at_most_once_per_gate():
+    _, stub = _run_gate(rc=0, summary="All tests pass.\nAll tests pass.\n"
+                                      "All tests pass.")
+    assert stub.calls <= 1, f"{stub.calls} executions for one gate invocation"
+
+
+@pytest.mark.xfail(TIMEOUT_ESCAPES, strict=True, reason=(
+    "OWED: subprocess.TimeoutExpired propagates uncaught out of _gate. A "
+    "traceback is not a verdict."))
+def test_a_run_timeout_is_uncheckable_not_a_traceback():
+    g, _ = _run_gate(raises=subprocess.TimeoutExpired(cmd="pytest -q", timeout=1800))
+    claims = tp(g)
+    assert claims
+    for c in claims:
+        assert c.verdict == "UNCHECKABLE"
+        assert c.why
+
+
+def test_run_with_no_repo_refuses_rather_than_running_in_the_verifiers_own_tree():
+    """The quiet defect on the zero-receipt path: gate_diff_text takes repo=None
+    by default and subprocess.run(cwd=None) executes wherever the verifier
+    happens to be standing. The one entry point built for having no checkout was
+    the one where cwd silently became the operator's own tree."""
+    stub = _Stub(returncode=0)
+    g = _with_stub(stub, lambda: gate_diff_text("All tests pass.", TOUCHED,
+                                                run="pytest -q"))
+    assert stub.calls == 0, "the command was executed with no repository to run it in"
+    for c in tp(g):
+        assert c.verdict == "UNCHECKABLE"
+        assert "verifier" in c.why.lower() or "cwd" in c.why.lower()
+
+
+@pytest.mark.xfail(TESTS_PASS_EXEMPT, strict=True, reason=(
+    "OWED: the `and kind != \"tests_pass\"` exemption lets a tests_pass claim "
+    "escape the branch that says the gate had nothing to read."))
+def test_a_diff_that_parsed_to_nothing_leaves_every_claim_unread():
+    """DECISION repair 1. With input that parsed to nothing the gate reports
+    measured=False, and no claim -- `tests_pass` included -- may be resolved
+    against evidence the gate does not have.
+
+    A tension worth recording rather than hiding: a test report is arguably
+    independent of whether the DIFF was readable, so it is defensible for
+    --evidence to answer here. The shipped module says no, the DECISION's
+    repair 1 says no, and this pins the shipped reading. Whoever changes it
+    should change this test deliberately."""
+    g = gate_diff_text("All tests pass.", "Sorry, I could not produce a diff.")
+    assert g.measured is False
+    for c in g.claims:
+        assert c.verdict == "UNCHECKABLE"
+        assert g.why_unmeasured in c.why or "carries no file" in c.why
+
+
+# ============================================= LIVE/OWED: the evidence wiring
+
+@owed_wiring
+def test_a_supporting_report_moves_tests_pass_off_uncheckable(ev):
+    g = gate_diff_text("Modified styxx/app.py. All tests pass.", TOUCHED,
+                       evidence=ev["green"])
+    claims = tp(g)
+    assert claims, "the claim must still be extracted"
+    for c in claims:
+        assert c.verdict == "VERIFIED", f"{c.verdict} -- {c.why}"
+    assert g.verdict == "PASS"
+
+
+@owed_wiring
+@pytest.mark.parametrize("name", CONTENT_NAMES + ["missing"])
+def test_the_verdict_is_the_adjudicators_verdict_not_a_second_opinion(ev, name):
+    """The gate may not re-derive an answer styxx.evidence already gave. Same
+    bytes, same verdict -- otherwise there are two adjudicators and only one of
+    them has a docstring saying what VERIFIED does not mean."""
+    want, _ = adjudicate_tests_pass(load_evidence(ev[name]), None)
+    g = gate_diff_text("All tests pass.", TOUCHED, evidence=ev[name])
+    claims = tp(g)
+    assert claims
+    for c in claims:
+        assert c.verdict == want, f"{name}: gate {c.verdict}, evidence {want}"
+
+
+@owed_wiring
+@pytest.mark.parametrize("name", CONTENT_NAMES + ["missing"])
+def test_the_adjudicators_reason_is_preserved_verbatim(ev, name):
+    """A paraphrase is a second opinion wearing the first one's clothes. The
+    reason the reader acts on has to be the one styxx.evidence wrote -- the
+    string that says an all-skipped suite is not a green run, or that a partial
+    read is a guess with a citation. diffgate may add context around it; it may
+    not restate it."""
+    _, want_why = adjudicate_tests_pass(load_evidence(ev[name]), None)
+    g = gate_diff_text("All tests pass.", TOUCHED, evidence=ev[name])
+    for c in tp(g):
+        assert want_why in c.why, (
+            f"{name}: the adjudicator's reason was paraphrased away:\n"
+            f"  gate:     {c.why}\n  evidence: {want_why}")
+
+
+@owed_wiring
+def test_a_supporting_report_is_not_read_as_the_tests_passed(ev):
+    """VERIFIED means an attestation reports PASSED and no signature was
+    checked. It does not mean the tests passed, and it says nothing about
+    whether the sentence extracted was a claim at all -- 179 corpus-wide
+    `tests_pass` extractions sit inside an UNCHECKED PR-template box where the
+    author is explicitly declining to assert."""
+    g = gate_diff_text("All tests pass.", TOUCHED, evidence=ev["green"])
+    for c in tp(g):
+        low = c.why.lower()
+        assert "no signature was checked" in low or "not mean the tests passed" in low, \
+            c.why
+
+
+@owed_wiring
+def test_no_report_supplied_leaves_it_uncheckable_and_names_the_channels(ev):
+    """"--evidence with no report" has two readings and they are different
+    absences. Nothing supplied at all is answered by the gate's own named
+    reason; a path that does not exist is answered by the adjudicator, and that
+    case is covered by the reason-preserved test above."""
+    g = gate_diff_text("All tests pass.", TOUCHED, evidence=ev["none"])
+    claims = tp(g)
+    assert claims
+    for c in claims:
+        assert c.verdict == "UNCHECKABLE"
+        assert c.why, "an UNCHECKABLE verdict must say why"
+        assert "no --run command supplied" not in c.why
+        assert "--evidence" in c.why
+        assert "no accusing verdict" in c.why.lower(), (
+            "the absence of the third word is part of the answer, not trivia")
+
+
+@owed_wiring
+@pytest.mark.parametrize("name", CONTENT_NAMES + ["none", "missing"])
+@pytest.mark.parametrize("strict", [False, True])
+@pytest.mark.parametrize("commit", [None, HEAD_COMMIT, OTHER_COMMIT])
+def test_no_evidence_content_can_produce_an_accusation(ev, name, strict, commit):
+    """By any route, for any content, at any commit, strict and not.
+
+    `red`, `collection_error` and `forged_failed` are the readings where the
+    evidence looks unambiguously bad, and `forged_failed` is an accusation
+    against a named commit that costs one hand-written JSON file and no key
+    material. None may become a verdict against the author. There is no
+    sub-population of evidence contents on which this relaxes."""
+    g = gate("Modified styxx/app.py. All tests pass.", TOUCHED,
+             evidence=ev[name], commit=commit, strict=strict)
+    for c in tp(g):
+        assert c.verdict != ACCUSE, f"{name}/{commit}: {c.why}"
+        assert c.verdict in set(E.VERDICTS), c.verdict
+
+
+@owed_wiring
+@pytest.mark.parametrize("label,summary,diff", CASES)
+@pytest.mark.parametrize("name", CONTENT_NAMES + ["missing"])
+@pytest.mark.parametrize("strict", [False, True])
+def test_adding_evidence_never_worsens_the_gate_against_no_evidence(
+        ev, label, summary, diff, name, strict):
+    """THE LOAD-BEARING ONE, AND IT IS THE WEAKER OF THE TWO READINGS.
+
+    RENAMED AND RESCOPED on 2026-09-01. This test shipped as
+    ``test_adding_evidence_never_worsens_the_gate_verdict``, and under that name
+    it was read as establishing that evidence never worsens a verdict FULL STOP.
+    It never measured that and it never could: the only baseline it compares
+    against is the EMPTY evidence set. The body is unchanged and correct. The
+    name and the docstring were the defect, and they are corrected here rather
+    than deleted, because the record of what a green test was taken to mean is
+    part of what the test is for.
+
+    WHAT IS ASSERTED. Over every claim combination, every evidence content and
+    both strictness settings: the gate handed evidence ranks no worse than the
+    same gate handed NONE -- at the overall verdict, and at every single claim.
+    Evidence may move a `tests_pass` claim UPWARD, from UNCHECKABLE to VERIFIED.
+    Relative to supplying nothing it may never move a claim downward, and it may
+    never turn a would-have-been PASS into a FAIL.
+
+    WHAT IS NOT ASSERTED, and is FALSE:
+    ``E -> E union {x}`` never worsens. It can and it does, deliberately, and
+    ``test_extending_an_evidence_set_can_demote_verified_and_must`` pins that so
+    the two are never again read off one report line.
+
+    This is what makes the leg safe to ship before Panel A exists: an adjudicator
+    that can only resolve upward FROM THE NO-EVIDENCE BASELINE cannot manufacture
+    an accusation however wrong the extraction feeding it is -- and that
+    extraction carries a mechanical non-assertion indicator on 6.27% of matches,
+    with the other 83% unmeasured. Whether such a match is a WRONG extraction is
+    Panel A's question, not the census's, and Panel A has not been run.
+
+    `_gate` argues this invariant in a comment. A comment is not a receipt."""
+    base = gate_diff_text(summary, diff, strict=strict)
+    with_ev = gate_diff_text(summary, diff, evidence=ev[name], strict=strict)
+
+    assert GATE_RANK[with_ev.verdict] <= GATE_RANK[base.verdict], (
+        f"{label}+{name}+strict={strict}: {base.verdict} -> {with_ev.verdict}")
+    assert [c.kind for c in with_ev.claims] == [c.kind for c in base.claims], (
+        "evidence added or removed claims; it is an adjudicator, not an extractor")
+    for a, b in zip(base.claims, with_ev.claims):
+        assert CLAIM_RANK[b.verdict] <= CLAIM_RANK[a.verdict], (
+            f"{label}+{name}: {a.kind} {a.verdict} -> {b.verdict} ({b.why})")
+    assert with_ev.measured == base.measured, (
+        "evidence about tests cannot make a diff readable or unreadable")
+
+
+# The grid for the pin below. Each row is an addition to an already-VERIFIED
+# evidence set, paired with the mechanism by which the contract refuses to keep
+# affirming once it is present. `demotes=False` rows are NEGATIVE CONTROLS and
+# are as load-bearing as the rest: a rule that demoted on any addition at all
+# would be counting files rather than reading them, and would be indistinguishable
+# from the real rule on a grid made only of demoting rows.
+SET_EXTENSIONS = [
+    # name,             demotes, mechanism
+    ("zero_bytes",      True,  "a file that exists and holds no report"),
+    ("missing",         True,  "a shard whose upload never arrived"),
+    ("unparsable",      True,  "bytes that are neither XML nor JSON"),
+    ("red",             True,  "a second source that disagrees (FAILED, PASSED)"),
+    ("forged_failed",   True,  "a hand-written FAILED attestation, no key material"),
+    ("collection_error", True, "a harness error: the runner broke, nothing lied"),
+    ("empty",           False, "a well-formed zero-test report: parses, adds nothing"),
+]
+
+
+@owed_wiring
+@pytest.mark.parametrize("name,demotes,mechanism", SET_EXTENSIONS)
+@pytest.mark.parametrize("strict", [False, True])
+def test_extending_an_evidence_set_can_demote_verified_and_must(
+        ev, name, demotes, mechanism, strict):
+    """THE PIN. THIS TEST GOING RED MEANS THE SAFETY RULE WAS WEAKENED.
+
+    Read this before you "fix" anything it reports.
+
+    Adding evidence to an evidence set that already resolved VERIFIED can move
+    that claim back to UNCHECKABLE, and under --strict can move the gate from
+    PASS to FAIL. That is NOT a monotonicity bug. It is the contract's central
+    rule, and this test exists so that the rule cannot be quietly removed by
+    someone who read the sibling test's name -- "never worsens" -- as a promise
+    that this could not happen.
+
+    THE RULE: a partial read may honestly DECLINE, but it may not honestly
+    AFFIRM. VERIFIED on a `tests_pass` claim asserts that the evidence in hand
+    says every test passed. If one of the supplied sources could not be read,
+    the evidence in hand is a subset of the evidence that was offered, and no
+    subset licenses a statement about the whole. You cannot certify "all tests
+    pass" from nine shards out of ten, and the tenth shard is exactly where a
+    real CI failure hides -- an upload that timed out, a runner that OOMed, a
+    matrix leg that never started. Affirming from an incomplete evidence set is
+    the single failure this module was built to refuse. The same reasoning
+    covers the sources that DID parse and disagree: refusing beats picking, and
+    refusing beats taking the union.
+
+    HOW SOMEONE BREAKS THIS. Not maliciously -- by seeing a green run demoted to
+    UNCHECKABLE by one junk file, calling it a regression, and making the
+    adjudicator skip sources it cannot read, or treat an empty file as "no
+    evidence supplied", or take the best available reading. Each of those turns
+    "I read everything and it all passed" into "I read what I could and what I
+    could read passed", which is a different sentence with the same word on it.
+    If this test is red, that is what changed. The repair is to revert it. If
+    you believe the rule itself is wrong, that is a preregistration and a panel,
+    not a patch.
+
+    WHAT IS MEASURED, because a pin that asserts nothing pins nothing: the
+    baseline `[green]` is confirmed VERIFIED and PASS first -- otherwise a module
+    that had stopped affirming altogether would pass this test trivially -- and
+    then each addition is checked against the direction recorded in
+    ``SET_EXTENSIONS``. 12 of the 14 (addition x strictness) cells demote; the 2
+    that do not are the well-formed zero-test report, which parses and adds
+    nothing, and it is in the grid to show the rule reads sources rather than
+    counting them."""
+    base = gate_diff_text("All tests pass.", TOUCHED, evidence=ev["green"],
+                          strict=strict)
+    base_claims = tp(base)
+    assert base_claims, "no tests_pass claim was extracted; the grid measures nothing"
+    assert all(c.verdict == "VERIFIED" for c in base_claims), (
+        "the baseline of this test is a green report resolving VERIFIED. It did "
+        f"not: {[(c.verdict, c.why) for c in base_claims]}. Until that is true "
+        "again this test cannot say anything about set extension.")
+    assert base.verdict == "PASS", base.verdict
+
+    ext = gate_diff_text("All tests pass.", TOUCHED,
+                         evidence=ev["green"] + ev[name], strict=strict)
+    ext_claims = tp(ext)
+    assert [c.kind for c in ext.claims] == [c.kind for c in base.claims], (
+        "extending the evidence set added or removed claims; the adjudicator "
+        "reached the extractor")
+
+    for c in ext_claims:
+        assert c.verdict != ACCUSE, (
+            f"{name}: extending the evidence set produced an accusation. The "
+            "demotion this test pins is VERIFIED -> UNCHECKABLE and stops "
+            f"there. {c.why}")
+
+    if demotes:
+        assert all(c.verdict == "UNCHECKABLE" for c in ext_claims), (
+            f"SAFETY RULE WEAKENED. Adding {name} ({mechanism}) to a green "
+            "evidence set left the `tests_pass` claim at "
+            f"{[c.verdict for c in ext_claims]}, so the gate is now certifying "
+            "'all tests pass' from an evidence set it did not fully read. A "
+            "partial read may DECLINE; it may not AFFIRM. This is not a "
+            "monotonicity bug to be fixed -- see this test's docstring. If the "
+            "adjudicator was changed to skip unreadable sources, or to special-"
+            "case empty files, or to take the best available reading, revert it.")
+        if strict:
+            assert ext.verdict == "FAIL", (
+                f"SAFETY RULE WEAKENED. Under --strict, {name} ({mechanism}) "
+                "demoted the claim but the gate still reported "
+                f"{ext.verdict}. A --strict gate that passes on an UNCHECKABLE "
+                "`tests_pass` claim has made strictness decorative.")
+        assert any(c.why != b.why for c, b in zip(ext_claims, base_claims)), (
+            "the verdict moved and the reason did not; the reader is not being "
+            "told which source could not be read")
+    else:
+        assert all(c.verdict == "VERIFIED" for c in ext_claims), (
+            f"NEGATIVE CONTROL FAILED. Adding {name} ({mechanism}) demoted the "
+            f"claim to {[c.verdict for c in ext_claims]}. This source parses "
+            "cleanly and contributes no failure, so nothing about it makes the "
+            "read partial. A rule that demotes here is counting files rather "
+            "than reading them, and the demotions this test pins would then be "
+            "evidence of nothing.")
+        assert ext.verdict == base.verdict, (ext.verdict, base.verdict)
+
+
+@owed_wiring
+@pytest.mark.parametrize("name", CONTENT_NAMES)
+@pytest.mark.parametrize("commit", [None, HEAD_COMMIT, OTHER_COMMIT])
+def test_evidence_never_worsens_the_run_leg_either(ev, name, commit):
+    """The two channels are a disjunction, and the dangerous direction is the
+    one where requiring BOTH would let adding a report turn a --strict PASS into
+    a --strict FAIL. Measured against the NO-EVIDENCE baseline -- a green --run
+    with nothing supplied on the evidence channel -- and so this is the run-leg
+    instance of the guarantee that holds, not of the set-extension property that
+    does not. Adding a SECOND report to a report already in hand is the pin
+    above; adding a first one to a green run is this."""
+    base, _ = _run_gate(rc=0, strict=True)
+    with_ev = _with_stub(_Stub(returncode=0), lambda: gate(
+        "All tests pass.", TOUCHED, run="pytest -q", repo=".",
+        evidence=ev[name], commit=commit, strict=True))
+    assert GATE_RANK[with_ev.verdict] <= GATE_RANK[base.verdict], (
+        f"{name}/{commit}: adding a report broke a green run")
+    for a, b in zip(base.claims, with_ev.claims):
+        assert CLAIM_RANK[b.verdict] <= CLAIM_RANK[a.verdict], (a.verdict, b.verdict)
+
+
+@owed_wiring
+@pytest.mark.parametrize("name", CONTENT_NAMES)
+def test_evidence_does_not_touch_any_other_claim_kind(ev, name):
+    """A test report says nothing about whether the diff touched the file the
+    summary named. If any non-`tests_pass` verdict or reason moves, the wiring
+    has reached somewhere it was not invited."""
+    summary = ("Modified styxx/app.py, added 1 tests, adds function test_one. "
+               "This change only touches styxx/. All tests pass.")
+    base = gate_diff_text(summary, TOUCHED)
+    with_ev = gate_diff_text(summary, TOUCHED, evidence=ev[name])
+    a = [(c.kind, c.verdict, c.why) for c in base.claims if c.kind != "tests_pass"]
+    b = [(c.kind, c.verdict, c.why) for c in with_ev.claims if c.kind != "tests_pass"]
+    assert a == b
+
+
+@owed_wiring
+def test_a_commit_the_evidence_does_not_name_stays_uncheckable(ev):
+    """The commit has to reach the adjudicator or `--evidence-commit` is
+    decoration. A green report that never names the change under review is a
+    green report about something else -- and a report from another branch, or
+    from last week, is the exact hazard styxx.evidence's binding section exists
+    for."""
+    want_verdict, want_why = adjudicate_tests_pass(
+        load_evidence(ev["green"]), OTHER_COMMIT)
+    assert want_verdict == "UNCHECKABLE"
+    g = gate("All tests pass.", TOUCHED, evidence=ev["green"],
+             commit=OTHER_COMMIT)
+    claims = tp(g)
+    assert claims
+    for c in claims:
+        assert c.verdict == "UNCHECKABLE", c.why
+        assert want_why in c.why
+
+
+@owed_wiring
+def test_evidence_is_deterministic_over_the_same_bytes(ev):
+    """styxx.evidence is a pure function of bytes and the wiring may not smuggle
+    ambient state in around it. Same inputs, same record, twice."""
+    a = gate_diff_text("All tests pass.", TOUCHED, evidence=ev["green"]).to_dict()
+    b = gate_diff_text("All tests pass.", TOUCHED, evidence=ev["green"]).to_dict()
+    assert a == b
+
+
+@owed_wiring
+def test_the_evidence_leg_runs_once_per_gate_not_once_per_match(ev):
+    """Same repair as the --run leg, and the same reason: every `tests_pass`
+    match in one summary asks the same question about the same suite. Counted
+    by intercepting the loader rather than by reading the code."""
+    calls = {"n": 0}
+    real = E.load_evidence
+
+    def counting(paths):
+        calls["n"] += 1
+        return real(paths)
+
+    D_ev = D.styxx.evidence if hasattr(D, "styxx") else E
+    E.load_evidence = counting
+    try:
+        gate_diff_text("All tests pass.\nAll tests pass.\nAll tests pass.",
+                       TOUCHED, evidence=ev["green"])
+    finally:
+        E.load_evidence = real
+    assert D_ev is E
+    assert calls["n"] <= 1, f"{calls['n']} evidence reads for one gate invocation"
+
+
+@owed_wiring
+def test_it_uses_styxx_evidence_not_a_private_copy():
+    """Asserted by source inspection, the way ``tests/test_undeclared.py``
+    asserts reconcile parses the diff with the gate's own parser rather than a
+    second one that can drift.
+
+    Here the drift would be worse than a disagreement about diffs: a private
+    reader of JUnit or in-toto bytes inside diffgate would be a reader with no
+    ``VERDICTS`` tuple, no self-check, and no docstring saying what VERIFIED
+    does not mean."""
+    src = inspect.getsource(D)
+    assert "from styxx.evidence import" in src, (
+        "diffgate does not import styxx.evidence")
+    assert "adjudicate_tests_pass" in src and "load_evidence" in src, (
+        "diffgate does not call the adjudicator; it has an opinion of its own")
+
+    tree = ast.parse(src)
+    imported = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported.update(a.name.split(".")[0] for a in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imported.add(node.module.split(".")[0])
+    assert "xml" not in imported, (
+        "diffgate parses XML itself; that is a second evidence reader")
+
+    # Identifiers only -- prose constants legitimately mention in-toto and JUnit,
+    # and a substring grep over the whole file would refuse the paragraphs that
+    # explain the delegation.
+    names = {n.attr for n in ast.walk(tree) if isinstance(n, ast.Attribute)}
+    names |= {n.id for n in ast.walk(tree) if isinstance(n, ast.Name)}
+    for smell in ("fromstring", "ElementTree", "predicateType", "failedTests",
+                  "passedTests", "testsuite", "observed"):
+        assert smell not in names, (
+            f"diffgate appears to read evidence bytes itself ({smell!r}); that "
+            "is a second adjudicator, and only one of them has a self-check")
+
+
+@owed_wiring
+def test_the_cli_exposes_the_evidence_channel_and_warns_about_the_other_one():
+    """A library-only wiring is a wiring nobody uses. And the CLI is where the
+    module advertises `--run`, which on an untrusted pull request is arbitrary
+    code execution against the tree under test -- pytest imports the PR's
+    conftest.py at collection, `npm test` runs the PR's package.json, and
+    os.environ is inherited unscrubbed."""
+    sig = inspect.signature(gate_diff_text).parameters
+    assert "evidence" in sig
+    assert _COMMIT_KW is not None, (
+        "no commit-binding parameter: a green report from another branch, or "
+        "from last week, would answer for this change")
+    # Exact option strings, not substrings. A substring check passed a mutant
+    # that renamed the flag to `--evidenceX`, because "--evidence" is a prefix of
+    # it -- the same mention/use sloppiness this file exists to avoid, committed
+    # by this file. Found by mutant M23.
+    src = inspect.getsource(D.main)
+    tree = ast.parse(src)
+    helps = {}
+    for n in ast.walk(tree):
+        if (isinstance(n, ast.Call) and isinstance(n.func, ast.Attribute)
+                and n.func.attr == "add_argument" and n.args
+                and isinstance(n.args[0], ast.Constant)):
+            kw = {k.arg: k.value for k in n.keywords}
+            h = kw.get("help")
+            helps[n.args[0].value] = (h.value if isinstance(h, ast.Constant)
+                                      and isinstance(h.value, str) else "")
+    assert "--evidence" in helps, sorted(helps)
+    assert set(helps) & {"--evidence-commit", "--commit"}, sorted(helps)
+    assert "--run" in helps, sorted(helps)
+    # Scoped to --run's OWN help. A whole-source search for "executes" was
+    # satisfied by --evidence's help saying it "executes nothing", so a mutant
+    # that stripped the warning off --run passed. Found by mutant M23b.
+    run_help = helps["--run"].lower()
+    assert "execut" in run_help, (
+        "--run's own help must say out loud that it runs a shell command: on an "
+        "untrusted pull request that is code execution against the tree under "
+        f"test. Got: {helps['--run']!r}")
+    assert "never an accusation" in run_help or "uncheckable" in run_help, (
+        "--run's help must say which verdicts it can produce, because the one "
+        "it cannot produce is the whole point")


### PR DESCRIPTION
Wires `styxx.evidence` into the gate, deletes the last unmeasured accusation, and measures the step before the verdict that this lab has never measured for any claim kind.

## The extraction census

Every precision we publish answers *given a claim was extracted, was the verdict right?* None answers the question before it: **given the regex fired, was a claim being made at all?** A false extraction produces a false accusation exactly as surely as a false adjudication, and it is invisible to every panel we have run — because every panel was shown the extracted claim and asked about the verdict.

Over the same 71,016 eligible PRs as `v14_gates.json`: **5,514 `tests_pass` matches**, of which **179 sit in UNTICKED task-list boxes** — 23.22% of every match on a task-list line. Verbatim: `- [ ] New and existing unit tests pass locally with my changes`. The author is declining to assert and the extractor emits a claim. 346 matches (6.27%) carry a mechanical non-assertion indicator, which already exceeds the 5% a 0.95 floor allows, before any judgment is applied.

**These are CONTAINMENT figures — they record where a match SITS, not that an extraction was WRONG.** That distinction is held in the code, the tests and the receipt; the judgment half is marked UNVALIDATED at every level a consumer can index into.

## The --run accusation is deleted

A nonzero exit is not evidence the author lied. It is also `pytest` rc=5 "no tests collected", a misspelled command, a missing dependency, and a flake — and today rc=5 is read as a lie. A sweep of 14 hedged shapes: **14/14 extracted, 14/14 CONTRADICTED under a failing run, exactly one a genuine claim.**

`--run` itself stays. The execution is *contextually* dangerous and only the operator knows whether the tree is trusted; the accusation is *unconditionally* unearned. Deleted, not flagged off — `WITHHOLD_PATH_ACCUSATION` is the counter-example this codebase already carries.

Measured cost: **zero**. 0 accusations on every split, and no test covered the branch.

## Four repairs, none a verdict change

- the no-evidence exemption: a gate printing *"this gate did not run"* still exited 1 carrying an accusation
- 50 matches launched 50 subprocesses at 1800s each, PR-author-controlled
- `TimeoutExpired` propagated as a traceback instead of a verdict
- `repo=None` silently executed **in the verifier's own working directory**

## Monotonicity, corrected rather than assumed

Adding evidence never worsens the gate against the empty baseline — that is the guarantee. Extending a *non-empty* evidence set can demote VERIFIED to UNCHECKABLE, and that is deliberate: a partial read may honestly decline but may not honestly affirm. You cannot certify "all tests pass" from nine shards of ten.

The suite previously asserted a shrink-only property without naming its baseline, and **seven distinct weakenings of the partial-read rule left it fully green**. Both properties are now tested separately, and the demotion is pinned so nobody "fixes" it by letting a partial read affirm.

Full suite 3179 passed. `flag_rate.json` reproduces byte-identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)