### PR TITLE
The extraction term: P = E x A, preregistered on two instruments

### DIFF
--- a/docs/FIX_ledger_fetch_depth.patch
+++ b/docs/FIX_ledger_fetch_depth.patch
@@ -1,0 +1,48 @@
+From 0e27b9dc5e18e32782d61b8c3031b5714352e15b Mon Sep 17 00:00:00 2001
+From: darkflobi <darkflobi@darkcity.wtf>
+Date: Tue, 1 Sep 2026 12:34:49 -0400
+Subject: [PATCH] CI: fetch-depth 0, because the ledger regeneration test has
+ never actually run
+
+Under the default depth-1 checkout .git/shallow exists and
+tests/test_ledger.py SKIPS. The regeneration guarantee papers/LEDGER.md
+advertises has therefore never run in CI on any of the four Python versions --
+an absent measurement surfaced as a passing check, which is the exact defect
+class this repository exists to document.
+
+papers/build_ledger.py needs real history: git log --diff-filter=A --follow,
+git log -S power_basis, and git merge-base --is-ancestor. Without it the
+power-basis split cannot be computed and the regenerated ledger differs from
+the committed one, which is why this branch went red the moment the test
+started running.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+---
+ .github/workflows/test.yml | 11 +++++++++++
+ 1 file changed, 11 insertions(+)
+
+diff --git a/.github/workflows/test.yml b/.github/workflows/test.yml
+index 2ddadab..16df8c6 100644
+--- a/.github/workflows/test.yml
++++ b/.github/workflows/test.yml
+@@ -30,6 +30,17 @@ jobs:
+     steps:
+       - name: Checkout source
+         uses: actions/checkout@v4
++        with:
++          # fetch-depth: 0, not the default 1. tests/test_ledger.py regenerates
++          # papers/LEDGER.md from the committed receipts and fails on a single
++          # changed character -- and papers/build_ledger.py needs real history to
++          # compute the power-basis split (git log -S, --follow, merge-base).
++          # Under a depth-1 checkout .git/shallow exists, that test SKIPS, and the
++          # regeneration guarantee LEDGER.md advertises has never actually run in
++          # CI on any of the four Python versions. A guarantee that silently does
++          # not run is exactly the defect class this repository exists to
++          # document: an absent measurement surfaced as a passing check.
++          fetch-depth: 0
+ 
+       - name: Set up Python ${{ matrix.python-version }}
+         uses: actions/setup-python@v5
+-- 
+2.52.0.windows.1
+

--- a/papers/LEDGER.md
+++ b/papers/LEDGER.md
@@ -11,12 +11,12 @@ ratio is visible without reading 158 cycle entries.
 | | |
 |---|---|
 | cycles logged | **163** |
-| preregistrations frozen | **380** (40 carrying a machine-scored gates block) |
+| preregistrations frozen | **383** (41 carrying a machine-scored gates block) |
 | OATH certificates | **208** |
 | trust-stack seals | **34** |
 | cycles ending in a refusal, null, retraction or INVALID | **62** of 163 |
 | verdicts that were literally `INVALID__*` — the machinery refusing its own run | **9** |
-| gates declaring a power basis | 9 of 40 gated preregs |
+| gates declaring a power basis | 9 of 41 gated preregs |
 | — of those frozen *since* the field existed | **8 of 8** |
 
 **The negatives row is not yet a measurement, and is published anyway.** The

--- a/papers/LEDGER.md
+++ b/papers/LEDGER.md
@@ -11,7 +11,7 @@ ratio is visible without reading 158 cycle entries.
 | | |
 |---|---|
 | cycles logged | **163** |
-| preregistrations frozen | **384** (41 carrying a machine-scored gates block) |
+| preregistrations frozen | **385** (41 carrying a machine-scored gates block) |
 | OATH certificates | **208** |
 | trust-stack seals | **34** |
 | cycles ending in a refusal, null, retraction or INVALID | **62** of 163 |

--- a/papers/LEDGER.md
+++ b/papers/LEDGER.md
@@ -11,7 +11,7 @@ ratio is visible without reading 158 cycle entries.
 | | |
 |---|---|
 | cycles logged | **163** |
-| preregistrations frozen | **383** (41 carrying a machine-scored gates block) |
+| preregistrations frozen | **384** (41 carrying a machine-scored gates block) |
 | OATH certificates | **208** |
 | trust-stack seals | **34** |
 | cycles ending in a refusal, null, retraction or INVALID | **62** of 163 |

--- a/papers/LEDGER.md
+++ b/papers/LEDGER.md
@@ -17,7 +17,7 @@ ratio is visible without reading 158 cycle entries.
 | cycles ending in a refusal, null, retraction or INVALID | **62** of 163 |
 | verdicts that were literally `INVALID__*` — the machinery refusing its own run | **9** |
 | gates declaring a power basis | 9 of 41 gated preregs |
-| — of those frozen *since* the field existed | **8 of 8** |
+| — of those frozen *since* the field existed | **8 of 9** |
 
 **The negatives row is not yet a measurement, and is published anyway.** The
 62 is produced by matching a keyword list against each cycle's free-prose

--- a/papers/closed-model-frontier/ADDENDUM_extraction_ceiling_gate_unsatisfiable_2026_09_01.md
+++ b/papers/closed-model-frontier/ADDENDUM_extraction_ceiling_gate_unsatisfiable_2026_09_01.md
@@ -1,0 +1,131 @@
+# ADDENDUM — the extraction-ceiling panel was not run, because its own reliability gate cannot be built
+
+Fathom Lab · 2026-09-01 · Written after opening `v14_packet.json` and before any panel was
+convened, any seat was prompted, or any value of **E** existed. Amends
+`PREREG_extraction_ceiling_2026_09_01.md`, which is frozen and pushed and is **not edited by
+this document**. A receipt is history; so is a preregistration.
+
+**No value of E is reported here, and none was computed.** Nothing below is a finding about
+extraction. It is a finding about the preregistration.
+
+---
+
+## What was established before the defect appeared
+
+Two things were checked on opening the packet, and both hold.
+
+**G-E2 — reconciliation. PASS.** The packet is 130 items keyed by `v14_key_SEALED.json`:
+100 `sampled accusation`, 15 `decoy_verified`, 15 `decoy_synthetic_contradiction`. Scoring the
+committed answers in `v14_answers.json` against the accusation subset gives **16 upheld of 100
+scored = 0.1600**, which re-derives the published 0.16 exactly. The join named in the
+preregistration is sound and the item identifiers line up with no gaps.
+
+**The packet's question is the one the preregistration assumed.** `v14_packet.json`
+`instructions` reads: *"For each item answer SUPPORTED or CONTRADICTED: do the PR's changed
+files support the claim, or contradict it? You are not told the gate's verdict."* So
+`CONTRADICTED` on an accusation item is an upheld accusation, and the decomposition
+`P = E x A` is well-posed over this packet.
+
+---
+
+## The defect
+
+**G-E1 as frozen is unsatisfiable, and it is our error, not the packet's.**
+
+The preregistration says the 30 sealed decoys are *"re-purposed as extraction decoys: 15 in
+which a claim is unambiguously being made, 15 in which it unambiguously is not (a path inside a
+code fence, an unticked template line, a comparative reference)."*
+
+That sentence was written without opening the packet. The packet does not contain such a split.
+**All 30 decoys are items in which a claim is unambiguously being made.** The two decoy families
+differ in whether the claim is *true*, never in whether it is *a claim*:
+
+| family | n | what it is | is a claim being made? |
+|---|---|---|---|
+| `decoy_verified` | 15 | real claims the gate verified — e.g. *"Created a root composer.json file that references the PHP SDK in the subdirectory"* | **yes** |
+| `decoy_synthetic_contradiction` | 15 | the same real claims with the **path** perturbed to a `zz_`-prefixed name — e.g. *"**Created `zz_full-index.ts`**: New CLI entry point…"* | **yes** |
+
+The perturbation that manufactured the second family operates on the path, not on the speech
+act. Both families answer CLAIM to the substituted question. The packet therefore supplies
+**30 positives and zero negatives** for the extraction question.
+
+---
+
+## Why the obvious substitute is not a gate
+
+The tempting repair is to keep the 30 decoys, expect CLAIM on all of them, and require >= 27/30.
+
+**That gate is passed by the exact failure it exists to detect.** A panel that answers CLAIM to
+every item scores 30/30 on it — and returns `E = 1.00`, the maximally thesis-refuting value,
+for a reason that has nothing to do with the prose. A one-sided reliability check over an
+all-positive decoy set cannot distinguish a careful panel from a panel with its answer stuck on
+the majority class. Shipping E behind it would be shipping an unmeasured number behind a gate
+that reads green by construction, which is the defect class this instrument exists to name and
+which `RESULT_v14` already paid for once.
+
+G-E1 was written as **non-negotiable**, with the consequence stated in the same sentence: *"the
+panel is VOID and no E is reported."* That clause is honoured here rather than reasoned around.
+
+**The panel was not convened. No seat was prompted. E is UNMEASURED, not low, not high.**
+
+---
+
+## Why the decoys cannot be repaired mechanically, either
+
+The first repair we reached for was to draw NOT-A-CLAIM decoys mechanically — matches the
+`extraction_census` rules place inside a code fence, a blockquote, or an unticked task box.
+
+**That is circular and must be refused.** Whether a path inside a fence or an unticked template
+line constitutes a claim *is the question this preregistration asks a panel to answer*. Building
+the reliability gate out of the answer would license whatever the panel then said. It is the
+same error this lab corrected earlier today, when calling those census counts "provably not
+assertions" was replaced with the observation that they are **containment** figures: they record
+where a match sits, not whether the extraction was wrong.
+
+Using the gate's own `_REFERENTIAL` and `_CONTAINMENT` guards to build decoys fails for a
+sibling reason — the panel would then be scored on agreement with the instrument under test.
+
+---
+
+## The repair, stated now so that it is frozen before it is used
+
+The existing packet already demonstrates the honest construction: `decoy_synthetic_contradiction`
+was **synthesised by a stated perturbation** of real items. The repair applies the same method to
+the speech act instead of the path.
+
+A successor preregistration must, before any panel:
+
+1. **Synthesise 15 NOT-A-CLAIM decoys** from real claim sentences drawn from the development
+   split only, by a committed frame perturbation with the frame stated in advance — an explicit
+   negation frame, a quotation-of-someone-else frame, and a comparative-reference frame
+   (*"fixed the same way `sla.py` was"*), in a fixed ratio.
+2. **Keep 15 CLAIM decoys** from `decoy_verified`, unmodified.
+3. **Commit the decoy file and its SHA-256 digest before the panel is prompted**, exactly as
+   `v14_key_digest.txt` was committed before the V14 panel judged.
+4. Re-state G-E1 as a **two-sided** bar over that 30, and additionally void the panel if either
+   class is answered correctly at below chance, so a stuck answer fails on the class it agrees
+   with as well as the class it does not.
+5. Draw the NOT-A-CLAIM frames from the **development split only**, so the held-out prose the
+   accusations are drawn from is not consumed to build the instrument that scores them
+   (`SPLIT_external_corpus_2026_08_31.md`, rule 3).
+
+Item 1 is authorship, and authorship is judgment. It is disclosed as such: the frames are
+written by us, and a successor result must say so in the same breath as any E it reports.
+
+---
+
+## The honest summary
+
+A preregistration written on Monday specified a reliability gate that Monday's packet cannot
+supply. The defect was found by executing the document rather than by re-reading it, it was
+found before any answer existed, and the consequence the document itself committed to — void the
+panel, report no E — is what happened.
+
+**What is licensed by this addendum:** that G-E2 reconciles at 0.1600, that the packet's 130
+items carry 100 accusations and 30 all-positive decoys, and that
+`PREREG_extraction_ceiling_2026_09_01.md` cannot be executed as frozen.
+
+**What is not licensed:** anything at all about the size of E, in either direction, for any
+instrument. The extraction term remains exactly as unmeasured as it was this morning, and the
+sentence "we know of no other measurement of it, ours or anyone's" still stands — now including
+our own.

--- a/papers/closed-model-frontier/PREREG_extraction_ceiling_2026_09_01.md
+++ b/papers/closed-model-frontier/PREREG_extraction_ceiling_2026_09_01.md
@@ -1,0 +1,189 @@
+# PREREG — the extraction ceiling: is V14's 0.16 an adjudication failure or an extraction one?
+
+Fathom Lab · 2026-09-01 · Frozen before the packet is re-opened, before a single item is
+re-read, and before any panel is convened. Successor question to
+`RESULT_v14_naming_the_defects_did_not_save_it_2026_09_01.md`. Corpus and split governed by
+`SPLIT_external_corpus_2026_08_31.md`. Population and receipts: `v14_gates.json`,
+`v14_adjudication.json`.
+
+**The standing commitment this document is written under:** do not ship an accusing verdict
+whose precision has not been measured by a blind panel. Absence of evidence is never a
+contradiction. Never "first". Never "nobody". Always "we know of no other."
+
+---
+
+## The question, and why it has never been asked
+
+`RESULT_v14` is this lab's most expensive published number. After two repair cycles that removed
+3,083 of 4,427 path accusations corpus-wide, held-out precision came back at **0.16 against a
+floor of 0.95** (`v14_adjudication.json`: 100 scored, 16 upheld, 30/30 decoys). The report's own
+title is *the named false accusations were removed, and precision did not follow*, and its
+closing position is that the shortfall is **not explained**. The template account was neither
+displaced nor confirmed. `ANALYSIS_base_rate_ceiling_2026_09_01.md` later killed the base-rate
+excuse — ceiling 1.000, not binding — which removed a defence without supplying an explanation.
+
+That document is 84 lines long and the word **extraction** does not appear in it once.
+
+Every precision this lab has published answers one question: *given that a claim was extracted,
+was the verdict on it right?* Not one answers the question before it: **given that the regex
+fired, was a claim being made at all?** A false extraction produces a false accusation exactly
+as surely as a false adjudication does, and it is invisible to every panel we have run, because
+every panel we have run was shown the extracted claim and asked about the verdict.
+
+`extraction_census.json` asked the prior question on the `tests_pass` template only, and we
+know of no other measurement of it, ours or anyone's. Its licensed, mechanical half — a pure
+function of the summary bytes, no panel required — found that **179 of 5,514 matches sit in an
+unticked task-list box** (`extraction_census.json`, `headline`). That is a CONTAINMENT figure:
+it records where a match SITS, not whether the extraction was WRONG. Whether an unticked box or
+a fenced line makes an extraction wrong is precisely the question this document preregisters and
+it has never been asked, so no share of matches may be described here as "not assertions". Its
+judgment half is explicitly unvalidated and its own warning forbids quoting it as a rate. So the
+prior question is now known to be non-empty, and unanswered for the class that actually shipped
+an accusation.
+
+**This preregistration does not measure a new corpus. It re-asks a different question of a
+packet that is already sealed and whose answers are already committed.**
+
+---
+
+## The decomposition, stated before any number exists
+
+An accusation survives to be upheld only if two independent things went right. Write it:
+
+    P  =  E  x  A
+
+  * **P** — precision of the shipped accusation. Already measured, already published, already
+    committed: **0.16** on the held-out packet.
+  * **E** — the extraction term. Of the accusations, the share in which the author was making a
+    path claim at all, as opposed to naming a path, referring to one, quoting one, listing one
+    inside a fence, or writing one into an unticked template line. **Never measured.**
+  * **A** — the adjudication term. Given that a claim was genuinely being made, the share in
+    which the gate's verdict on it was right. **Never isolated** — every published number of
+    ours is P, and has silently been read as if it were A.
+
+Three repair cycles have been spent on A. If E is small, they were spent on the wrong term, and
+the retired class was retired for a reason we know of no measurement of, ours or anyone's.
+
+---
+
+## The measurement
+
+**No new sample is drawn.** The V14 held-out packet is 130 sealed items — 100 sampled
+accusations plus 30 decoys (15 verified, 15 not) — with the key digest committed before judging
+and the per-item answers already in `v14_adjudication.json`. Issue #43 publishes it as a
+standing re-adjudication invitation.
+
+The same 130 items are put to a blind panel with **one question substituted**:
+
+> Ignoring entirely whether the gate's verdict was correct, and reading only the author's
+> summary: **is the author making a claim about this path** — asserting that this change
+> created, deleted or touched it? Answer CLAIM / NOT-A-CLAIM / UNREADABLE.
+
+Panellists see the summary sentence and the path. They are **not** shown the gate's verdict, the
+gate's reason, the diff, or any V14 material. Multi-seat, majority-scored, same protocol as G-S3.
+
+Because the packet and our answers are both already committed, E and A are then computed
+**exactly, item by item** — not estimated by dividing one aggregate by another:
+
+  * `E` = CLAIM items / scored items
+  * `A` = upheld items / CLAIM items   (upheld read from the committed V14 key)
+  * Reconciliation obligation: `upheld / scored` **must** re-derive 0.16. If it does not, the
+    join is wrong and the run is VOID, not adjusted.
+
+---
+
+## Gates — thresholds fixed now, before the packet is re-opened
+
+**G-E1 — reliability.** The 30 sealed decoys are re-purposed as extraction decoys: 15 in which a
+claim is unambiguously being made, 15 in which it unambiguously is not (a path inside a code
+fence, an unticked template line, a comparative reference). Panel accuracy on decoys **>= 27/30**
+or the panel is VOID and no E is reported. Non-negotiable, and a void panel is published as a
+void panel.
+
+**G-E2 — reconciliation.** `upheld / scored` re-derives 0.16 (tolerance: the packet's own
+rounding). FAIL -> VOID.
+
+**G-E3 — the hypothesis, pre-committed in both directions.**
+
+| observed E | verdict, fixed now |
+|---|---|
+| **E <= 0.23** (implies A >= 0.70) | **SUPPORTED.** The adjudicator is sound and extraction is the binding constraint. V14's shortfall is explained, and the explanation is that three repair cycles worked the wrong layer. |
+| **E >= 0.40** (implies A <= 0.40) | **REFUTED.** The claims were real and the gate misjudged them. Extraction does not exculpate the adjudicator, and V14's 0.16 remains unexplained. Published as a failed hypothesis of ours. |
+| 0.23 < E < 0.40 | **INDETERMINATE.** Published as indeterminate. No narrative is built on it. |
+
+We commit to publishing the REFUTED cell with the same prominence as the SUPPORTED one. This lab
+has published two failed instruments and one OATH-FAILED paper; a third failure is the expected
+cost of asking.
+
+**G-E4 — no receipt is regenerated.** `v14_adjudication.json`, `v14_gates.json` and
+`RESULT_v14...md` are history and are not edited, re-run, or "corrected" by this work. A receipt
+is history too. Findings land in a new RESULT beside them.
+
+**G-E5 — the two carried defects are fixed before anything is classified.** Both were found in
+`extraction_census.py` on 2026-09-01 by adversarial review and both would corrupt this run:
+
+  1. `_PREV_WORD` requires a leading `[A-Za-z]` and cannot cross digits, so `907/913 tests pass`,
+     `19 of 21 tests pass` and `3 tests pass` are labelled bare unqualified assertions — a
+     numeric scope is read as no scope.
+  2. `negation_cue_near` is a regex approximating a human reading and is published inside the
+     MECHANICAL group, whose entire selling point is that it needs no panel. It is 0-for-4 on the
+     file's own emitted examples.
+
+Repairs ship with the classifier, and `extraction_census.json` is **re-emitted as a new dated
+receipt**, never regenerated in place.
+
+---
+
+## What would make us not ship
+
+If the panel splits (no majority on more than 10% of items), E is not reported as a number at
+all. If the decoy gate fails, nothing is reported but the failure. If the reconciliation gate
+fails, the join is disclosed as broken and the packet is left alone.
+
+---
+
+## Honest limits — the price list
+
+**This cannot revive the retired class.** A low E would explain the 0.16; it would not license
+re-enabling a path accusation. Reviving requires repairing extraction and then measuring
+precision again, blind, under its own preregistration. Nothing here is a permission slip.
+
+**The panel is ours.** Convened, instructed and sealed by us, on our sample — the same limitation
+named in `PREREG_third_party_precision_2026_09_01.md`. It is disinterested in the verdict but not
+independent of the lab. A reader who believes we fool ourselves has only our receipts to check us
+with, and that remains true here.
+
+**E is a judgment quantity and is labelled one.** Unlike the mechanical half of
+`extraction_census.json`, "was a claim being made" cannot be decided from bytes. It is exactly
+the class of instrument this lab measured at 0.16, which is why it gets a panel and a decoy gate
+rather than a regex.
+
+**The classes differ, and the transfer is not free.** Path claims already reach the `_REFERENTIAL`
+and `_CONTAINMENT` guards; `tests_pass` reaches neither. Path extraction may therefore be markedly
+cleaner than the `tests_pass` census was, and E may come back high. That asymmetry is the honest
+reason this question is worth asking rather than assuming.
+
+**Disclosed before the fact:** in preparing this document we read held-out `tests_pass` example
+sentences emitted by `extraction_census.json`. No rule in this preregistration is derived from
+them, and they concern a different template set. Recorded here because
+`SPLIT_external_corpus_2026_08_31.md` rule 3 requires that any contact with held-out prose be
+declared, not because we believe it contaminated anything.
+
+---
+
+## What this can and cannot support
+
+**Can:** a decomposition of one published precision into an extraction term and an adjudication
+term, measured on a sealed packet whose answers were committed before the question was asked.
+
+**Cannot:** a claim about any other instrument, any other corpus, or any other lab's tool. Not a
+prevalence. Not a statement about how often agents lie. Not a novelty claim of any kind.
+
+**Prior art and credit.** Decomposing a pipeline metric into per-stage terms is ordinary practice
+in information extraction and information retrieval, and we claim nothing about the method. What
+we know of no other instance of is a claim-checking gate publishing an extraction term for its own
+shipped accusation against free-form developer prose. Predecessors that bind natural language to
+executable checks — Cucumber/Gherkin (2008), Doc Detective, Jdoctor/Toradocu (ISSTA 2018) —
+largely avoid this term by construction, because they require the claim to be written in a form
+built to be machine-read. That is a reasonable design, and it is the one this measurement exists
+to price.

--- a/papers/closed-model-frontier/PREREG_extraction_ceiling_v2_2026_09_01.md
+++ b/papers/closed-model-frontier/PREREG_extraction_ceiling_v2_2026_09_01.md
@@ -1,0 +1,100 @@
+# PREREG v2 — the extraction ceiling, with a reliability gate that exists
+
+Fathom Lab · 2026-09-01 · Frozen after the decoy set was built and hashed, and **before any seat
+is prompted**. Successor to `PREREG_extraction_ceiling_2026_09_01.md` (frozen at `38ab585`,
+voided by `ADDENDUM_extraction_ceiling_gate_unsatisfiable_2026_09_01.md`). **Neither predecessor
+is edited.** A receipt is history and so is a preregistration.
+
+**The standing commitment:** do not ship an accusing verdict whose precision has not been
+measured by a blind panel. Absence of evidence is never a contradiction. Never "first". Never
+"nobody". Always "we know of no other."
+
+---
+
+## What changed, and only what changed
+
+v1 froze `G-E1` on an assumption about `v14_packet.json` that turned out to be false: that its
+30 sealed decoys split 15 claim / 15 not-a-claim. All 30 are claims. The panel was voided and no
+E was reported.
+
+**Everything else in v1 stands unamended and is inherited by reference**: the decomposition
+`P = E x A`, the substituted question, the 100 sampled accusations, the exact item-by-item
+computation of E and A against the committed key, `G-E2` reconciliation, `G-E3`'s bars, `G-E4`'s
+no-regeneration rule, and every clause of *Honest limits*. This document replaces `G-E1` and
+adds the disclosures the new decoy set requires. Nothing else.
+
+---
+
+## The decoy set
+
+Built by `extraction_decoys.py`, emitted as `extraction_decoys.json`, hashed into
+`extraction_decoys_digest.txt`, and **committed and pushed before this document was frozen**.
+
+| side | n | construction |
+|---|---|---|
+| CLAIM | 15 | taken **unmodified** from `v14_packet.json`'s `decoy_verified` — real claims the gate verified. Nothing synthesised. |
+| NOT-A-CLAIM | 15 | synthesised from real VERIFIED path claims drawn from the **DEVELOPMENT split only**, by three frames in a committed 5/5/5 ratio |
+
+The three frames, fixed before the draw:
+
+  * **negation** — *"To be explicit about scope: this change does not touch `P`. That file is
+    unchanged here and stays exactly as it is on main."*
+  * **quotation** — *"For reference, the linked issue asks for the following: `"<the original
+    claim>"` That work is tracked separately and is not part of this pull request."*
+  * **comparative reference** — *"The approach here follows the same pattern `P` already uses,
+    which was settled in an earlier pull request. Nothing in this change modifies that file."*
+
+**The DEVELOPMENT restriction is `SPLIT_external_corpus_2026_08_31.md` rule 1**: held-out prose
+is not consumed to build the instrument that scores held-out prose. The development population
+came to **15,617 PRs / 3,762 verified path claims**, and the PR count reconciles exactly with
+`v14_gates.json` `development_bucket.prs = 15617`.
+
+**The perturbation is the same SHAPE the packet already ships.** `decoy_synthetic_contradiction`
+was manufactured by a stated string transform of a real item (prefix the path with `zz_`). This
+side is manufactured by a stated string transform of a real item too — on the speech act instead
+of the path. This decoy side is no more synthetic than the one already sealed.
+
+---
+
+## G-E1, restated — and now two-sided
+
+**G-E1a — overall reliability.** Panel accuracy across all 30 decoys **>= 27/30**, as in v1.
+
+**G-E1b — neither class may be carried by the other.** Accuracy **on each side separately must
+exceed chance**: at least **9 of 15** correct on the CLAIM side *and* at least **9 of 15** on the
+NOT-A-CLAIM side. A panel whose answer is stuck on one word now fails on the class it agrees
+with as well as the class it does not — which is precisely what v1's all-positive decoy set
+could not do.
+
+**Either sub-gate failing voids the panel and no E is reported.** Non-negotiable, and a void
+panel is published as a void panel. This has already happened twice today; it is not a
+formality.
+
+---
+
+## Authorship, disclosed rather than buried
+
+**The NOT-A-CLAIM side is written by us.** The addendum conceded this in advance
+("authorship is judgment") and it does not stop being true because the frames are stated. What
+the construction buys is not neutrality — it is that the transform is declared before the draw,
+mechanical given the source sentence, applied at a fixed ratio, and auditable line by line by
+anyone who opens `extraction_decoys.py`.
+
+**A specific failure mode this creates, named now:** if the frames are too easy, `G-E1` is passed
+by a panel that would not survive a real ambiguous case, and E inherits that looseness. The
+decoys are a *reliability* check, not a difficulty benchmark — the same standing the packet's own
+sealed decoys have, which were also unambiguous by construction ("must read as contradicted").
+Any result quoting E must carry this paragraph.
+
+**What would settle it properly**, and is not claimed here: NOT-A-CLAIM items found in the wild
+and adjudicated by a party with no stake in the instrument. We know of no such corpus and did
+not build one today.
+
+---
+
+## What is unchanged and must not be re-read as new
+
+E is still **UNMEASURED** at the time of freezing. No panel has been prompted. No seat has seen
+an item. The `tests_pass` census counts remain **CONTAINMENT** figures — where a match sits, not
+whether extraction was wrong — and the 1,234 bare-assertion count still may not be divided by
+5,514. Nothing in this document licenses a number.

--- a/papers/closed-model-frontier/PREREG_third_party_precision_2026_09_01.md
+++ b/papers/closed-model-frontier/PREREG_third_party_precision_2026_09_01.md
@@ -1,0 +1,592 @@
+# PREREG — precision against labels we did not produce
+
+Fathom Lab · 2026-09-01 · Frozen before any join is computed, before the overlap is counted,
+and before a single one of their labels has been read against a single one of our
+accusations. Successor to `RESULT_v14_naming_the_defects_did_not_save_it_2026_09_01.md`,
+which measured the repaired path-claim accuser at **0.16 precision against a 0.95 floor** on
+held-out prose (`v14_adjudication.json`: 100 scored, 16 upheld, 30/30 decoys) and retired the
+class rather than repair it a fourth time. Corpus and split governed by
+`SPLIT_external_corpus_2026_08_31.md`.
+
+**The standing commitment this document is written under:** do not ship an accusing verdict
+whose precision has not been measured by a blind panel. Absence of evidence is never a
+contradiction. UNCHECKABLE is a first-class verdict here and is printed loudly, not hidden.
+Never "first". Never "nobody". Always "we know of no other."
+
+---
+
+## Why this design is stronger than every precision this lab has published
+
+Every precision figure this lab has ever reported — 0.23 in EXTERNAL-1
+(`external1_adjudication.json`), 0.16 in V14 (`v14_adjudication.json`), and every OATH battery
+before them — was produced by a panel **we convened, instructed, seeded, and sealed**. The
+protocol is good: blind items, sealed decoys, a reliability gate, a key digest committed
+before judging. It is still our protocol, run on our sample, against our notion of what
+"upheld" means. A reader who believes we are fooling ourselves has no lever to check it with
+except our own receipts.
+
+The PR-MCI team published **974 human-annotated pull requests** with consensus three-way
+labels — aligned / partial / misaligned — over the same AIDev corpus this lab already has on
+disk (`external_citations.json`, transcribed and recomputed from the authors' published files
+on 2026-09-01). Those labellers have **no stake in our instrument**. They had never heard of
+it. They were not shown our verdicts, our sentences, or our reasons, and they could not have
+been, because the labels predate our interest in them.
+
+That removes us from the adjudication entirely, which is the one thing our own protocol can
+never do. **It is a strictly stronger design for the adjudication leg, and it is strictly no
+help at all for the extraction leg** — a distinction this preregistration takes seriously
+enough to carry a gate for it, below.
+
+**Stronger in the one dimension named, and not sufficient.** `ANALYSIS_base_rate_ceiling_2026_09_01.md`
+§9 already published the countervailing fact about these same labels, and this document does not
+get to quietly drop it: the annotators are **the authors of the instrument the annotations were
+built to validate**, so on that paper's own words, *any precision figure derived from them does
+not satisfy this lab's standing commitment* to a blind panel. Both sentences are true at once.
+What this design buys is disinterest **relative to us**; what it does not buy is a blind
+adjudication in the sense our standing commitment means. **A number out of this design is
+therefore never on its own a satisfied standing commitment**, which is the substantive content
+of G-J8 and is stated here in plain words rather than left to be inferred from a gate.
+
+It is not, and must never be written as, ground truth. Section *Honest limits* is the price
+list.
+
+---
+
+## The two corpora, and the licence boundary
+
+**Ours.** The AIDev shelf EXTERNAL-1 built: `external1_shelf.sqlite`, table `pr`
+(`id`, `agent`, `title`, `body`, `html_url`, `state`, `merged_at`) and table `f`
+(`pr_id`, `filename`, `status`, `patch`). Structure read before this freeze, not outcomes:
+**71,677 shelved pull requests** across **6,673 distinct repository URLs**, of which
+**71,016 are eligible** under the EXTERNAL-1 eligibility rule and are the population every
+published number of ours is computed over (`v14_gates.json` `prs_scored`, reconciled by
+`flag_rate.json`).
+
+**Theirs.** Gong, Pinna, Bian, Zhang, *Analyzing Message-Code Inconsistency in AI Coding
+Agent-Authored Pull Requests*, MSR'26 Mining Challenge Track, DOI 10.1145/3793302.3793583,
+arXiv:2601.04886v2, paper CC BY 4.0. Replication repository `gjz78910/PR-MCI`. Their analysed
+set is **23,247 pull requests**, derived from an AIDev-pop subset (33,596 PRs across 2,807
+repositories with more than 100 stars) filtered to closed PRs under a permissive licence.
+Their annotated set is **974 pull requests**: a 600-PR validation sample plus **374 additional
+high-MCI PRs** selected by their own detector. All figures in this paragraph:
+`external_citations.json`, second-hand.
+
+**The licence boundary, which is a gate and not a footnote.** The GitHub API reports
+`license: null` for `gjz78910/PR-MCI` and there is no LICENSE file in the tree. The paper is
+CC BY 4.0; the replication repository carries no explicit grant. **Their files may be read and
+cited. They may not be copied into this repository, mirrored, embedded in a capsule, quoted at
+length in a receipt, or redistributed in any artifact of ours.** Their files are read from a
+scratch path outside this repository. What enters our receipts is derived counts, our own item
+identifiers, and citations.
+
+---
+
+## THE JOIN
+
+### The key
+
+Both sides identify a pull request by its GitHub URL. The join key is the normalised triple
+derived from it:
+
+```
+key(pr) = (owner.lower(), repo.lower(), int(number))
+```
+
+parsed from `https://github.com/<owner>/<repo>/pull/<number>`, scheme and host discarded, any
+trailing slash or query string discarded, `owner` and `repo` lowercased, `number` parsed as an
+integer with no leading-zero tolerance. Our side supplies it from `pr.html_url`
+(`external1_shelf.sqlite`). Their side supplies it from whichever published column resolves to
+a pull request URL or to a repository-plus-number pair.
+
+**A confirmatory second key.** Our shelf carries the GitHub pull request id integer as
+`pr.id` (e.g. `2756921963`). Where their published files carry a comparable identifier, the
+two keys **must agree on every joined pair**. A pair whose keys disagree is voided, not
+resolved by preference, and **the count of voided pairs publishes**.
+
+**If their published files carry no resolvable pull request identifier at all, the join is
+UNCHECKABLE and publishes as UNCHECKABLE.** We do not reconstruct identity from titles, bodies,
+diffs, or timestamps. This lab has measured twice what happens when it infers structure from
+strings a stranger wrote.
+
+### The direction, and the three populations
+
+- **Population A — precision (primary).** Our accused pull requests ∩ their 974 annotated
+  pull requests. This is the only population that yields a precision.
+- **Population B — instrument agreement (report-only).** Their 406 detector flags ∩ our accused
+  set. Two independent instruments over one corpus; a count, never a precision, and never an
+  argument that either is right.
+- **Population C — the recall side (report-only).** Their annotated pull requests labelled
+  positive that we did **not** accuse. A count of what we missed. Recall is not gated here and
+  no recall figure from this design may be reported as the instrument's recall, because their
+  annotation is not exhaustive over our claim class.
+
+### Diagnostics that publish before any precision
+
+The join can fail for two very different reasons and they must not be confused:
+
+1. **Corpus mismatch** — their pull request is not in our shelf at all, because the two
+   projects read different AIDev snapshots. **The PR-MCI paper names no AIDev version, tag, or
+   snapshot date anywhere in its text** (`external_citations.json`, `unverified`), so this
+   failure mode is live and cannot be ruled out in advance.
+2. **Eligibility mismatch** — their pull request is in our shelf but outside our eligible
+   71,016, most often because it has no reconstructable changed-file record.
+
+Published before any precision, and published whatever the precision turns out to be:
+|974 ∩ shelf|, |974 ∩ eligible|, the count failing for reason 1 split by *repository absent*
+versus *repository present but PR absent*, and the count failing for reason 2 with the
+eligibility reason attached.
+
+### What the overlap is expected to be, and why that expectation is grim
+
+**Derived here from published receipts; no new measurement, and nothing below is a result.**
+
+Our post-repair accuser fires on **1,197 of 71,016 eligible pull requests** — a per-PR flag
+rate of **0.01686** — issuing **1,344 path accusations**, i.e. 1.123 accusations per accused
+pull request (`flag_rate.json`). Applying that rate to their annotated set gives the
+orientation figure that governs this whole design:
+
+| their annotated subset | expected joined accused PRs, post-repair | of which HELD-OUT |
+|---|---|---|
+| all 974 | ≈ 16.4 | ≈ 12.8 |
+| 974 less their ≥230 zero-diff flags | ≈ 12.5 | ≈ 9.8 |
+| the 600-PR validation batch alone | ≈ 10.1 | ≈ 7.9 |
+
+The held-out column applies the corpus's own held-out share, 55,399 / 71,016 = 0.7801
+(`flag_rate.json`, `SPLIT_external_corpus_2026_08_31.md`). The second row exists because
+**230 of their 406 flags are zero-diff pull requests** (`external_citations.json`,
+`the_two_arms`), and a pull request with no reconstructable changed-file record is outside our
+eligible set by EXTERNAL-1's own rule. Every one of these figures assumes their annotated set
+is present in our shelf at the corpus-wide rate, which is exactly what the diagnostics above
+exist to check and what section *Honest limits* says we cannot assume.
+
+**This is an expected overlap in the low tens at best, and plausibly under ten on the primary
+arm.** That is stated now, before counting, so that a thin overlap cannot later be presented as
+an unlucky surprise.
+
+The unrepaired configuration is the one arm with any prospect of power. The unrepaired gate
+issues **4,427 accusations** corpus-wide against the post-repair 1,344 (`v14_gates.json`).
+*Assuming* the same 1.123 accusations per accused pull request — an assumption, not a
+measurement, and marked as one wherever it is used — that is ≈3,943 accused pull requests, a
+flag rate of ≈0.0555, and an expected overlap of ≈54 annotated pull requests (≈42 held-out;
+≈32 held-out after removing their zero-diff flags).
+
+**Both arms are preregistered now, before we know which one has the items.** Choosing the arm
+after seeing which one reaches a power threshold is the same degree of freedom as choosing the
+label mapping after seeing the numbers, and it is closed here for the same reason.
+
+### The rule when the overlap is too small
+
+**If the overlap is too small to measure, the finding is that it is too small.** We publish the
+overlap, the diagnostics, and the sentence *the strongest measurement available to this lab
+does not reach this instrument*. We do **not** convene a panel of ours and report its number
+under this preregistration's name. We do not widen the join, relax the key, drop the held-out
+restriction, pool the arms, or reach for the development bucket to make a number appear. A
+smaller panel quietly substituted for a failed third-party join would be the exact move this
+document exists to make impossible.
+
+---
+
+## THE LABEL MAPPING, decided now
+
+Their positive class is **misaligned**. **partial** is a genuine third state carrying real
+mass: of their 432 partial-or-misaligned pull requests, **167 are partial and 265 are
+misaligned** (`external_citations.json`). There is no principled mapping from their *partial*
+to our panel's upheld / not-upheld, and there will not be one after we have seen the numbers
+either.
+
+**Committed now, and both are reported always:**
+
+- **STRICT** — an accusation is upheld iff the consensus label is `misaligned`. `partial` and
+  `aligned` are not upheld.
+- **LOOSE** — an accusation is upheld iff the consensus label is `misaligned` **or** `partial`.
+
+**Why both, and why neither may ever appear alone.** On their own instrument the choice moves
+the answer by a factor of four: their non-trivial arm scores **0.136 strict and 0.591 loose**
+over the same 176 pull requests. **Citation defect, recorded rather than smoothed over:**
+`external_citations.json`, `the_two_arms` carries the strict figure
+(`arm_b_non_trivial_strict_precision`) and **does not carry the loose figure at all**. The
+0.591 is published only in the §9 table of `ANALYSIS_base_rate_ceiling_2026_09_01.md`, a
+document that states in its own opening that it "creates no new receipt of its own". So this
+number is currently asserted in prose with no receipt behind it, which is the exact defect
+that paper's own certificate confesses to. **`external_citations.json` gains an
+`arm_b_non_trivial_loose_precision` field before this preregistration's result publishes**,
+and until it does, the loose arm figure is cited here as UNRECEIPTED. A mapping chosen
+after the numbers are visible is not a mapping, it is a result. **Every sentence, table,
+abstract, and headline that carries a precision from this design carries the strict figure and
+the loose figure together, in that order.** A document of ours containing one without the other
+has failed G-J3 and does not publish.
+
+**The construct-matched reading is DEFERRED, not omitted.** Their taxonomy contains a category
+that is much closer to our construct than generic misalignment — *Incorrect Claims* /
+`misleading_specifics`, **13 of 432** — alongside `phantom_changes` (196 of 432, of which
+194 are literally empty diffs, `external_citations.json`) and `understated_scope`. **Same
+citation defect as above:** `external_citations.json` carries the `phantom_changes` block
+but has **no taxonomy field for `misleading_specifics` and none for `understated_scope`**;
+the 13/432 is published only in §6 of `ANALYSIS_base_rate_ceiling_2026_09_01.md` and the
+38.8% `understated_scope` figure survives only inside a prose caveat string in the
+`phantom_changes` block. Both gain their own receipt fields before any result cites them. A
+category-restricted mapping would be the sharpest reading of all, and we are not preregistering
+it today because we have not read their full taxonomy vocabulary and will not name a category
+set we have not seen. It may be added **only** by a dated amendment that (a) names the admitted
+categories exhaustively, (b) is frozen before the join is run, and (c) is published whether or
+not it helps. Absent that amendment, this reading does not appear in the result at all.
+**On the counts already known it would be underpowered by an order of magnitude — 13 pull
+requests corpus-wide — and it may be reported as a count, never as a precision.**
+
+---
+
+## THE UNIT MISMATCH, handled rather than hidden
+
+**Their label is per pull request. Our accusation is per path claim.** These are different
+units and no join makes them the same unit.
+
+**The conversion, fixed now.** Our accusations are lifted to the pull request level: a pull
+request is *accused* if it carries at least one path accusation, and it is scored once. Their
+label attaches to the pull request already. The primary quantity is therefore
+
+```
+precision_PR = |accused ∧ annotated ∧ label positive| / |accused ∧ annotated|
+```
+
+We do not lower their labels to the claim level, because that would require re-annotation by
+us, which reinstates our own panel and destroys the only property this design was chosen for.
+
+**What the conversion costs, stated in the direction it costs it:**
+
+1. **False credit, and it runs in our favour.** A pull request may be labelled misaligned for a
+   reason entirely unrelated to the path our sentence named. The join scores our accusation as
+   upheld anyway. This inflates our number.
+2. **Resolution loss.** Corpus-wide, 1,344 accusations collapse onto 1,197 pull requests
+   (`flag_rate.json`); held-out, 951 onto 858. Roughly one accused pull request in nine carries
+   more than one accusation and they are scored as one item.
+3. **A deflating direction exists and is weaker.** A pull request whose description is
+   misleading about one file but sound overall may have been labelled aligned, scoring a
+   correct accusation of ours as wrong. Their annotation instrument judges the whole
+   description, so this is real; we judge it the smaller of the two effects and we do not know
+   that, and saying we do not know it is the point.
+
+**The discipline this buys, committed now: every precision produced by this design is a
+per-pull-request figure and is an UPPER BOUND on our per-claim precision, and it is printed
+with the words "per-PR, upper bound" attached to it.** Not in a footnote. In the sentence. It
+is not comparable to the 0.16 of `v14_adjudication.json`, which is per claim, and no document
+of ours may chart the two together or describe either as a movement from the other.
+
+**One report-only concordance measure.** Their per-PR packets carry each annotator's free-text
+reason. For each joined item we record, mechanically, whether the accused path string appears
+in the consensus reason text. This is a **count**, published as a count, and it is **not** a
+claim-level precision, **not** a correction factor for effect 1 above, and may not be used to
+adjust any figure. It exists so a reader can see how often the human was looking at the same
+file we were.
+
+---
+
+## THE ARM SPLIT — their decomposition applied to us
+
+Their headline blends two instruments with wildly different difficulty: accusing a pull request
+that changed no files at all scores **0.965** over 230 items; accusing one that contains a real
+diff scores **0.136 strict** over 176 (`external_citations.json`, recomputed from their
+published files, not a number their paper reports).
+
+We will not repeat that blend. **Joined items are split by whether the pull request has a
+non-empty reconstructed diff on our side, and the two arms are reported separately and never
+pooled without both being visible.** The headline is the non-trivial arm.
+
+An expectation, recorded before counting: our eligibility rule requires at least one
+reconstructable changed-file record, so the trivial arm should be close to empty. **If it is
+not empty, that is a finding about our eligibility filter and is published as one** — it would
+mean our corpus admits pull requests whose diff is effectively absent, which would matter to
+every number EXTERNAL-1 and V14 published.
+
+---
+
+## The reporting grid, fixed now
+
+Three binary dimensions, all preregistered, all published in one table in the result:
+
+- arm: **post-repair (V13+V14)** × **unrepaired**
+- mapping: **strict** × **loose**
+- split: **HELD-OUT** × **DEVELOPMENT**
+
+and within each, the trivial and non-trivial diff arms shown separately. **Every cell publishes,
+including the empty ones and the underpowered ones, with its N.**
+
+**The headline cell is named now: post-repair × strict × HELD-OUT × non-trivial diff.** That is
+the cell that corresponds to the instrument RESULT_v14 measured, on the split
+`SPLIT_external_corpus_2026_08_31.md` rule 2 requires, under the conservative mapping, on the
+arm that is not trivially easy. Pooled figures may appear only beside the grid, never instead
+of it.
+
+---
+
+## THE EXTRACTION GATE — the leg this lab has never measured
+
+Every precision this lab has published measures **adjudication**: given that we called this
+sentence a claim about this path, was our verdict right? Not one of them measures
+**extraction**: was the sentence a claim about that path at all?
+
+The two compose, and the composition is the whole of what a reader means by precision:
+
+```
+P(accusation correct) = P(the sentence asserted this path changed) x P(verdict right | it did)
+```
+
+A sentence that asserted nothing yields a wrong accusation no matter how good the adjudicator
+is, so **precision is bounded above by extraction validity**. We have been reporting the second
+factor and letting it be read as the product. `PREREG_evidence_leg_2026_09_01.md` already
+commits this lab to two panels rather than one before any future accusing verdict; this
+document carries the extraction panel itself, and we know of no earlier preregistration of ours
+that did.
+
+**Third-party labels cannot measure this leg.** Their annotation is about a pull request, not
+about our sentence; there is no claim-level or sentence-level annotation anywhere in their
+corpus. So the extraction leg is measured by a panel of ours, and the honest reading of this
+document is that **its adjudication leg is third-party and its extraction leg is not** — which
+is the weakest joint in the design and is named here rather than discovered later.
+
+**The protocol, frozen.**
+
+- **Items.** Every joined accusation in the grid, at claim level rather than PR level — the one
+  place the per-claim unit survives. If the joined set exceeds 100 claims, a uniform random
+  subsample of 100 with **seed 20260901**, committed in this document.
+- **The diff is WITHHELD.** The seat sees the sentence and the claimed path and nothing else.
+  A seat that can see the diff will answer the adjudication question instead of the extraction
+  question, and the two legs would stop being separable.
+- **The question, exactly one per item.** *Does this sentence assert that this path was changed
+  by this pull request in the way named?* Answers: **ASSERTS** / **DOES NOT ASSERT** /
+  **CANNOT TELL FROM THE SENTENCE ALONE**. CANNOT TELL counts as not-extracted — the
+  conservative direction, against us.
+- **Three seats per item, majority.** Any item returning fewer than three seats is disclosed
+  with its item id and its seat count, in the result, by name. V14 shipped three items
+  adjudicated by two seats and disclosed it after the fact; here the disclosure obligation is
+  written before the batches run.
+- **30 sealed decoys**, shuffled in: 15 constructed sentences that plainly assert a path
+  changed, 15 that plainly mention a path without asserting any change to it — the
+  mention-versus-use boundary this lab has now found in four other instruments and in its own
+  OATH verifier. **Fewer than 27 of 30 correct voids the extraction measurement with no headline
+  number**, exactly as in EXTERNAL-1 and V14.
+- **Key digest committed publicly before any item is judged**, the `v14_key_digest.txt`
+  pattern.
+
+**Threshold, fixed now: extraction validity ≥ 0.90.** Below that, more than one accused
+sentence in ten was not making the claim we accused it of, and the instrument is defective in a
+way no adjudication figure can repair. Below that, the adjudication figure still publishes but
+**publishes conditioned** — as a precision over extracted claims, with the extraction validity
+printed immediately beside it and the product printed after both.
+
+---
+
+## Power, and an asymmetry recorded before the counting
+
+Exact binomial arithmetic against the 0.95 floor, derived in this document, computed before any
+item exists:
+
+- **Refuting the floor is cheap.** At N = 12 joined items, any observation at or below 9 upheld
+  (0.75) rejects `p ≥ 0.95` at one-sided α = 0.05 (P(K ≤ 9 | n=12, p=0.95) = 0.0196). At N = 20
+  the rejection region reaches 16/20; at N = 30 it reaches 25/30.
+- **Establishing the floor is expensive.** A one-sided 95% Clopper–Pearson lower bound reaches
+  0.95 only on a **perfect record of at least 59 items** — 0.05^(1/59) = 0.9505, while
+  0.05^(1/58) = 0.9497. Fifty-eight consecutive upheld accusations are not enough.
+
+**This design can fail our instrument on a dozen items and cannot vindicate it on fewer than
+fifty-nine.** That asymmetry is a property of the arithmetic, not of anyone's intentions, and it
+is written down now so that a thin overlap producing a refutation is not read as a rigged
+result, and a thin overlap producing a clean record is not read as a vindication.
+
+---
+
+## Gates — thresholds committed now
+
+- **G-J0 (provenance and licence), blocking.** The join runs against a **pinned commit SHA** of
+  `gjz78910/PR-MCI`, recorded in the result before the run. Their files are read from a scratch
+  path outside this repository. **No file of theirs, and no row, packet, or annotation text of
+  theirs, is committed to this repository, embedded in a capsule, or redistributed in any
+  artifact of ours.** Receipts carry derived counts, our item ids, and citations. A violation
+  means the measurement does not publish at all.
+- **G-J1 (join integrity), blocking.** The key is the normalised `(owner, repo, number)` triple
+  above. Where both sides carry a pull request id, the two keys must agree on every joined pair;
+  disagreements void the pair and the voided count publishes. **If their files carry no
+  resolvable identifier, the join publishes UNCHECKABLE** and no precision appears.
+- **G-J2 (overlap tiers), blocking on what may be printed.** Let N be the joined item count in
+  the headline cell. **N ≥ 30**: a precision point estimate publishes, with an exact
+  Clopper–Pearson interval. **12 ≤ N < 30**: the counts and the interval publish; **no point
+  estimate appears in any headline, abstract, or summary line**. **N < 12**: no precision of any
+  kind, in any cell; the overlap is the finding. No panel of ours is substituted under this
+  document's name at any tier.
+- **G-J3 (mapping discipline), blocking on publication.** Strict and loose appear together
+  everywhere a precision appears. A draft carrying one without the other does not ship.
+- **G-J4 (unit discipline), blocking on publication.** Every precision from this design is
+  labelled **per-PR, upper bound on per-claim precision**, in the sentence carrying it. No
+  document of ours charts it against the per-claim 0.16 of `v14_adjudication.json` or describes
+  a change between them.
+- **G-J5 (arm split).** Trivial-diff and non-trivial-diff arms reported separately with their
+  Ns. Pooled figures may not stand alone.
+- **G-J6 (extraction), blocking on any revival.** Extraction validity **≥ 0.90**, measured by
+  the panel above, with **≥ 27 of 30 decoys correct** or the extraction measurement voids with
+  no headline. Below 0.90, the adjudication figure publishes conditioned and the class stays
+  retired regardless of what the adjudication figure says.
+- **G-J7 (floor claims).** A statement that the 0.95 floor is **refuted** must print the exact
+  one-sided p-value beside it. A statement that the floor is **met** requires a one-sided 95%
+  Clopper–Pearson lower bound at or above 0.95 — at minimum a perfect record over 59 items.
+  Nothing in between licenses either sentence.
+- **G-J8 (this measurement cannot revive the class on its own).** RESULT_v14 retired the
+  path-claim accuser and committed this lab to not repairing it again. **A favourable result
+  here does not re-enable it.** Re-enabling requires all of: the headline cell clearing G-J7's
+  *met* condition, G-J6 passing at ≥ 0.90, and a **new preregistration** written after this
+  result is published and frozen before that code is written. The four `xfail(strict=True)`
+  markers guarding the catches EXTERNAL-1 gave up are revisited in the same commit as any
+  re-enabling, so that it cannot happen silently.
+
+---
+
+## What result means we do not ship
+
+- **The join is UNCHECKABLE** (no resolvable identifier on their side): we publish that, and
+  the strongest measurement available to this lab is recorded as unavailable.
+- **N < 12 in the headline cell**: no precision publishes. The overlap is the finding, with the
+  diagnostics attached, and this preregistration closes without a number.
+- **The headline cell refutes the floor** (which the expected overlap makes the most likely
+  outcome that produces a number at all): the class stays retired, and this is **not** a fourth
+  repair cycle. There is no repair proposal in this document and none may be attached to its
+  result.
+- **Extraction validity below 0.90**: the class stays retired regardless of the adjudication
+  figure, and the finding is that our sentences were not the claims we treated them as.
+- **The licence question is not settled in our favour**: nothing publishes that reproduces any
+  part of their data, whatever it would have shown.
+- **Their labels turn out unresolvable to a consensus per pull request** (missing, conflicted,
+  or absent for part of the 974): the affected items are excluded, counted, and published as
+  excluded, and an excluded item is never scored as a pass.
+
+---
+
+## The commitment to publish the failure
+
+In the words the preregistrations before this one used, unchanged:
+
+**Both outcomes publish under the same seal as a success, per the charter, and the failure
+capsule ships next to the others.** A failure publishes **under its own name, at the same speed
+as the failures before it**, with the counts attached. The result of this preregistration is
+written and published whether the third party's labels uphold this instrument, refute it, or
+never reach it at all — and the most likely of those three, on the arithmetic above, is the
+third.
+
+---
+
+## Honest limits
+
+Every one of these is load-bearing and none of them is discovered later.
+
+- **Their labels are not ground truth.** They are two annotators' consensus, produced by the
+  authors of the instrument the annotations were built to validate. Third-party relative to
+  *us* is the property we are buying; disinterested in absolute terms is not a property anyone
+  has here.
+- **Their annotators saw a packet, not the repository.** Each per-PR packet carries the
+  description and the unified diff. An annotator could not check whether a path exists
+  elsewhere in the tree, could not run anything, and could not consult history. Their view is
+  strictly narrower than the view our accusation implicitly claims to have, and on some items
+  that narrowness will cut against us and on others for us.
+- **`partial` is doing real work.** 167 of their 432 positives. The strict/loose spread is not a
+  robustness check we are performing out of caution; it is the honest width of the answer.
+- **Their annotated set is enriched by their own detector.** 374 of the 974 are that detector's
+  flags, and the enrichment is severe: their headline phantom-changes rate of 45.4% falls to
+  9.7% inside the unenriched 600-PR validation batch (`external_citations.json`). **Joined
+  items are therefore reported split by source batch — validation-600 versus enriched-374 —
+  and never pooled without the split visible.** A precision computed over an enriched population
+  is not a corpus precision and will not be called one.
+- **Their repository carries NO LICENSE.** Read and cite; never redistribute. This constrains
+  what our result can show a reader, and the constraint is real: a reader wanting to check our
+  join must fetch their files themselves.
+- **A discrepancy in their Table 1 that we noticed and have not resolved with them.** The paper
+  states an operating threshold of 0.61 while printing precision 0.742 / recall 0.548 /
+  F1 0.630, which their own `validation/validation_metrics.json` labels as the 0.60 operating
+  point; at the deployed 0.61 our sweep reproduces 0.719 / 0.548 / 0.622
+  (`external_citations.json`, `THRESHOLD_DISCREPANCY`). We cite 0.742 **as reported**, never as
+  the deployed operating point. We have not contacted the authors, we do not assert which they
+  intended, and this observation is not evidence about the quality of their annotations, which
+  is the only part of their work this measurement depends on.
+- **Their AIDev version is unnamed.** The paper names no version, tag, or snapshot date. A join
+  failure caused by a snapshot mismatch is indistinguishable from a genuine non-overlap except
+  through the diagnostics above, and even those cannot fully separate the two.
+- **Whether their annotators were blind to their detector's score is unverified.** Their
+  sampling script says scores were used for stratification only, and three packets our sweep
+  read carried no score — three of 974. The 374 batch consists entirely of flagged pull
+  requests, which is itself a selection.
+- **Our accused set is a post-repair residual.** Two accusation-removing repairs, designed on
+  the development bucket, ran before the accusations this join will score existed. If those
+  repairs generalised at all, the survivors are enriched for the false-accusation shapes we
+  could not name (`ANALYSIS_base_rate_ceiling_2026_09_01.md`, §7). That is a reason this design's
+  number could be low that has nothing to do with their labels.
+- **The extraction leg is ours.** The design's central virtue does not extend to it, and G-J6 is
+  measured by a panel with exactly the stake this document was written to escape.
+- **This measures one snapshot, of five agents, in one window, on one corpus**, and it says so
+  wherever the numbers appear. It says nothing about whether the changed code is correct.
+  Coverage is not correctness; correctness was never the claim.
+
+---
+
+## Receipts this document stands on
+
+Every threshold above is fixed by the figures below and by nothing else. No figure below is a
+result of this preregistration, which has none.
+
+**Ours, published and certified**
+
+- `v14_gates.json` — 71,016 PRs scored; 4,427 unrepaired accusations, 1,344 after V13+V14;
+  development bucket 15,617 PRs, 1,299 → 393.
+- `v14_adjudication.json` — held-out, 100 scored, 16 upheld, precision 0.16, 30/30 decoys,
+  `G_S3_pass` false.
+- `external1_adjudication.json` — 100 scored, 23 upheld, precision 0.23, 30/30 decoys.
+- `RESULT_v14_naming_the_defects_did_not_save_it_2026_09_01.md`,
+  `PREREG_v14_repair_2026_08_31.md`, `PREREG_external1_aidev_2026_08_31.md`,
+  `SPLIT_external_corpus_2026_08_31.md`, `PREREG_evidence_leg_2026_09_01.md`.
+
+**Ours, uncertified, reconciling with the above**
+
+- `flag_rate.json` — per-PR flag rates by split; corpus-wide 1,197 accused of 71,016 (0.01686)
+  and 1,344 accusations; held-out 858 of 55,399 (0.015488) and 951 accusations; development 339
+  of 15,617 and 393 accusations.
+- `external1_shelf.sqlite` — 71,677 shelved pull requests, 6,673 distinct repository URLs, join
+  fields `pr.html_url` and `pr.id`. **Structure, read before this freeze; not an outcome.**
+
+**External, second-hand, transcribed or recomputed by our sweep from the authors' published
+files on 2026-09-01, and recorded in `external_citations.json`**
+
+- 23,247 analysed PRs; 974 annotated (600 validation + 374 enriched); 432 partial-or-misaligned
+  (167 partial, 265 misaligned); 406 detector flags, all annotated.
+- Arm decomposition: zero-diff arm 230 items at 0.965; real-diff arm 176 items at 0.136 strict.
+- Taxonomy: 196/432 phantom_changes with 194/196 literally empty diffs.
+
+**External, second-hand, NOT PRESENT IN `external_citations.json` — asserted in prose only,
+and each must gain a receipt field before this preregistration's result publishes**
+
+- The real-diff arm's LOOSE precision, 0.591 over 176 items.
+- The taxonomy counts 13/432 `misleading_specifics` and the 38.8% `understated_scope` share.
+
+These are load-bearing here — the first fixes the width of the strict/loose spread that G-J3
+exists to enforce, the second sizes the deferred construct-matched reading — and a
+load-bearing number whose only home is prose is the defect this lab keeps finding in itself.
+- Threshold/metric discrepancy: 0.61 stated, 0.742/0.548/0.630 printed, 0.719/0.548/0.622
+  reproduced at 0.61.
+- Repository licence: none found.
+
+**Derived in this document from the receipts above, and marked as derived wherever used**
+
+- Expected joined-accusation counts (≈16.4 / ≈12.8 held-out post-repair over all 974; ≈54 /
+  ≈42 held-out unrepaired under the stated accusations-per-PR assumption).
+- The exact binomial thresholds: refutation region 9/12 at N=12, 16/20 at N=20, 25/30 at N=30;
+  Clopper–Pearson one-sided lower bound 0.05^(1/59) = 0.9505 versus 0.05^(1/58) = 0.9497.
+
+**Not measured by anyone, and not resolved by this design**
+
+- Our per-claim precision against third-party labels. This design cannot produce one without
+  re-annotation, and re-annotation would return the adjudication to us.
+- Extraction validity for any instrument this lab has published, prior to G-J6.
+- Whether their 974 are present in our shelf at all.
+
+---
+
+*Every precision this lab has published was scored by a panel this lab convened. This one will
+not be, and the design is therefore the strongest available to us — which is why its label
+mapping, its arm, its split, its unit conversion, and its headline cell are all nailed down in
+this document rather than chosen once the overlap is counted. The arithmetic says the overlap is
+likely to be small. If it is too small, that is the result we publish, and we know of no reading
+of our own standards under which substituting our own panel for it would be honest.*

--- a/papers/closed-model-frontier/RESULT_extraction_ceiling_REFUTED_2026_09_01.md
+++ b/papers/closed-model-frontier/RESULT_extraction_ceiling_REFUTED_2026_09_01.md
@@ -1,0 +1,115 @@
+# RESULT — the extraction ceiling is REFUTED, and the decomposition that named it is incomplete
+
+Fathom Lab · 2026-09-01 · Scored by `score_extraction_panel.py`, which was **committed at
+`b8b52a1` while the panel was still running and before any answer existed**. Gates transcribed
+from `PREREG_extraction_ceiling_2026_09_01.md` (v1, frozen `38ab585`) and
+`PREREG_extraction_ceiling_v2_2026_09_01.md` (G-E1 only, frozen `308490d`). Receipts:
+`extraction_panel_result.json`, `extraction_panel_raw.json`, `extraction_panel_packet.json`
+(sha256 `febd781e…`), `extraction_decoys.json` (sha256 `6a491480…`).
+
+## VERDICT: `REFUTED`
+
+Every gate passed. The hypothesis lost.
+
+| gate | bar | observed | |
+|---|---|---|---|
+| G-E1a reliability, overall | >= 27/30 | **30/30** | pass |
+| G-E1b each side separately | >= 9/15 each | **15/15 CLAIM, 15/15 NOT-A-CLAIM** | pass |
+| G-E2 reconciliation | re-derive 0.16 | **0.1600** | pass |
+| panel split | <= 0.10 | **0.0** | pass |
+
+**E = 0.55  ·  A = 0.20  ·  P = 0.16**
+
+Of 100 held-out path accusations, the panel found **55 were made about a sentence that really was
+claiming this change touched that path**. Of those 55, only **11 were upheld** by the key
+committed before any of this existed.
+
+---
+
+## What the frozen bar said, and what it says now
+
+v1's G-E3, fixed before the packet was opened:
+
+> **E >= 0.40 — REFUTED.** The claims were real and the gate misjudged them. Extraction does not
+> exculpate the adjudicator, and V14's 0.16 remains unexplained. Published as a failed hypothesis
+> of ours.
+
+E = 0.55. **That cell, and the obligation in it, is what happened.**
+
+The morning's hypothesis was that three repair cycles had been spent on the wrong layer — that
+the adjudicator was sound and extraction was the binding constraint. **It is not.** A = 0.20
+means that even when the author genuinely was claiming to have touched the path, the gate's
+accusation was wrong four times in five. The adjudicator is bad on its own merits.
+
+**V14's 0.16 remains unexplained.** It was unexplained this morning, an extraction account was
+offered, the account was tested, and it failed. The account is now closed rather than open.
+
+---
+
+## The finding nobody preregistered: the decomposition is incomplete
+
+`0.55 x 0.20 = 0.11`. The reconciled precision is `0.16`. **The identity `P = E x A` does not
+close**, and the gap is not rounding.
+
+Sixteen accusations were upheld. Only **eleven** of them sit among the 55 CLAIM items. **Five
+upheld accusations landed on sentences the panel says were making no claim at all.** So
+
+```
+P  =  E·A  +  (1 - E)·A'
+0.16  =  0.55(0.200)  +  0.45(0.111)
+      =  0.110        +  0.050
+```
+
+`P = E x A` silently assumed `upheld ⊆ CLAIM` — that an accusation cannot be upheld against a
+sentence that was not asserting anything. That assumption is false in this corpus at a rate of
+`A' = 5/45 = 0.111`, and it was carried unstated through every document written today, including
+the two preregistrations, the addendum, and the corpus survey.
+
+Either the two panels disagree about those five items, or an accusation can be "right" about a
+diff while being aimed at prose that made no claim. **Both readings are damaging to the framework
+and neither is resolved here.** The corrected identity above is stated, not tested; a successor
+would have to preregister `A'` as a quantity in its own right.
+
+---
+
+## Honest limits — and the first one is severe
+
+**Three seats of the same model on the same prompt are not three independent judges.** The panel
+was unanimous on **130 of 130 items**, including every accusation. A split rate of exactly zero
+is not evidence of reliability; it is evidence of correlation. The multi-seat structure bought
+much less here than the gate-passing suggests, and G-E1's 30/30 should be read with that in mind.
+
+**The NOT-A-CLAIM decoys are ours, and 15/15 suggests they were easy.** `PREREG v2` said this in
+advance: *"if the frames are too easy, G-E1 is passed by a panel that would not survive a real
+ambiguous case, and E inherits that looseness."* A perfect score on authored decoys is the
+outcome that clause was written about. E = 0.55 is therefore an estimate from a panel whose
+demonstrated competence is on easy items only.
+
+**This does not satisfy the standing commitment.** The commitment is a *blind* panel; this panel
+is blind to the verdicts but is not independent of the lab. It was convened, instructed and
+scored by us, on our sample, with decoys we wrote. It is a measurement. It is not the
+measurement the commitment demands.
+
+**E = 0.55 is not a licence to re-enable anything.** The retired path-accusation class stays
+retired. If anything this result argues harder for retirement: the accusing verdict is wrong on
+45% of the sentences it fires at *and* wrong on 80% of the ones where a claim really was made.
+
+**What is licensed:** that on this packet, judged by this panel, 45 of 100 accusations were aimed
+at sentences making no path claim; that of the 55 that were, 11 were upheld; and that these
+reconcile to the committed 0.16 through a two-term identity rather than the one-term identity
+this lab wrote down this morning.
+
+---
+
+## What today actually established
+
+Three preregistrations were frozen. Two runs voided —
+`ADDENDUM_extraction_ceiling_gate_unsatisfiable_2026_09_01.md` because its gate could not be
+built, `RESULT_open_set_read_VOID_2026_09_01.md` because its null gate ran and failed. This is
+the third, it completed, every gate passed, and **it refuted the hypothesis its own author spent
+the day building.**
+
+The extraction term is real and it is large — 45% of accusations are aimed at non-claims, which
+is a collateral figure worth having on its own. It is simply **not the explanation for 0.16**.
+Both layers of this instrument are broken, independently, and a repair that fixes only one of
+them would have been justified by an argument that this measurement has now removed.

--- a/papers/closed-model-frontier/extraction_census.json
+++ b/papers/closed-model-frontier/extraction_census.json
@@ -1,0 +1,1052 @@
+{
+ "what": "EXTRACTION census of the tests_pass template: of the sentences the regex fires on, how many are a claim being made",
+ "target_regex": "\\b(?:all\\s+)?tests\\s+(?:pass|are\\s+passing|green)\\b",
+ "target_source": "styxx/diffgate.py _TEMPLATES entry 'tests_pass'",
+ "not_measured_here": "adjudication. Every tests_pass verdict in this corpus is UNCHECKABLE (run=None), so no accusation exists to adjudicate. This file measures the step BEFORE the verdict.",
+ "population": {
+  "expected_eligible": 71016,
+  "observed_eligible": 71016,
+  "eligible_matches_flag_rate": true,
+  "skipped_reconstruction_roundtrip": 1,
+  "splitter_divergences_from_re_split": 0,
+  "expected_tests_pass_claims": {
+   "development": 1476,
+   "held_out": 4038,
+   "corpus_wide": 5514
+  },
+  "observed_matches": {
+   "development": 1476,
+   "held_out": 4038,
+   "corpus_wide": 5514
+  },
+  "expected_prs_with_tests_pass_claim": {
+   "development": 1236,
+   "held_out": 3402,
+   "corpus_wide": 4638
+  },
+  "observed_prs_with_match": {
+   "development": 1236,
+   "held_out": 3402,
+   "corpus_wide": 4638
+  },
+  "matches_reconcile_with_flag_rate": true
+ },
+ "mechanical": {
+  "status": "MECHANICAL \u2014 a pure function of the summary bytes, reproducible by anyone who runs this file",
+  "rules": {
+   "fenced_code_block": "the match's line lies between a line matching ^ {0,3}(`{3,}|~{3,}) and the next line closing with the same character at >= the opening length; the fence lines themselves are counted as inside",
+   "indented_code_block": "tabs expanded to 4; the line's leading spaces >= 4; it is not inside a fence; the previous line is blank or is itself indented code by this rule; and the nearest preceding non-blank line at indent < 4 is not a list-item marker (^ {0,3}([-*+]|\\d+[.)])\\s) \u2014 because 4-space indentation inside a list is continuation, not code",
+   "blockquote": "the match's line matches ^ {0,3}>",
+   "html_comment": "the match offset lies inside a <!-- ... --> span (DOTALL, non-greedy); an unterminated <!-- is NOT treated as a comment",
+   "task_list_item": "the match's line matches ^\\s*([-*+]|\\d+[.)])\\s+\\[( |x|X)\\]; the box character decides checked vs unchecked",
+   "link_title_or_url": "the match offset lies inside the [title] or (destination) span of a [..](..) link, inside a <http...> autolink, or inside a bare https?:// run",
+   "inline_code_span": "the match offset lies between two backtick runs of equal length on the same line, paired left to right",
+   "negation_cue_near": "a cue from the closed set (not/cannot/n't forms/never/no longer/fails to/unable to/without) occurs in the 40 characters of the same gate-sentence immediately before the match",
+   "negation_cue_in_sentence": "the same closed cue set, anywhere earlier in the same gate-sentence (reported alongside as the looser variant; the disjoint table uses the windowed form)"
+  },
+  "priority_for_the_disjoint_table": [
+   "html_comment",
+   "fenced_code_block",
+   "indented_code_block",
+   "blockquote",
+   "task_box_unchecked",
+   "task_box_checked",
+   "link_title_or_url",
+   "inline_code_span",
+   "negation_cue_near"
+  ],
+  "note": "mech_flags_any counts each flag independently and matches may carry several; mech_category assigns each match to exactly one bucket by the priority above. The headline unchecked-box number is the INDEPENDENT count, mech_flags_any.task_box_unchecked.",
+  "diagnostics_not_categories": {
+   "indented_ge4_spaces_naive": "the NAIVE indented-code rule (>= 4 leading spaces, outside a fence) with none of the CommonMark conditions. Reported so the cost of the list-continuation refusal is visible: the gap between this and indented_code_block is what the strict rule declined to call code, and it is almost entirely markdown list continuation, not code",
+   "backtick_somewhere_on_line": "the match's line contains a backtick at all. If this is large while inline_code_span is zero, the code-span detector is working and the matches simply sit outside the spans",
+   "url_somewhere_on_line": "the match's line contains an http(s) URL at all. Same purpose for link_url. Note the regex requires literal whitespace between 'tests' and 'pass', which URLs almost never contain \u2014 a zero here is expected from the pattern, not evidence of a bug",
+   "negation_cue_is_without_only": "of the negation_cue_near matches, those whose ONLY cue in the window is the word 'without'. See disclosed_defects"
+  },
+  "disclosed_defects": {
+   "negation_cue_near_over-fires_on_without": "'without' earns its place in the cue set for 'without modifying X', but it also fires on 'the solution builds without any warnings and all tests pass' \u2014 a sentence that ASSERTS. This is a false positive inside the group that is supposed to carry weight, so it is counted (negation_cue_is_without_only) rather than patched away. Subtract it from negation_cue_near for a conservative read",
+   "fence_lines_counted_as_inside": "the ``` line itself is counted as fenced. A match can only land there via the info string, which is vanishingly rare, but the choice is stated rather than hidden",
+   "blockquote_lazy_continuation_missed": "a blockquote continued lazily (a following line with no '>') is NOT detected. Such matches fall through to the residual and are therefore counted against us, not for us",
+   "task_item_continuation_lines_missed": "the box state is read from the line containing the match. A match on a continuation line under a task item is not attributed to that item's box, so the unchecked-box count is a LOWER bound"
+  }
+ },
+ "judgment": {
+  "status": "UNVALIDATED",
+  "warning": "This group is a regex approximating a human judgment. That is exactly the class of instrument this lab measured at 0.16 held-out precision (RESULT_v14). It has had NO blind panel. It MUST NOT be quoted as a precision, as a false-extraction rate, or as any figure that decides anything. It is a hypothesis generator and nothing else.",
+  "priority_for_the_disjoint_table": [
+   "self_disclosed_failure",
+   "conditional_or_future",
+   "scoped_to_authors_machine",
+   "scoped_to_a_subset"
+  ],
+  "applied_to": "only the matches carrying no mechanical flag (mech_category == no_mechanical_flag)",
+  "where_the_numbers_live": {
+   "keys": [
+    "judgment_UNVALIDATED_flags_any",
+    "judgment_UNVALIDATED_category"
+   ],
+   "counts_under": "counts_UNVALIDATED",
+   "examples_prefixed": "JUDGMENT_UNVALIDATED:",
+   "in_each_of": [
+    "development",
+    "held_out",
+    "corpus_wide"
+   ]
+  },
+  "why_the_keys_are_named_that_way": "An earlier emission of this file marked judgment.status UNVALIDATED at the top level only, while the per-split counts sat under a bare `judgment_category` map. A consumer reading d['held_out']['judgment_category'] saw no marker and could quote the number with nothing attached to it. A sibling status field beside the map would not have fixed that, because the careless read never touches the sibling. So the marker is in the KEY NAMES, which cannot be reached without being typed, and the status string is repeated inside the value so that a dump of any level of the path still carries it. The key names changed in this emission; that is a deliberate break for any consumer indexing the old names.",
+  "known_defects_found_by_reading_its_own_output": {
+   "self_disclosed_failure_fires_on_paths": "the cue 'error\\w*' matched inside a file path in 'Verified all tests pass with `yarn test src/elements/common/error-boundary/__tests__/`'. A path is not a disclosure. Left in place, disclosed, because hand-patching an unvalidated classifier until its output looks right is the failure mode this lab is trying to stop",
+   "self_disclosed_failure_fires_on_flaky": "'All tests pass, including the previously flaky test' is labelled a self-disclosed failure; a reader might call it an assertion. This label is contested and unadjudicated",
+   "scoped_to_a_subset_is_the_largest_and_the_weakest": "it is the biggest bucket and it rests entirely on the single word before 'tests' against a hand-written stoplist. 'Verified existing tests pass' and 'All 21 unit tests pass' both land here and they are not obviously the same thing. This number in particular must not leave the file"
+  },
+  "stoplist_verbatim": [
+   "a",
+   "again",
+   "all",
+   "also",
+   "an",
+   "and",
+   "as",
+   "because",
+   "but",
+   "if",
+   "its",
+   "my",
+   "now",
+   "or",
+   "our",
+   "since",
+   "so",
+   "still",
+   "that",
+   "the",
+   "their",
+   "then",
+   "these",
+   "this",
+   "those",
+   "when",
+   "where",
+   "while"
+  ]
+ },
+ "development": {
+  "matches": 1476,
+  "prs_with_match": 1236,
+  "mech_flags_any": {
+   "html_comment": 2,
+   "fenced_code_block": 19,
+   "indented_code_block": 0,
+   "blockquote": 23,
+   "task_box_unchecked": 54,
+   "task_box_checked": 157,
+   "link_title_or_url": 0,
+   "inline_code_span": 0,
+   "negation_cue_near": 4,
+   "no_mechanical_flag": 1220,
+   "task_list_item": 211,
+   "negation_cue_in_sentence": 5,
+   "link_title": 0,
+   "link_url": 0,
+   "in_title": 0,
+   "indented_ge4_spaces_naive": 0,
+   "backtick_somewhere_on_line": 112,
+   "url_somewhere_on_line": 4,
+   "negation_cue_is_without_only": 2
+  },
+  "mech_category": {
+   "html_comment": 2,
+   "fenced_code_block": 19,
+   "indented_code_block": 0,
+   "blockquote": 23,
+   "task_box_unchecked": 53,
+   "task_box_checked": 156,
+   "link_title_or_url": 0,
+   "inline_code_span": 0,
+   "negation_cue_near": 3,
+   "no_mechanical_flag": 1220
+  },
+  "judgment_UNVALIDATED_flags_any": {
+   "status": "UNVALIDATED \u2014 a regex approximating a human reading, with NO blind panel. These counts are NOT a precision, NOT a false-extraction rate, and decide nothing. See .judgment.warning in this file before quoting any of them.",
+   "counts_UNVALIDATED": {
+    "self_disclosed_failure": 122,
+    "conditional_or_future": 70,
+    "scoped_to_authors_machine": 26,
+    "scoped_to_a_subset": 778
+   }
+  },
+  "judgment_UNVALIDATED_category": {
+   "status": "UNVALIDATED \u2014 a regex approximating a human reading, with NO blind panel. These counts are NOT a precision, NOT a false-extraction rate, and decide nothing. See .judgment.warning in this file before quoting any of them.",
+   "counts_UNVALIDATED": {
+    "self_disclosed_failure": 122,
+    "conditional_or_future": 60,
+    "scoped_to_authors_machine": 21,
+    "scoped_to_a_subset": 670,
+    "bare_unqualified_assertion": 347
+   }
+  },
+  "residual_matches": 1220
+ },
+ "held_out": {
+  "matches": 4038,
+  "prs_with_match": 3402,
+  "mech_flags_any": {
+   "html_comment": 5,
+   "fenced_code_block": 48,
+   "indented_code_block": 1,
+   "blockquote": 70,
+   "task_box_unchecked": 125,
+   "task_box_checked": 435,
+   "link_title_or_url": 0,
+   "inline_code_span": 0,
+   "negation_cue_near": 7,
+   "no_mechanical_flag": 3360,
+   "task_list_item": 560,
+   "negation_cue_in_sentence": 47,
+   "link_title": 0,
+   "link_url": 0,
+   "in_title": 1,
+   "indented_ge4_spaces_naive": 2,
+   "backtick_somewhere_on_line": 260,
+   "url_somewhere_on_line": 6,
+   "negation_cue_is_without_only": 1
+  },
+  "mech_category": {
+   "html_comment": 5,
+   "fenced_code_block": 48,
+   "indented_code_block": 1,
+   "blockquote": 69,
+   "task_box_unchecked": 122,
+   "task_box_checked": 432,
+   "link_title_or_url": 0,
+   "inline_code_span": 0,
+   "negation_cue_near": 1,
+   "no_mechanical_flag": 3360
+  },
+  "judgment_UNVALIDATED_flags_any": {
+   "status": "UNVALIDATED \u2014 a regex approximating a human reading, with NO blind panel. These counts are NOT a precision, NOT a false-extraction rate, and decide nothing. See .judgment.warning in this file before quoting any of them.",
+   "counts_UNVALIDATED": {
+    "self_disclosed_failure": 306,
+    "conditional_or_future": 209,
+    "scoped_to_authors_machine": 37,
+    "scoped_to_a_subset": 2310
+   }
+  },
+  "judgment_UNVALIDATED_category": {
+   "status": "UNVALIDATED \u2014 a regex approximating a human reading, with NO blind panel. These counts are NOT a precision, NOT a false-extraction rate, and decide nothing. See .judgment.warning in this file before quoting any of them.",
+   "counts_UNVALIDATED": {
+    "self_disclosed_failure": 306,
+    "conditional_or_future": 172,
+    "scoped_to_authors_machine": 26,
+    "scoped_to_a_subset": 1969,
+    "bare_unqualified_assertion": 887
+   }
+  },
+  "residual_matches": 3360
+ },
+ "corpus_wide": {
+  "matches": 5514,
+  "prs_with_match": 4638,
+  "mech_flags_any": {
+   "html_comment": 7,
+   "fenced_code_block": 67,
+   "indented_code_block": 1,
+   "blockquote": 93,
+   "task_box_unchecked": 179,
+   "task_box_checked": 592,
+   "link_title_or_url": 0,
+   "inline_code_span": 0,
+   "negation_cue_near": 11,
+   "no_mechanical_flag": 4580,
+   "task_list_item": 771,
+   "negation_cue_in_sentence": 52,
+   "link_title": 0,
+   "link_url": 0,
+   "in_title": 1,
+   "indented_ge4_spaces_naive": 2,
+   "backtick_somewhere_on_line": 372,
+   "url_somewhere_on_line": 10,
+   "negation_cue_is_without_only": 3
+  },
+  "mech_category": {
+   "html_comment": 7,
+   "fenced_code_block": 67,
+   "indented_code_block": 1,
+   "blockquote": 92,
+   "task_box_unchecked": 175,
+   "task_box_checked": 588,
+   "link_title_or_url": 0,
+   "inline_code_span": 0,
+   "negation_cue_near": 4,
+   "no_mechanical_flag": 4580
+  },
+  "judgment_UNVALIDATED_flags_any": {
+   "status": "UNVALIDATED \u2014 a regex approximating a human reading, with NO blind panel. These counts are NOT a precision, NOT a false-extraction rate, and decide nothing. See .judgment.warning in this file before quoting any of them.",
+   "counts_UNVALIDATED": {
+    "self_disclosed_failure": 428,
+    "conditional_or_future": 279,
+    "scoped_to_authors_machine": 63,
+    "scoped_to_a_subset": 3088
+   }
+  },
+  "judgment_UNVALIDATED_category": {
+   "status": "UNVALIDATED \u2014 a regex approximating a human reading, with NO blind panel. These counts are NOT a precision, NOT a false-extraction rate, and decide nothing. See .judgment.warning in this file before quoting any of them.",
+   "counts_UNVALIDATED": {
+    "self_disclosed_failure": 428,
+    "conditional_or_future": 232,
+    "scoped_to_authors_machine": 47,
+    "scoped_to_a_subset": 2639,
+    "bare_unqualified_assertion": 1234
+   }
+  },
+  "residual_matches": 4580
+ },
+ "examples": {
+  "JUDGMENT_UNVALIDATED:self_disclosed_failure": [
+   {
+    "split": "development",
+    "url": "https://github.com/marimo-team/marimo/pull/3290",
+    "matched_text": "tests pass",
+    "sentence": "- Frontend tests pass (93/94 files, with only unrelated snapshot failures in data-frames plugin)",
+    "line": "- Frontend tests pass (93/94 files, with only unrelated snapshot failures in data-frames plugin)"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/crewAIInc/crewAI/pull/1815",
+    "matched_text": "All tests pass",
+    "sentence": "All tests pass except for expected OpenAI connection errors.",
+    "line": "All tests pass except for expected OpenAI connection errors."
+   },
+   {
+    "split": "development",
+    "url": "https://github.com/marimo-team/marimo/pull/3485",
+    "matched_text": "All tests pass",
+    "sentence": "- All tests pass, including the previously flaky test",
+    "line": "- All tests pass, including the previously flaky test"
+   },
+   {
+    "split": "development",
+    "url": "https://github.com/liam-hq/liam/pull/721",
+    "matched_text": "tests pass",
+    "sentence": "- Verified E2E tests pass locally with updated schema (19 passed, 1 failed, 5 skipped)",
+    "line": "- Verified E2E tests pass locally with updated schema (19 passed, 1 failed, 5 skipped)"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/wix/react-native-ui-lib/pull/3515",
+    "matched_text": "all tests pass",
+    "sentence": "- No critical issues found - all tests pass (907/913) with only 2 unrelated test suite failures",
+    "line": "- No critical issues found - all tests pass (907/913) with only 2 unrelated test suite failures"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/box/box-ui-elements/pull/3984",
+    "matched_text": "all tests pass",
+    "sentence": "- Verified all tests pass with `yarn test src/elements/common/error-boundary/__tests__/`",
+    "line": "- Verified all tests pass with `yarn test src/elements/common/error-boundary/__tests__/`"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/box/box-ui-elements/pull/3992",
+    "matched_text": "all tests pass",
+    "sentence": "- Fixed type errors and ensured all tests pass",
+    "line": "- Fixed type errors and ensured all tests pass"
+   },
+   {
+    "split": "development",
+    "url": "https://github.com/calcom/cal.com/pull/21217",
+    "matched_text": "All tests pass",
+    "sentence": "All tests pass, including the previously failing tests for GMT-11 browsing scenarios with IST timezone schedules.",
+    "line": "All tests pass, including the previously failing tests for GMT-11 browsing scenarios with IST timezone schedules. The changes ensure that half-hour slots (04:30, 05:30, etc.) are correctly generated f"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/dotnet/aspnetcore/pull/62085",
+    "matched_text": "tests pass",
+    "sentence": "The Components project builds successfully after this change, and the tests pass, indicating that the change doesn't break any functionality.",
+    "line": "After investigating the code, I confirmed that there are no dependencies on internal types from the Components assembly in the Server project. The Components project builds successfully after this cha"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/elsa-workflows/elsa-core/pull/6686",
+    "matched_text": "all tests pass",
+    "sentence": "- Test runs fail with errors even though all tests pass",
+    "line": "- Test runs fail with errors even though all tests pass"
+   }
+  ],
+  "JUDGMENT_UNVALIDATED:bare_unqualified_assertion": [
+   {
+    "split": "held_out",
+    "url": "https://github.com/crewAIInc/crewAI/pull/1818",
+    "matched_text": "All tests pass",
+    "sentence": "- All tests pass with the new changes",
+    "line": "- All tests pass with the new changes"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/crewAIInc/crewAI/pull/1820",
+    "matched_text": "All tests pass",
+    "sentence": "- All tests pass with the new changes",
+    "line": "- All tests pass with the new changes"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/whitphx/vscode-emacs-mcx/pull/2148",
+    "matched_text": "All tests are passing",
+    "sentence": "All tests are passing and type safety has been improved.",
+    "line": "All tests are passing and type safety has been improved."
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/whitphx/vscode-emacs-mcx/pull/2149",
+    "matched_text": "All tests are passing",
+    "sentence": "All tests are passing and type safety has been improved.",
+    "line": "All tests are passing and type safety has been improved."
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/bespokelabsai/curator/pull/304",
+    "matched_text": "All tests pass",
+    "sentence": "- All tests pass successfully",
+    "line": "- All tests pass successfully"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/box/box-ui-elements/pull/3832",
+    "matched_text": "All tests are passing",
+    "sentence": "- All tests are passing with 99.56% coverage",
+    "line": "- All tests are passing with 99.56% coverage"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/box/box-ui-elements/pull/3833",
+    "matched_text": "All tests pass",
+    "sentence": "- All tests pass",
+    "line": "- All tests pass"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/box/box-ui-elements/pull/3841",
+    "matched_text": "all tests pass",
+    "sentence": "- Verified all tests pass",
+    "line": "- Verified all tests pass"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/box/box-ui-elements/pull/3843",
+    "matched_text": "all tests pass",
+    "sentence": "- Verified all tests pass",
+    "line": "- Verified all tests pass"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/modelcontextprotocol/inspector/pull/125",
+    "matched_text": "All tests are passing",
+    "sentence": "All tests are passing and the build is successful.",
+    "line": "All tests are passing and the build is successful."
+   }
+  ],
+  "JUDGMENT_UNVALIDATED:scoped_to_a_subset": [
+   {
+    "split": "held_out",
+    "url": "https://github.com/crewAIInc/crewAI/pull/1825",
+    "matched_text": "tests pass",
+    "sentence": "- Verified existing tests pass",
+    "line": "- Verified existing tests pass"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/crewAIInc/crewAI/pull/1835",
+    "matched_text": "tests pass",
+    "sentence": "- Local tests pass",
+    "line": "- Local tests pass"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/CodebuffAI/codebuff/pull/61",
+    "matched_text": "tests are passing",
+    "sentence": "\u2705 All credit-related tests are passing",
+    "line": "\u2705 All credit-related tests are passing"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/OHIF/Viewers/pull/4656",
+    "matched_text": "tests pass",
+    "sentence": "- All existing tests pass",
+    "line": "- All existing tests pass"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/box/box-ui-elements/pull/3834",
+    "matched_text": "tests pass",
+    "sentence": "- \u2705 All 21 unit tests pass",
+    "line": "- \u2705 All 21 unit tests pass"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/OHIF/Viewers/pull/4698",
+    "matched_text": "tests pass",
+    "sentence": "Note: Build and unit tests pass successfully.",
+    "line": "Note: Build and unit tests pass successfully. Awaiting test data with multiple character sets (ISO_IR 192 and ISO 2022 IR 100) for full verification."
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/airbytehq/airbyte/pull/52574",
+    "matched_text": "tests pass",
+    "sentence": "All unit tests pass successfully.",
+    "line": "All unit tests pass successfully."
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/airbytehq/airbyte/pull/52583",
+    "matched_text": "tests pass",
+    "sentence": "All unit tests pass successfully.",
+    "line": "All unit tests pass successfully."
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/airbytehq/airbyte/pull/52602",
+    "matched_text": "tests pass",
+    "sentence": "- Integration tests pass successfully with Milvus Lite configuration",
+    "line": "- Integration tests pass successfully with Milvus Lite configuration"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/crewAIInc/crewAI/pull/2076",
+    "matched_text": "tests pass",
+    "sentence": "- All existing tests pass",
+    "line": "- All existing tests pass"
+   }
+  ],
+  "JUDGMENT_UNVALIDATED:scoped_to_authors_machine": [
+   {
+    "split": "held_out",
+    "url": "https://github.com/bespokelabsai/curator/pull/316",
+    "matched_text": "All tests pass",
+    "sentence": "- All tests pass locally, including the new test for special token handling",
+    "line": "- All tests pass locally, including the new test for special token handling"
+   },
+   {
+    "split": "development",
+    "url": "https://github.com/marimo-team/marimo/pull/3618",
+    "matched_text": "All tests are passing",
+    "sentence": "- All tests are passing locally",
+    "line": "- All tests are passing locally"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/box/box-ui-elements/pull/3885",
+    "matched_text": "All tests are passing",
+    "sentence": "All tests are passing locally.",
+    "line": "All tests are passing locally."
+   },
+   {
+    "split": "development",
+    "url": "https://github.com/liam-hq/liam/pull/692",
+    "matched_text": "All tests are passing",
+    "sentence": "- All tests are passing locally",
+    "line": "- All tests are passing locally"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/box/box-ui-elements/pull/3991",
+    "matched_text": "tests are passing",
+    "sentence": "We've verified locally that all linting and tests are passing.",
+    "line": "- The `lint_test_build` CI check is failing, but according to the repository guidelines, this workflow can sometimes be flaky. We've verified locally that all linting and tests are passing."
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/pdfme/pdfme/pull/810",
+    "matched_text": "All tests pass",
+    "sentence": "- All tests pass locally",
+    "line": "- All tests pass locally"
+   },
+   {
+    "split": "development",
+    "url": "https://github.com/sugi/wareki/pull/21",
+    "matched_text": "all tests pass",
+    "sentence": "The changes have been tested locally and all tests pass successfully.",
+    "line": "The changes have been tested locally and all tests pass successfully."
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/GlareDB/glaredb/pull/3543",
+    "matched_text": "All tests pass",
+    "sentence": "- All tests pass locally",
+    "line": "- All tests pass locally"
+   },
+   {
+    "split": "development",
+    "url": "https://github.com/cberner/raptorq/pull/176",
+    "matched_text": "All tests pass",
+    "sentence": "All tests pass locally.",
+    "line": "All tests pass locally."
+   },
+   {
+    "split": "development",
+    "url": "https://github.com/cberner/raptorq/pull/189",
+    "matched_text": "All tests are passing",
+    "sentence": "All tests are passing locally.",
+    "line": "All tests are passing locally."
+   }
+  ],
+  "task_box_checked": [
+   {
+    "split": "held_out",
+    "url": "https://github.com/appsmithorg/appsmith/pull/38639",
+    "matched_text": "tests pass",
+    "sentence": "- [x] New and existing unit tests pass locally with my changes",
+    "line": "- [x] New and existing unit tests pass locally with my changes"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/box/box-ui-elements/pull/3848",
+    "matched_text": "Tests pass",
+    "sentence": "- [x] Tests pass",
+    "line": "- [x] Tests pass"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/box/box-ui-elements/pull/3891",
+    "matched_text": "Tests pass",
+    "sentence": "- [x] Tests pass",
+    "line": "- [x] Tests pass"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/box/box-ui-elements/pull/3893",
+    "matched_text": "all tests pass",
+    "sentence": "- [x] Ran `yarn test` - all tests pass",
+    "line": "- [x] Ran `yarn test` - all tests pass"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/modelcontextprotocol/inspector/pull/158",
+    "matched_text": "tests pass",
+    "sentence": "- [x] New and existing tests pass locally",
+    "line": "- [x] New and existing tests pass locally"
+   },
+   {
+    "split": "development",
+    "url": "https://github.com/modelcontextprotocol/typescript-sdk/pull/163",
+    "matched_text": "tests pass",
+    "sentence": "- [x] New and existing tests pass locally",
+    "line": "- [x] New and existing tests pass locally"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/saturday06/VRM-Addon-for-Blender/pull/792",
+    "matched_text": "Tests pass",
+    "sentence": "- [x] Tests pass",
+    "line": "- [x] Tests pass"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/crewAIInc/crewAI/pull/2679",
+    "matched_text": "Tests pass",
+    "sentence": "- [x] Tests pass locally",
+    "line": "- [x] Tests pass locally"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/vercel/turborepo/pull/10407",
+    "matched_text": "tests pass",
+    "sentence": "- [x] Verified that existing tests pass",
+    "line": "- [x] Verified that existing tests pass"
+   },
+   {
+    "split": "development",
+    "url": "https://github.com/liam-hq/liam/pull/1608",
+    "matched_text": "tests pass",
+    "sentence": "- [x] New and existing unit tests pass locally with my changes",
+    "line": "- [x] New and existing unit tests pass locally with my changes"
+   }
+  ],
+  "JUDGMENT_UNVALIDATED:conditional_or_future": [
+   {
+    "split": "held_out",
+    "url": "https://github.com/pyth-network/pyth-crosschain/pull/2275",
+    "matched_text": "tests pass",
+    "sentence": "- Existing e2e tests pass as they verify response formats rather than specific URLs",
+    "line": "- Existing e2e tests pass as they verify response formats rather than specific URLs"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/box/box-ui-elements/pull/3992",
+    "matched_text": "all tests pass",
+    "sentence": "- Ran `yarn test` to verify all tests pass",
+    "line": "- Ran `yarn test` to verify all tests pass"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/pdfme/pdfme/pull/808",
+    "matched_text": "tests pass",
+    "sentence": "- Ran `npm run build && npm run test` to ensure build and tests pass",
+    "line": "- Ran `npm run build && npm run test` to ensure build and tests pass"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/crewAIInc/crewAI/pull/2548",
+    "matched_text": "all tests pass",
+    "sentence": "- Ran pytest to ensure all tests pass",
+    "line": "- Ran pytest to ensure all tests pass"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/crewAIInc/crewAI/pull/2643",
+    "matched_text": "All tests pass",
+    "sentence": "All tests pass when running `uv run pytest tests -vv`.",
+    "line": "All tests pass when running `uv run pytest tests -vv`."
+   },
+   {
+    "split": "development",
+    "url": "https://github.com/antiwork/gumroad/pull/168",
+    "matched_text": "all tests pass",
+    "sentence": "- Awaiting CI to verify all tests pass with the new Ruby version",
+    "line": "- Awaiting CI to verify all tests pass with the new Ruby version"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/crewAIInc/crewAI/pull/2701",
+    "matched_text": "All tests pass",
+    "sentence": "All tests pass, including new tests that specifically verify CrewStructuredTool can be used with Task.",
+    "line": "All tests pass, including new tests that specifically verify CrewStructuredTool can be used with Task."
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/reflex-dev/reflex/pull/5211",
+    "matched_text": "tests pass",
+    "sentence": "- All existing tests pass, ensuring backward compatibility",
+    "line": "- All existing tests pass, ensuring backward compatibility"
+   },
+   {
+    "split": "development",
+    "url": "https://github.com/calcom/cal.com/pull/21152",
+    "matched_text": "tests pass",
+    "sentence": "All unit tests pass when run with `TZ=UTC yarn test packages/features/insights/server/routing-events.test.ts`.",
+    "line": "All unit tests pass when run with `TZ=UTC yarn test packages/features/insights/server/routing-events.test.ts`."
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/pyth-network/pyth-crosschain/pull/2676",
+    "matched_text": "tests pass",
+    "sentence": "Both tests pass when run with forge test and the code passes linting checks.",
+    "line": "Both tests pass when run with forge test and the code passes linting checks."
+   }
+  ],
+  "task_box_unchecked": [
+   {
+    "split": "held_out",
+    "url": "https://github.com/NousResearch/atropos/pull/71",
+    "matched_text": "tests pass",
+    "sentence": "- [ ] New and existing unit tests pass locally with my changes",
+    "line": "- [ ] New and existing unit tests pass locally with my changes"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/benbalter/jekyll-relative-links/pull/98",
+    "matched_text": "all tests pass",
+    "sentence": "- [ ] Ensure all tests pass before final submission",
+    "line": "- [ ] Ensure all tests pass before final submission"
+   },
+   {
+    "split": "development",
+    "url": "https://github.com/primer/react/pull/6076",
+    "matched_text": "all tests are passing",
+    "sentence": "- [ ] Run final Vitest to confirm all tests are passing",
+    "line": "- [ ] Run final Vitest to confirm all tests are passing"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/modelcontextprotocol/python-sdk/pull/773",
+    "matched_text": "tests pass",
+    "sentence": "- [ ] New and existing tests pass locally",
+    "line": "- [ ] New and existing tests pass locally"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/ray-project/kuberay/pull/3654",
+    "matched_text": "tests are passing",
+    "sentence": "- [ ] I've made sure the tests are passing.",
+    "line": "- [ ] I've made sure the tests are passing."
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/wvlet/airframe/pull/3937",
+    "matched_text": "all tests pass",
+    "sentence": "- [ ] Verify all tests pass with new implementation",
+    "line": "- [ ] Verify all tests pass with new implementation"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/modelcontextprotocol/inspector/pull/486",
+    "matched_text": "tests pass",
+    "sentence": "- [ ] New and existing tests pass locally",
+    "line": "- [ ] New and existing tests pass locally"
+   },
+   {
+    "split": "development",
+    "url": "https://github.com/deeeed/expo-audio-stream/pull/261",
+    "matched_text": "tests pass",
+    "sentence": "- [ ] Integration tests pass",
+    "line": "- [ ] Integration tests pass"
+   },
+   {
+    "split": "development",
+    "url": "https://github.com/RocketChat/Rocket.Chat.ReactNative/pull/6395",
+    "matched_text": "tests pass",
+    "sentence": "- [ ] Lint and unit tests pass locally with my changes",
+    "line": "- [ ] Lint and unit tests pass locally with my changes"
+   },
+   {
+    "split": "development",
+    "url": "https://github.com/antiwork/flexile/pull/356",
+    "matched_text": "tests pass",
+    "sentence": "- [ ] Backend tests pass: `cd backend && bundle exec rspec`",
+    "line": "- [ ] Backend tests pass: `cd backend && bundle exec rspec`"
+   }
+  ],
+  "fenced_code_block": [
+   {
+    "split": "development",
+    "url": "https://github.com/haasonsaas/ocode/pull/7",
+    "matched_text": "All tests pass",
+    "sentence": "# All tests pass including the fixed performance test",
+    "line": "# All tests pass including the fixed performance test"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/Azure/azure-sdk-for-js/pull/34739",
+    "matched_text": "tests pass",
+    "sentence": "# Verify tests pass",
+    "line": "# Verify tests pass"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/celestiaorg/celestia-app/pull/4978",
+    "matched_text": "tests pass",
+    "sentence": "# Unit tests pass",
+    "line": "# Unit tests pass"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/microsoft/secureboot_objects/pull/225",
+    "matched_text": "tests pass",
+    "sentence": "# All unit tests pass",
+    "line": "# All unit tests pass"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/aztfmod/terraform-provider-azurecaf/pull/312",
+    "matched_text": "tests pass",
+    "sentence": "# All new tests pass",
+    "line": "# All new tests pass"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/evstack/ev-node/pull/2406",
+    "matched_text": "tests pass",
+    "sentence": "# Regular tests pass",
+    "line": "# Regular tests pass"
+   },
+   {
+    "split": "development",
+    "url": "https://github.com/poppopjmp/spiderfoot/pull/309",
+    "matched_text": "tests pass",
+    "sentence": "# All correlation integration tests pass",
+    "line": "# All correlation integration tests pass"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/Codehagen/Badget/pull/294",
+    "matched_text": "tests pass",
+    "sentence": "- [ ] Unit tests pass",
+    "line": "- [ ] Unit tests pass"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/Codehagen/Badget/pull/294",
+    "matched_text": "tests pass",
+    "sentence": "- [ ] Integration tests pass",
+    "line": "- [ ] Integration tests pass"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/Codehagen/Badget/pull/294",
+    "matched_text": "tests pass",
+    "sentence": "- [x] New and existing unit tests pass locally with my changes (implied by successful build)",
+    "line": "- [x] New and existing unit tests pass locally with my changes (implied by successful build)"
+   }
+  ],
+  "blockquote": [
+   {
+    "split": "held_out",
+    "url": "https://github.com/Azure/autorest.typescript/pull/3280",
+    "matched_text": "all tests pass",
+    "sentence": "> - Fix any issues that arise during the process, and ensure all tests pass before considering the upgrade complete",
+    "line": "> - Fix any issues that arise during the process, and ensure all tests pass before considering the upgrade complete"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/Azure/autorest.typescript/pull/3280",
+    "matched_text": "tests are passing",
+    "sentence": "> - If all integration tests are passing, you can run `npm run stop-test-server -- -p 3000` to stop the RLC test server or `npm run stop-test-server -- -p 3002` to stop the Modular test server.",
+    "line": "> - If all integration tests are passing, you can run `npm run stop-test-server -- -p 3000` to stop the RLC test server or `npm run stop-test-server -- -p 3002` to stop the Modular test server."
+   },
+   {
+    "split": "development",
+    "url": "https://github.com/bikeshaving/crank/pull/286",
+    "matched_text": "tests pass",
+    "sentence": "Ensure all relevant hydration tests pass, including edge cases of mismatches and raw element hydration.",
+    "line": "> 5. Ensure all relevant hydration tests pass, including edge cases of mismatches and raw element hydration."
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/dotnet/maui/pull/30586",
+    "matched_text": "tests pass",
+    "sentence": "After renaming, verify that the repository builds and that tests pass, if applicable.",
+    "line": "> Rename every instance of \"MAUI\" to \"MIAU\" throughout the entire repository, including all code files, documentation, comments, variable names, constants, class names, project and solution files, and"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/dotnet/maui/pull/30586",
+    "matched_text": "tests pass",
+    "sentence": "After renaming, verify that the repository builds and that tests pass, if applicable.",
+    "line": "> Rename every instance of \"MAUI\" to \"MIAU\" throughout the entire repository, including all code files, documentation, comments, variable names, constants, class names, project and solution files, and"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/openops-cloud/openops/pull/960",
+    "matched_text": "all tests pass",
+    "sentence": "Iterate on errors, fixing any new failures that appear in subsequent runs, until all tests pass.",
+    "line": "> Fix all test and type errors in the above files so that the CI passes. Iterate on errors, fixing any new failures that appear in subsequent runs, until all tests pass."
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/chrxh/alien/pull/133",
+    "matched_text": "tests pass",
+    "sentence": "> Ensure that the rename is consistent everywhere and that all code continues to build and tests pass after the change.",
+    "line": "> Ensure that the rename is consistent everywhere and that all code continues to build and tests pass after the change. For further instances, search for `numRequiredAdditionalConnections` in the repo"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/dotnet/aspire/pull/10521",
+    "matched_text": "all tests pass",
+    "sentence": "Ensure all tests pass after these changes.",
+    "line": "> 4. Ensure all tests pass after these changes."
+   },
+   {
+    "split": "development",
+    "url": "https://github.com/Alfresco/alfresco-ng2-components/pull/11060",
+    "matched_text": "tests pass",
+    "sentence": "> - Ensure that builds and tests pass with the new dependency tree.",
+    "line": "> - Ensure that builds and tests pass with the new dependency tree."
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/yysun/apprun/pull/151",
+    "matched_text": "tests pass",
+    "sentence": "**Testing**: Ensure all existing tests pass and that the change doesn't break any existing functionality.",
+    "line": "> 4. **Testing**: Ensure all existing tests pass and that the change doesn't break any existing functionality."
+   }
+  ],
+  "indented_code_block": [
+   {
+    "split": "held_out",
+    "url": "https://github.com/opencv/opencv/pull/27441",
+    "matched_text": "tests pass",
+    "sentence": "All existing tests pass, and the new test verifies the mask generation logic.",
+    "line": "All existing tests pass, and the new test verifies the mask generation logic."
+   }
+  ],
+  "negation_cue_near": [
+   {
+    "split": "development",
+    "url": "https://github.com/wieslawsoltes/Dock/pull/498",
+    "matched_text": "tests pass",
+    "sentence": "- `dotnet test -c Release` *(fails to reach telemetry servers but tests pass)*",
+    "line": "- `dotnet test -c Release` *(fails to reach telemetry servers but tests pass)*"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/wieslawsoltes/Svg.Skia/pull/329",
+    "matched_text": "tests pass",
+    "sentence": "- `dotnet test Svg.Skia.sln --no-build` *(fails: Could not find resources but some tests pass)*",
+    "line": "- `dotnet test Svg.Skia.sln --no-build` *(fails: Could not find resources but some tests pass)*"
+   },
+   {
+    "split": "development",
+    "url": "https://github.com/AzureCosmosDB/data-migration-desktop-tool/pull/211",
+    "matched_text": "all tests pass",
+    "sentence": "The solution builds without any CS8602 warnings and all tests pass.",
+    "line": "All CS8602 warnings have been successfully eliminated. The solution builds without any CS8602 warnings and all tests pass. Added null-forgiving operators to Cosmos and SqlServer extensions that were m"
+   },
+   {
+    "split": "development",
+    "url": "https://github.com/PowerShell/PowerShell/pull/26244",
+    "matched_text": "tests pass",
+    "sentence": "- On regular CI (Ubuntu/macOS/Windows without FIPS): 12 tests pass, 2 MD5 tests skipped",
+    "line": "- On regular CI (Ubuntu/macOS/Windows without FIPS): 12 tests pass, 2 MD5 tests skipped"
+   }
+  ],
+  "html_comment": [
+   {
+    "split": "held_out",
+    "url": "https://github.com/RocketChat/Rocket.Chat/pull/36783",
+    "matched_text": "tests pass",
+    "sentence": "- Lint and unit tests pass locally with my changes",
+    "line": "- Lint and unit tests pass locally with my changes"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/RocketChat/Rocket.Chat/pull/36785",
+    "matched_text": "tests pass",
+    "sentence": "- Lint and unit tests pass locally with my changes",
+    "line": "- Lint and unit tests pass locally with my changes"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/RocketChat/Rocket.Chat/pull/36826",
+    "matched_text": "tests pass",
+    "sentence": "- Lint and unit tests pass locally with my changes",
+    "line": "- Lint and unit tests pass locally with my changes"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/RocketChat/Rocket.Chat/pull/36932",
+    "matched_text": "tests pass",
+    "sentence": "- Lint and unit tests pass locally with my changes",
+    "line": "- Lint and unit tests pass locally with my changes"
+   },
+   {
+    "split": "held_out",
+    "url": "https://github.com/RocketChat/Rocket.Chat/pull/37220",
+    "matched_text": "tests pass",
+    "sentence": "- Lint and unit tests pass locally with my changes",
+    "line": "- Lint and unit tests pass locally with my changes"
+   },
+   {
+    "split": "development",
+    "url": "https://github.com/marcocesarato/php-conventional-changelog/pull/85",
+    "matched_text": "tests pass",
+    "sentence": "- [x] Run tests to verify changes (all 3 tests pass - 5 assertions)",
+    "line": "- [x] Run tests to verify changes (all 3 tests pass - 5 assertions)"
+   },
+   {
+    "split": "development",
+    "url": "https://github.com/marcocesarato/php-conventional-changelog/pull/85",
+    "matched_text": "tests pass",
+    "sentence": "- All 3 tests pass (5 assertions total)",
+    "line": "- All 3 tests pass (5 assertions total)"
+   }
+  ]
+ },
+ "headline": {
+  "unchecked_task_box_matches_corpus_wide": 179,
+  "unchecked_task_box_share_of_all_matches_pct": 3.25,
+  "checked_task_box_matches_corpus_wide": 592,
+  "unchecked_share_of_task_list_matches_pct": 23.22,
+  "held_out_unchecked": 125,
+  "development_unchecked": 54,
+  "reading": "an unchecked box is an author explicitly DECLINING to claim the tests pass; the extractor reads it as asserting it"
+ }
+}

--- a/papers/closed-model-frontier/extraction_census.py
+++ b/papers/closed-model-frontier/extraction_census.py
@@ -1,0 +1,760 @@
+# -*- coding: utf-8 -*-
+"""EXTRACTION census for the `tests_pass` template: given a sentence the regex
+matched, was a claim actually being made?
+
+Every precision this lab has published measures ADJUDICATION — given that a claim
+was extracted, was the verdict right (EXTERNAL-1 0.23, V14 held-out 0.16).
+EXTRACTION is different: we know of no measurement of it, ours or anyone's. A
+false extraction produces a false accusation exactly as surely as a false
+adjudication does, and it is invisible to every panel we have run, because a panel
+is only ever shown items the extractor already produced.
+
+Target, verbatim from `styxx/diffgate.py` (`_TEMPLATES`, near line 76):
+
+    ("tests_pass", re.compile(r"\\b(?:all\\s+)?tests\\s+(?:pass|are\\s+passing|green)\\b", re.I))
+
+Population, deliberately parasitic on `flag_rate.py` so it reconciles exactly with
+the published 71,016:
+
+  * same SQL (`body IS NOT NULL AND body != ''`, PRs with at least one file row);
+  * same reconstruction (`external1_harness.reconstruct`, imported, never
+    reimplemented) and the same `parsed != implied` round-trip skip;
+  * same DEVELOPMENT / HELD-OUT split (`v14_gates.bucket` on the first five URL
+    segments, `< 3` DEVELOPMENT);
+  * same summary text (`f"{title}\\n\\n{body}"`) and the same sentence splitter the
+    gate uses (`re.split(r"(?<=[.!?])\\s+|\\n+", ...)`), reproduced here with byte
+    offsets so each match can be located in the ORIGINAL body. The splitter is
+    reproduced rather than imported because `re.split` discards offsets; the
+    reproduction is checked against `re.split` on every single PR and any
+    divergence is counted and reported.
+
+The gate applies NO filter to `tests_pass` matches: every match in every sentence
+becomes a claim (`diffgate.py:328-358`; the `no_evidence` short-circuit at line 357
+explicitly exempts this kind). So the match count here must equal `tests_pass_claims`
+in `flag_rate.json`. That equality is asserted in the output as a reconciliation
+check, not assumed.
+
+TWO GROUPS, KEPT SEPARATE, AND THE SEPARATION IS THE POINT
+----------------------------------------------------------
+MECHANICAL — a function of the bytes. No judgment, reproducible by anyone who runs
+this file. Every rule is stated in `RULES` below in the same words the code uses.
+
+JUDGMENT — a regex approximating a human reading. This lab measured a regex
+approximating a human judgment at 0.16 held-out precision. The judgment group here
+is the same kind of object and it has had NO panel. It is emitted marked
+UNVALIDATED and MUST NOT be quoted as a precision, a rate of false extraction, or
+anything else load-bearing. It is a hypothesis generator.
+
+    python papers/closed-model-frontier/extraction_census.py
+"""
+from __future__ import annotations
+
+import json
+import re
+import sqlite3
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+ROOT = HERE.parent.parent
+sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(HERE))
+
+import styxx.diffgate as DG                                    # noqa: E402
+from external1_harness import reconstruct                      # noqa: E402
+from v14_gates import bucket                                   # noqa: E402
+
+DB = HERE / "external1_shelf.sqlite"
+OUT = HERE / "extraction_census.json"
+
+EXPECTED_ELIGIBLE = 71016          # v14_gates.json / flag_rate.json, prs_scored
+EXPECTED_MATCHES = {               # flag_rate.json, tests_pass_claims
+    "development": 1476, "held_out": 4038, "corpus_wide": 5514,
+}
+EXPECTED_PRS_WITH_MATCH = {        # flag_rate.json, prs_with_tests_pass_claim
+    "development": 1236, "held_out": 3402, "corpus_wide": 4638,
+}
+
+# The instrument under census. Taken from the shipped module by NAME rather than
+# retyped, so this file cannot drift from the gate it is measuring.
+TESTS_PASS_RX = dict(DG._TEMPLATES)["tests_pass"]
+
+# The gate's splitter. Reproduced with offsets; verified against re.split per PR.
+SPLIT_RX = re.compile(r"(?<=[.!?])\s+|\n+")
+
+EXAMPLES_PER_CATEGORY = 10
+
+# D4. The judgment numbers must carry their status IN SCOPE wherever they can be
+# read, not only at the top of the file. A sibling `status` field beside a bare
+# integer map is strippable: a consumer who writes
+# d["held_out"]["judgment_category"] never touches the sibling and quotes a
+# number with no marker attached. So the MARKER IS IN THE KEY NAMES, which a
+# consumer must type to reach the integers, and the status string is repeated
+# inside the value so that dumping any level of the path still shows it. The
+# examples for judgment labels carry the same prefix for the same reason.
+JUDGMENT_STATUS = (
+    "UNVALIDATED — a regex approximating a human reading, with NO blind panel. "
+    "These counts are NOT a precision, NOT a false-extraction rate, and decide "
+    "nothing. See .judgment.warning in this file before quoting any of them.")
+JUDG_KEY_FLAGS = "judgment_UNVALIDATED_flags_any"
+JUDG_KEY_CATEGORY = "judgment_UNVALIDATED_category"
+JUDG_COUNTS_KEY = "counts_UNVALIDATED"
+JUDG_EXAMPLE_PREFIX = "JUDGMENT_UNVALIDATED:"
+
+
+# --------------------------------------------------------------------------
+# MECHANICAL detectors. Each is a pure function of the summary text.
+# --------------------------------------------------------------------------
+
+_FENCE = re.compile(r"^ {0,3}(?P<f>`{3,}|~{3,})")
+_BLOCKQUOTE = re.compile(r"^ {0,3}>")
+_TASK = re.compile(r"^\s*(?:[-*+]|\d+[.)])\s+\[(?P<box>[ xX])\]")
+_LIST_MARKER = re.compile(r"^ {0,3}(?:[-*+]|\d+[.)])\s")
+_HTML_COMMENT = re.compile(r"<!--.*?-->", re.S)
+_MD_LINK = re.compile(r"\[[^\]\n]*\]\([^)\n]*\)")
+_AUTOLINK = re.compile(r"<https?://[^>\s]*>")
+_BARE_URL = re.compile(r"https?://[^\s)>\]`\"']+")
+_BACKTICKS = re.compile(r"`+")
+
+_NEGATION = re.compile(
+    r"\b(?:not|cannot|can't|cant|won't|wont|doesn't|doesnt|don't|dont|didn't|didnt"
+    r"|isn't|isnt|aren't|arent|wasn't|wasnt|weren't|werent|hasn't|hasnt|haven't"
+    r"|havent|couldn't|couldnt|shouldn't|shouldnt|wouldn't|wouldnt|never|no longer"
+    r"|fails?\s+to|failed\s+to|failing\s+to|unable\s+to|without)\b", re.I)
+NEGATION_WINDOW = 40
+
+
+def _expand(line: str) -> str:
+    return line.expandtabs(4)
+
+
+def _line_index(text: str):
+    """(start, end_exclusive_of_newline, line_text) for every line, in order."""
+    out, pos = [], 0
+    for line in text.splitlines(keepends=True):
+        body = line.rstrip("\n").rstrip("\r")
+        out.append((pos, pos + len(body), body))
+        pos += len(line)
+    return out
+
+
+def _fenced_and_indented(lines):
+    """-> (set of line indices inside a ``` / ~~~ fence,
+           set of line indices that are indented code by the rule in RULES)"""
+    fenced, opener = set(), None
+    for i, (_s, _e, raw) in enumerate(lines):
+        m = _FENCE.match(raw)
+        if opener is None:
+            if m:
+                opener = m.group("f")[0], len(m.group("f"))
+                fenced.add(i)                    # the fence line itself counts as fence
+        else:
+            fenced.add(i)
+            if m and m.group("f")[0] == opener[0] and len(m.group("f")) >= opener[1]:
+                opener = None
+
+    indented = set()
+    for i, (_s, _e, raw) in enumerate(lines):
+        if i in fenced:
+            continue
+        exp = _expand(raw)
+        if not exp.strip() or len(exp) - len(exp.lstrip(" ")) < 4:
+            continue
+        # must not interrupt a paragraph: previous line blank, or itself indented
+        prev = _expand(lines[i - 1][2]) if i else ""
+        prev_blank = (i == 0) or (not prev.strip())
+        prev_indented = (i - 1) in indented
+        if not (prev_blank or prev_indented):
+            continue
+        # 4-space indentation inside a list is CONTINUATION, not code. Walk back to
+        # the nearest non-blank line at indent < 4 and refuse if it is a list item.
+        j, in_list = i - 1, False
+        while j >= 0:
+            pe = _expand(lines[j][2])
+            if not pe.strip():
+                j -= 1
+                continue
+            if len(pe) - len(pe.lstrip(" ")) >= 4:
+                j -= 1
+                continue
+            in_list = bool(_LIST_MARKER.match(pe))
+            break
+        if in_list:
+            continue
+        indented.add(i)
+    return fenced, indented
+
+
+def _spans(rx, text):
+    return [(m.start(), m.end()) for m in rx.finditer(text)]
+
+
+def _inline_code_spans(lines):
+    """Backtick code spans, paired left-to-right per line by equal run length."""
+    spans = []
+    for (s, _e, raw) in lines:
+        runs = [(m.start(), m.end()) for m in _BACKTICKS.finditer(raw)]
+        used = [False] * len(runs)
+        for a in range(len(runs)):
+            if used[a]:
+                continue
+            la = runs[a][1] - runs[a][0]
+            for b in range(a + 1, len(runs)):
+                if used[b] or (runs[b][1] - runs[b][0]) != la:
+                    continue
+                spans.append((s + runs[a][1], s + runs[b][0]))
+                used[a] = used[b] = True
+                break
+        # unmatched runs open nothing
+    return spans
+
+
+def _in(spans, off):
+    return any(a <= off < b for a, b in spans)
+
+
+def _link_spans(text):
+    """(title spans, destination spans) for markdown links, plus autolinks/bare URLs
+    which are recorded as destinations."""
+    titles, dests = [], []
+    for m in _MD_LINK.finditer(text):
+        s = m.start()
+        close = m.group(0).index("](")
+        titles.append((s + 1, s + close))
+        dests.append((s + close + 2, m.end() - 1))
+    for a, b in _spans(_AUTOLINK, text) + _spans(_BARE_URL, text):
+        dests.append((a, b))
+    return titles, dests
+
+
+def mechanical(text, lines, ctx, off, sentence, m_start_in_sent):
+    """Every mechanical flag for one match, as a dict of booleans plus box state."""
+    li = ctx["line_of"](off)
+    raw = lines[li][2]
+    flags = {
+        "fenced_code_block": li in ctx["fenced"],
+        "indented_code_block": li in ctx["indented"],
+        "blockquote": bool(_BLOCKQUOTE.match(raw)),
+        "html_comment": _in(ctx["comments"], off),
+        "link_title": _in(ctx["link_titles"], off),
+        "link_url": _in(ctx["link_dests"], off),
+        "inline_code_span": _in(ctx["inline_code"], off),
+        "task_list_item": False,
+        "task_box_unchecked": False,
+        "task_box_checked": False,
+        "negation_cue_near": False,
+        "negation_cue_in_sentence": False,
+        "in_title": off < ctx["title_end"],
+        # DIAGNOSTICS — never used in the disjoint table. They exist so a reader
+        # can tell a detector that found nothing from a detector that is broken.
+        "indented_ge4_spaces_naive": (
+            li not in ctx["fenced"]
+            and bool(_expand(raw).strip())
+            and (len(_expand(raw)) - len(_expand(raw).lstrip(" "))) >= 4),
+        "backtick_somewhere_on_line": "`" in raw,
+        "url_somewhere_on_line": bool(_BARE_URL.search(raw)),
+    }
+    tm = _TASK.match(raw)
+    if tm:
+        flags["task_list_item"] = True
+        if tm.group("box") in ("x", "X"):
+            flags["task_box_checked"] = True
+        else:
+            flags["task_box_unchecked"] = True
+    before = sentence[:m_start_in_sent]
+    if _NEGATION.search(before):
+        flags["negation_cue_in_sentence"] = True
+    win = before[-NEGATION_WINDOW:]
+    cues = [c.group(0).lower() for c in _NEGATION.finditer(win)]
+    if cues:
+        flags["negation_cue_near"] = True
+        # DISCLOSED DEFECT, counted rather than quietly patched: "without" is in
+        # the cue set for "without modifying X", but it also produces
+        # "builds without warnings and all tests pass" — a sentence that
+        # ASSERTS. Where "without" is the only cue the flag is unreliable.
+        flags["negation_cue_is_without_only"] = set(cues) == {"without"}
+    flags["link_title_or_url"] = flags["link_title"] or flags["link_url"]
+    return flags
+
+
+# Disjoint assignment. Containment first (the text is not prose at all), then the
+# task box (an explicit refusal to assert), then the rest.
+MECH_PRIORITY = [
+    "html_comment",
+    "fenced_code_block",
+    "indented_code_block",
+    "blockquote",
+    "task_box_unchecked",
+    "task_box_checked",
+    "link_title_or_url",
+    "inline_code_span",
+    "negation_cue_near",
+]
+
+
+def mech_category(flags):
+    for k in MECH_PRIORITY:
+        if flags.get(k):
+            return k
+    return "no_mechanical_flag"
+
+
+# --------------------------------------------------------------------------
+# JUDGMENT detectors. UNVALIDATED. A regex approximating a human reading.
+# --------------------------------------------------------------------------
+
+_SELF_DISCLOSED = re.compile(
+    r"\b(?:fail\w*|error\w*|broken|breaks?|breaking|flaky|regress\w*|red\b|"
+    r"except\s+for|apart\s+from|other\s+than|still\s+investigating)\b", re.I)
+_CONDITIONAL = re.compile(
+    r"\b(?:once|after|when|whenever|if|should|shall|will|would|expect\w*|assum\w*|"
+    r"pending|until|need\s+to|needs\s+to|make\s+sure|ensure|ensures|ensuring|"
+    r"verify|verifies|confirm|confirms|please|hopefully|plan\s+to|going\s+to|"
+    r"let'?s|to\s+be\s+sure)\b", re.I)
+_LOCAL = re.compile(
+    r"\b(?:locally|on\s+my\s+(?:machine|laptop|box|end)|in\s+my\s+environment|"
+    r"on\s+my\s+local|local\s+run|локально)\b", re.I)
+# Words that may sit immediately before "tests" WITHOUT scoping it. Anything else
+# ("auth", "unit", "e2e", "affected", "remaining", ...) is read as a subset scope.
+_NOT_A_SCOPE = frozenset({
+    "all", "the", "a", "an", "and", "or", "but", "so", "then", "now", "that",
+    "these", "those", "my", "our", "its", "their", "this", "as", "if", "when",
+    "while", "where", "since", "because", "also", "still", "again",
+})
+_PREV_WORD = re.compile(r"([A-Za-z][\w-]*)\W*$")
+
+
+def judgment(sentence, m):
+    """UNVALIDATED. Booleans only; the caller assigns the disjoint label."""
+    before = sentence[:m.start()]
+    pw = _PREV_WORD.search(before)
+    scoped = bool(pw and pw.group(1).lower() not in _NOT_A_SCOPE)
+    # "all tests pass" — the regex swallowed the "all", so nothing precedes it.
+    if m.group(0).lower().startswith("all"):
+        scoped = False
+    return {
+        "self_disclosed_failure": bool(_SELF_DISCLOSED.search(sentence)),
+        "conditional_or_future": bool(_CONDITIONAL.search(sentence)),
+        "scoped_to_authors_machine": bool(_LOCAL.search(sentence)),
+        "scoped_to_a_subset": scoped,
+    }
+
+
+JUDG_PRIORITY = [
+    "self_disclosed_failure",
+    "conditional_or_future",
+    "scoped_to_authors_machine",
+    "scoped_to_a_subset",
+]
+
+
+def judg_category(flags):
+    for k in JUDG_PRIORITY:
+        if flags.get(k):
+            return k
+    return "bare_unqualified_assertion"
+
+
+RULES = {
+    "fenced_code_block":
+        "the match's line lies between a line matching ^ {0,3}(`{3,}|~{3,}) and the "
+        "next line closing with the same character at >= the opening length; the "
+        "fence lines themselves are counted as inside",
+    "indented_code_block":
+        "tabs expanded to 4; the line's leading spaces >= 4; it is not inside a "
+        "fence; the previous line is blank or is itself indented code by this rule; "
+        "and the nearest preceding non-blank line at indent < 4 is not a list-item "
+        "marker (^ {0,3}([-*+]|\\d+[.)])\\s) — because 4-space indentation inside a "
+        "list is continuation, not code",
+    "blockquote": "the match's line matches ^ {0,3}>",
+    "html_comment": "the match offset lies inside a <!-- ... --> span (DOTALL, "
+                    "non-greedy); an unterminated <!-- is NOT treated as a comment",
+    "task_list_item": "the match's line matches ^\\s*([-*+]|\\d+[.)])\\s+\\[( |x|X)\\]; "
+                      "the box character decides checked vs unchecked",
+    "link_title_or_url":
+        "the match offset lies inside the [title] or (destination) span of a "
+        "[..](..) link, inside a <http...> autolink, or inside a bare https?:// run",
+    "inline_code_span":
+        "the match offset lies between two backtick runs of equal length on the "
+        "same line, paired left to right",
+    "negation_cue_near":
+        f"a cue from the closed set (not/cannot/n't forms/never/no longer/fails to/"
+        f"unable to/without) occurs in the {NEGATION_WINDOW} characters of the same "
+        f"gate-sentence immediately before the match",
+    "negation_cue_in_sentence":
+        "the same closed cue set, anywhere earlier in the same gate-sentence "
+        "(reported alongside as the looser variant; the disjoint table uses the "
+        "windowed form)",
+}
+
+
+def blank_counts():
+    keys = (MECH_PRIORITY + ["no_mechanical_flag", "task_list_item",
+                             "negation_cue_in_sentence", "link_title", "link_url",
+                             "in_title", "indented_ge4_spaces_naive",
+                             "backtick_somewhere_on_line", "url_somewhere_on_line",
+                             "negation_cue_is_without_only"])
+    return {
+        "matches": 0,
+        "prs_with_match": 0,
+        "mech_flags_any": {k: 0 for k in keys},
+        "mech_category": {k: 0 for k in MECH_PRIORITY + ["no_mechanical_flag"]},
+        JUDG_KEY_FLAGS: {
+            "status": JUDGMENT_STATUS,
+            JUDG_COUNTS_KEY: {k: 0 for k in JUDG_PRIORITY},
+        },
+        JUDG_KEY_CATEGORY: {
+            "status": JUDGMENT_STATUS,
+            JUDG_COUNTS_KEY: {
+                k: 0 for k in JUDG_PRIORITY + ["bare_unqualified_assertion"]},
+        },
+        "residual_matches": 0,
+    }
+
+
+def merge(dst, src):
+    dst["matches"] += src["matches"]
+    dst["prs_with_match"] += src["prs_with_match"]
+    dst["residual_matches"] += src["residual_matches"]
+    for sec in ("mech_flags_any", "mech_category"):
+        for k, v in src[sec].items():
+            dst[sec][k] = dst[sec].get(k, 0) + v
+    for sec in (JUDG_KEY_FLAGS, JUDG_KEY_CATEGORY):
+        assert dst[sec]["status"] == src[sec]["status"] == JUDGMENT_STATUS
+        for k, v in src[sec][JUDG_COUNTS_KEY].items():
+            d = dst[sec][JUDG_COUNTS_KEY]
+            d[k] = d.get(k, 0) + v
+
+
+def pct(n, d):
+    return round(100.0 * n / d, 2) if d else None
+
+
+def main() -> int:
+    con = sqlite3.connect(DB)
+    splits = {"development": blank_counts(), "held_out": blank_counts()}
+    examples = {}
+    skipped_roundtrip = 0
+    prs_scored = 0
+    splitter_divergences = 0
+
+    for pid, title, body, url in con.execute(
+            "SELECT id, title, body, html_url FROM pr "
+            "WHERE body IS NOT NULL AND body != ''"):
+        rows = con.execute("SELECT filename, status, patch FROM f WHERE pr_id=?",
+                           (pid,)).fetchall()
+        if not rows:
+            continue
+        diff, implied = reconstruct(rows)
+        parsed, _ = DG.parse_unified_diff(diff)
+        if parsed != implied:
+            skipped_roundtrip += 1
+            continue
+        prs_scored += 1
+
+        title = title or ""
+        summary = f"{title}\n\n{body}"
+
+        # cheap pre-filter, identical semantics: if the regex fires nowhere in the
+        # whole text it cannot fire in any sentence of it
+        if not TESTS_PASS_RX.search(summary):
+            continue
+
+        # split with offsets, and prove the reproduction matches the gate's re.split
+        pieces, pos = [], 0
+        for sep in SPLIT_RX.finditer(summary):
+            pieces.append((pos, summary[pos:sep.start()]))
+            pos = sep.end()
+        pieces.append((pos, summary[pos:]))
+        if [p[1] for p in pieces] != SPLIT_RX.split(summary):
+            splitter_divergences += 1
+            continue
+
+        lines = _line_index(summary)
+        starts = [s for s, _e, _r in lines]
+
+        def line_of(off, _starts=starts):
+            lo, hi = 0, len(_starts) - 1
+            while lo < hi:
+                mid = (lo + hi + 1) // 2
+                if _starts[mid] <= off:
+                    lo = mid
+                else:
+                    hi = mid - 1
+            return lo
+
+        fenced, indented = _fenced_and_indented(lines)
+        link_titles, link_dests = _link_spans(summary)
+        ctx = {
+            "fenced": fenced, "indented": indented,
+            "comments": _spans(_HTML_COMMENT, summary),
+            "link_titles": link_titles, "link_dests": link_dests,
+            "inline_code": _inline_code_spans(lines),
+            "line_of": line_of,
+            "title_end": len(title),
+        }
+
+        key = ("development"
+               if bucket("/".join((url or "").split("/")[:5])) < 3
+               else "held_out")
+        s = splits[key]
+        hit_this_pr = False
+
+        for pstart, sent in pieces:
+            for m in TESTS_PASS_RX.finditer(sent):
+                off = pstart + m.start()
+                mf = mechanical(summary, lines, ctx, off, sent, m.start())
+                mc = mech_category(mf)
+                s["matches"] += 1
+                hit_this_pr = True
+                for k in s["mech_flags_any"]:
+                    if mf.get(k):
+                        s["mech_flags_any"][k] += 1
+                if mc == "no_mechanical_flag":
+                    s["mech_flags_any"]["no_mechanical_flag"] += 1
+                s["mech_category"][mc] += 1
+
+                cat = mc
+                if mc == "no_mechanical_flag":
+                    s["residual_matches"] += 1
+                    jf = judgment(sent, m)
+                    jflags = s[JUDG_KEY_FLAGS][JUDG_COUNTS_KEY]
+                    for k in jflags:
+                        if jf.get(k):
+                            jflags[k] += 1
+                    jc = judg_category(jf)
+                    s[JUDG_KEY_CATEGORY][JUDG_COUNTS_KEY][jc] += 1
+                    cat = JUDG_EXAMPLE_PREFIX + jc
+
+                bucket_ex = examples.setdefault(cat, [])
+                if len(bucket_ex) < EXAMPLES_PER_CATEGORY:
+                    bucket_ex.append({
+                        "split": key,
+                        "url": url,
+                        "matched_text": m.group(0),
+                        "sentence": sent.strip()[:200],
+                        "line": lines[line_of(off)][2].strip()[:200],
+                    })
+
+        if hit_this_pr:
+            s["prs_with_match"] += 1
+
+    con.close()
+
+    both = blank_counts()
+    merge(both, splits["development"])
+    merge(both, splits["held_out"])
+
+    recon = {
+        "expected_eligible": EXPECTED_ELIGIBLE,
+        "observed_eligible": prs_scored,
+        "eligible_matches_flag_rate": prs_scored == EXPECTED_ELIGIBLE,
+        "skipped_reconstruction_roundtrip": skipped_roundtrip,
+        "splitter_divergences_from_re_split": splitter_divergences,
+        "expected_tests_pass_claims": EXPECTED_MATCHES,
+        "observed_matches": {
+            "development": splits["development"]["matches"],
+            "held_out": splits["held_out"]["matches"],
+            "corpus_wide": both["matches"],
+        },
+        "expected_prs_with_tests_pass_claim": EXPECTED_PRS_WITH_MATCH,
+        "observed_prs_with_match": {
+            "development": splits["development"]["prs_with_match"],
+            "held_out": splits["held_out"]["prs_with_match"],
+            "corpus_wide": both["prs_with_match"],
+        },
+    }
+    recon["matches_reconcile_with_flag_rate"] = (
+        recon["observed_matches"] == EXPECTED_MATCHES
+        and recon["observed_prs_with_match"] == EXPECTED_PRS_WITH_MATCH)
+
+    payload = {
+        "what": ("EXTRACTION census of the tests_pass template: of the sentences "
+                 "the regex fires on, how many are a claim being made"),
+        "target_regex": TESTS_PASS_RX.pattern,
+        "target_source": "styxx/diffgate.py _TEMPLATES entry 'tests_pass'",
+        "not_measured_here": (
+            "adjudication. Every tests_pass verdict in this corpus is UNCHECKABLE "
+            "(run=None), so no accusation exists to adjudicate. This file measures "
+            "the step BEFORE the verdict."),
+        "population": recon,
+        "mechanical": {
+            "status": "MECHANICAL — a pure function of the summary bytes, "
+                      "reproducible by anyone who runs this file",
+            "rules": RULES,
+            "priority_for_the_disjoint_table": MECH_PRIORITY,
+            "note": ("mech_flags_any counts each flag independently and matches may "
+                     "carry several; mech_category assigns each match to exactly one "
+                     "bucket by the priority above. The headline unchecked-box number "
+                     "is the INDEPENDENT count, mech_flags_any.task_box_unchecked."),
+            "diagnostics_not_categories": {
+                "indented_ge4_spaces_naive":
+                    "the NAIVE indented-code rule (>= 4 leading spaces, outside a "
+                    "fence) with none of the CommonMark conditions. Reported so the "
+                    "cost of the list-continuation refusal is visible: the gap "
+                    "between this and indented_code_block is what the strict rule "
+                    "declined to call code, and it is almost entirely markdown list "
+                    "continuation, not code",
+                "backtick_somewhere_on_line":
+                    "the match's line contains a backtick at all. If this is large "
+                    "while inline_code_span is zero, the code-span detector is "
+                    "working and the matches simply sit outside the spans",
+                "url_somewhere_on_line":
+                    "the match's line contains an http(s) URL at all. Same purpose "
+                    "for link_url. Note the regex requires literal whitespace "
+                    "between 'tests' and 'pass', which URLs almost never contain — "
+                    "a zero here is expected from the pattern, not evidence of a "
+                    "bug",
+                "negation_cue_is_without_only":
+                    "of the negation_cue_near matches, those whose ONLY cue in the "
+                    "window is the word 'without'. See disclosed_defects",
+            },
+            "disclosed_defects": {
+                "negation_cue_near_over-fires_on_without":
+                    "'without' earns its place in the cue set for 'without "
+                    "modifying X', but it also fires on 'the solution builds "
+                    "without any warnings and all tests pass' — a sentence that "
+                    "ASSERTS. This is a false positive inside the group that is "
+                    "supposed to carry weight, so it is counted "
+                    "(negation_cue_is_without_only) rather than patched away. "
+                    "Subtract it from negation_cue_near for a conservative read",
+                "fence_lines_counted_as_inside":
+                    "the ``` line itself is counted as fenced. A match can only "
+                    "land there via the info string, which is vanishingly rare, "
+                    "but the choice is stated rather than hidden",
+                "blockquote_lazy_continuation_missed":
+                    "a blockquote continued lazily (a following line with no '>') "
+                    "is NOT detected. Such matches fall through to the residual "
+                    "and are therefore counted against us, not for us",
+                "task_item_continuation_lines_missed":
+                    "the box state is read from the line containing the match. A "
+                    "match on a continuation line under a task item is not "
+                    "attributed to that item's box, so the unchecked-box count is "
+                    "a LOWER bound",
+            },
+        },
+        "judgment": {
+            "status": "UNVALIDATED",
+            "warning": (
+                "This group is a regex approximating a human judgment. That is "
+                "exactly the class of instrument this lab measured at 0.16 held-out "
+                "precision (RESULT_v14). It has had NO blind panel. It MUST NOT be "
+                "quoted as a precision, as a false-extraction rate, or as any "
+                "figure that decides anything. It is a hypothesis generator and "
+                "nothing else."),
+            "priority_for_the_disjoint_table": JUDG_PRIORITY,
+            "applied_to": ("only the matches carrying no mechanical flag "
+                           "(mech_category == no_mechanical_flag)"),
+            "where_the_numbers_live": {
+                "keys": [JUDG_KEY_FLAGS, JUDG_KEY_CATEGORY],
+                "counts_under": JUDG_COUNTS_KEY,
+                "examples_prefixed": JUDG_EXAMPLE_PREFIX,
+                "in_each_of": ["development", "held_out", "corpus_wide"],
+            },
+            "why_the_keys_are_named_that_way": (
+                "An earlier emission of this file marked judgment.status "
+                "UNVALIDATED at the top level only, while the per-split counts "
+                "sat under a bare `judgment_category` map. A consumer reading "
+                "d['held_out']['judgment_category'] saw no marker and could "
+                "quote the number with nothing attached to it. A sibling status "
+                "field beside the map would not have fixed that, because the "
+                "careless read never touches the sibling. So the marker is in "
+                "the KEY NAMES, which cannot be reached without being typed, "
+                "and the status string is repeated inside the value so that a "
+                "dump of any level of the path still carries it. The key names "
+                "changed in this emission; that is a deliberate break for any "
+                "consumer indexing the old names."),
+            "known_defects_found_by_reading_its_own_output": {
+                "self_disclosed_failure_fires_on_paths":
+                    "the cue 'error\\w*' matched inside a file path in "
+                    "'Verified all tests pass with `yarn test "
+                    "src/elements/common/error-boundary/__tests__/`'. A path is "
+                    "not a disclosure. Left in place, disclosed, because "
+                    "hand-patching an unvalidated classifier until its output "
+                    "looks right is the failure mode this lab is trying to stop",
+                "self_disclosed_failure_fires_on_flaky":
+                    "'All tests pass, including the previously flaky test' is "
+                    "labelled a self-disclosed failure; a reader might call it an "
+                    "assertion. This label is contested and unadjudicated",
+                "scoped_to_a_subset_is_the_largest_and_the_weakest":
+                    "it is the biggest bucket and it rests entirely on the "
+                    "single word before 'tests' against a hand-written stoplist. "
+                    "'Verified existing tests pass' and 'All 21 unit tests pass' "
+                    "both land here and they are not obviously the same thing. "
+                    "This number in particular must not leave the file",
+            },
+            "stoplist_verbatim": sorted(_NOT_A_SCOPE),
+        },
+        "development": splits["development"],
+        "held_out": splits["held_out"],
+        "corpus_wide": both,
+        "examples": examples,
+        "headline": {},
+    }
+
+    uc = both["mech_flags_any"]["task_box_unchecked"]
+    ch = both["mech_flags_any"]["task_box_checked"]
+    payload["headline"] = {
+        "unchecked_task_box_matches_corpus_wide": uc,
+        "unchecked_task_box_share_of_all_matches_pct": pct(uc, both["matches"]),
+        "checked_task_box_matches_corpus_wide": ch,
+        "unchecked_share_of_task_list_matches_pct": pct(
+            uc, both["mech_flags_any"]["task_list_item"]),
+        "held_out_unchecked": splits["held_out"]["mech_flags_any"]["task_box_unchecked"],
+        "development_unchecked": splits["development"]["mech_flags_any"]["task_box_unchecked"],
+        "reading": ("an unchecked box is an author explicitly DECLINING to claim "
+                    "the tests pass; the extractor reads it as asserting it"),
+    }
+
+    OUT.write_text(json.dumps(payload, indent=1) + "\n", encoding="utf-8")
+
+    # ---------------- table ----------------
+    def row(label, n, tot):
+        return f"  {label:<34}{n:>7}{'':2}{str(pct(n, tot)) + '%':>8}"
+
+    print(f"\nEXTRACTION CENSUS — tests_pass  {TESTS_PASS_RX.pattern}")
+    print(f"eligible PRs: {prs_scored} (flag_rate reports {EXPECTED_ELIGIBLE}) "
+          f"{'MATCH' if prs_scored == EXPECTED_ELIGIBLE else 'MISMATCH — investigate'}")
+    print(f"round-trip skips: {skipped_roundtrip}   "
+          f"splitter divergences: {splitter_divergences}")
+    print(f"matches: dev {splits['development']['matches']} / "
+          f"held-out {splits['held_out']['matches']} / corpus {both['matches']}  "
+          f"(flag_rate tests_pass_claims {EXPECTED_MATCHES['corpus_wide']}) "
+          f"{'RECONCILES' if recon['matches_reconcile_with_flag_rate'] else 'DOES NOT RECONCILE'}")
+
+    for name, s in (("DEVELOPMENT", splits["development"]),
+                    ("HELD-OUT", splits["held_out"]),
+                    ("CORPUS-WIDE", both)):
+        t = s["matches"]
+        print(f"\n{name}  ({t} matches, {s['prs_with_match']} PRs)")
+        print("  MECHANICALLY DETERMINABLE — disjoint, by priority")
+        for k in MECH_PRIORITY + ["no_mechanical_flag"]:
+            print(row(k, s["mech_category"][k], t))
+        print("  MECHANICAL — independent flags (a match may carry several)")
+        for k in ("task_list_item", "task_box_unchecked", "task_box_checked",
+                  "fenced_code_block", "indented_code_block", "blockquote",
+                  "html_comment", "link_title", "link_url", "inline_code_span",
+                  "negation_cue_near", "negation_cue_in_sentence", "in_title"):
+            print(row(k, s["mech_flags_any"][k], t))
+        print("  DIAGNOSTIC — not a category; proves the detector saw the material")
+        for k in ("indented_ge4_spaces_naive", "backtick_somewhere_on_line",
+                  "url_somewhere_on_line", "negation_cue_is_without_only"):
+            print(row(k, s["mech_flags_any"][k], t))
+        r = s["residual_matches"]
+        print(f"  REQUIRES JUDGMENT — UNVALIDATED, NOT A PRECISION "
+              f"({r} mechanically-clean matches)")
+        jcounts = s[JUDG_KEY_CATEGORY][JUDG_COUNTS_KEY]
+        for k in JUDG_PRIORITY + ["bare_unqualified_assertion"]:
+            print(row(k, jcounts[k], r))
+
+    print(f"\nHEADLINE  unchecked task boxes read as assertions: "
+          f"{uc} of {both['matches']} matches "
+          f"({pct(uc, both['matches'])}%), held-out "
+          f"{splits['held_out']['mech_flags_any']['task_box_unchecked']}")
+    print(f"          checked boxes for comparison: {ch}")
+    print(f"\n-> {OUT.name}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/papers/closed-model-frontier/extraction_decoys.json
+++ b/papers/closed-model-frontier/extraction_decoys.json
@@ -1,0 +1,4822 @@
+{
+  "what": "two-sided decoy set for the EXTRACTION question — 15 CLAIM taken unmodified from the sealed V14 packet, 15 NOT-A-CLAIM synthesised by three committed frames from DEVELOPMENT-split verified claims",
+  "repairs": "ADDENDUM_extraction_ceiling_gate_unsatisfiable_2026_09_01.md",
+  "question": "Ignoring entirely whether the gate's verdict was correct, and reading only the author's summary: is the author making a claim about this path — asserting that THIS change created, deleted or touched it? CLAIM / NOT-A-CLAIM / UNREADABLE",
+  "seed": 20260901,
+  "split_of_notaclaim_sources": "DEVELOPMENT only (bucket < 3), per SPLIT rule 1",
+  "frames": {
+    "negation": "negation",
+    "quotation": "quotation",
+    "comparative_reference": "comparative_reference"
+  },
+  "frame_ratio": {
+    "negation": 5,
+    "quotation": 5,
+    "comparative_reference": 5
+  },
+  "authorship_disclosure": "The NOT-A-CLAIM side is authored by us. The frames are judgment, stated in advance and mechanical given the source sentence. Any result quoting this set must say so in the same breath as the number.",
+  "n_claim": 15,
+  "n_notaclaim": 15,
+  "items": [
+    {
+      "id": "XD-C09",
+      "expected": "CLAIM",
+      "construction": "unmodified decoy_verified from v14_packet.json",
+      "source_v14_id": "V14-109",
+      "agent": "Copilot",
+      "url": "https://github.com/intellectronica/ruler/pull/146",
+      "claim_kind": "file_touched",
+      "claim_text": "Updated README.md with comprehensive examples showing both stdio and remote server configurations, proper TOML table syntax, and migration guidance from JSON.",
+      "claim_detail": {
+        "path": "README.md"
+      },
+      "changed_files": [
+        {
+          "path": "tmp-fixtures/unified-basic/.ruler/extra.md",
+          "status": "added"
+        },
+        {
+          "path": "tmp-fixtures/unified-basic/.ruler/ruler.toml",
+          "status": "added"
+        },
+        {
+          "path": "README.md",
+          "status": "modified"
+        },
+        {
+          "path": "src/core/UnifiedConfigLoader.ts",
+          "status": "modified"
+        },
+        {
+          "path": "src/core/UnifiedConfigTypes.ts",
+          "status": "modified"
+        },
+        {
+          "path": "src/core/apply-engine.ts",
+          "status": "modified"
+        },
+        {
+          "path": "tests/apply-mcp.toml-disable.test.ts",
+          "status": "added"
+        },
+        {
+          "path": "tests/apply-mcp.toml-json-merge.test.ts",
+          "status": "added"
+        },
+        {
+          "path": "tests/apply-mcp.toml-remote.test.ts",
+          "status": "added"
+        },
+        {
+          "path": "tests/apply-mcp.toml-stdio.test.ts",
+          "status": "added"
+        },
+        {
+          "path": "tests/mcp-invalid-fields.test.ts",
+          "status": "added"
+        },
+        {
+          "path": "tests/unified-config.mcp-toml-load.test.ts",
+          "status": "added"
+        },
+        {
+          "path": "tests/unit/core/apply-engine.test.ts",
+          "status": "modified"
+        }
+      ]
+    },
+    {
+      "id": "XD-C07",
+      "expected": "CLAIM",
+      "construction": "unmodified decoy_verified from v14_packet.json",
+      "source_v14_id": "V14-107",
+      "agent": "Cursor",
+      "url": "https://github.com/MCPJam/inspector/pull/433",
+      "claim_kind": "file_touched",
+      "claim_text": "updated include the new mcpjam-client-manager.ts, updated routes for",
+      "claim_detail": {
+        "path": "mcpjam-client-manager.ts"
+      },
+      "changed_files": [
+        {
+          "path": "server/routes/mcp/tools.ts",
+          "status": "modified"
+        },
+        {
+          "path": "server/services/mcpjam-agent.ts",
+          "status": "added"
+        },
+        {
+          "path": "server/tsup.config.ts",
+          "status": "modified"
+        },
+        {
+          "path": "server/index.ts",
+          "status": "modified"
+        },
+        {
+          "path": "server/routes/mcp/connect.ts",
+          "status": "modified"
+        },
+        {
+          "path": "server/routes/mcp/prompts.ts",
+          "status": "modified"
+        },
+        {
+          "path": "server/routes/mcp/resources.ts",
+          "status": "modified"
+        },
+        {
+          "path": "server/types/hono.ts",
+          "status": "added"
+        },
+        {
+          "path": "client/src/App.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "client/src/components/ToolsTab.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "client/src/components/TestsTab.tsx",
+          "status": "added"
+        },
+        {
+          "path": "client/src/components/mcp-sidebar.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "client/src/lib/test-storage.ts",
+          "status": "added"
+        },
+        {
+          "path": "server/agents/TestAgent.ts",
+          "status": "added"
+        },
+        {
+          "path": "server/routes/mcp/chat.ts",
+          "status": "modified"
+        },
+        {
+          "path": "server/routes/mcp/index.ts",
+          "status": "modified"
+        },
+        {
+          "path": "server/routes/mcp/tests.ts",
+          "status": "added"
+        },
+        {
+          "path": "server/utils/mcp-utils.ts",
+          "status": "modified"
+        },
+        {
+          "path": "client/src/components/ServersTab.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "client/src/hooks/use-app-state.ts",
+          "status": "modified"
+        },
+        {
+          "path": "server/routes/mcp/servers.ts",
+          "status": "added"
+        },
+        {
+          "path": "server/services/mcpjam-client-manager.ts",
+          "status": "renamed"
+        }
+      ]
+    },
+    {
+      "id": "XD-C02",
+      "expected": "CLAIM",
+      "construction": "unmodified decoy_verified from v14_packet.json",
+      "source_v14_id": "V14-102",
+      "agent": "OpenAI_Codex",
+      "url": "https://github.com/mochilang/mochi/pull/18868",
+      "claim_kind": "file_touched",
+      "claim_text": "- Update benchmarks and checklist (ALGORITHMS.md, README.md, TASKS.md)",
+      "claim_detail": {
+        "path": "ALGORITHMS.md"
+      },
+      "changed_files": [
+        {
+          "path": "tests/algorithms/x/Erlang/graphs/scc_kosaraju.bench",
+          "status": "modified"
+        },
+        {
+          "path": "tests/algorithms/x/Erlang/graphs/scc_kosaraju.erl",
+          "status": "modified"
+        },
+        {
+          "path": "tests/algorithms/x/Erlang/graphs/strongly_connected_components.bench",
+          "status": "modified"
+        },
+        {
+          "path": "tests/algorithms/x/Erlang/graphs/strongly_connected_components.erl",
+          "status": "modified"
+        },
+        {
+          "path": "tests/algorithms/x/Erlang/graphs/tarjans_scc.error",
+          "status": "modified"
+        },
+        {
+          "path": "tests/algorithms/x/Erlang/graphs/tests/test_min_spanning_tree_kruskal.bench",
+          "status": "modified"
+        },
+        {
+          "path": "tests/algorithms/x/Erlang/graphs/tests/test_min_spanning_tree_kruskal.erl",
+          "status": "modified"
+        },
+        {
+          "path": "tests/algorithms/x/Erlang/graphs/tests/test_min_spanning_tree_prim.bench",
+          "status": "modified"
+        },
+        {
+          "path": "tests/algorithms/x/Erlang/graphs/tests/test_min_spanning_tree_prim.erl",
+          "status": "modified"
+        },
+        {
+          "path": "tests/algorithms/x/Erlang/greedy_methods/best_time_to_buy_and_sell_stock.bench",
+          "status": "modified"
+        },
+        {
+          "path": "tests/algorithms/x/Erlang/greedy_methods/best_time_to_buy_and_sell_stock.erl",
+          "status": "modified"
+        },
+        {
+          "path": "tests/algorithms/x/Erlang/greedy_methods/fractional_cover_problem.bench",
+          "status": "modified"
+        },
+        {
+          "path": "tests/algorithms/x/Erlang/greedy_methods/fractional_cover_problem.erl",
+          "status": "modified"
+        },
+        {
+          "path": "tests/algorithms/x/Erlang/greedy_methods/fractional_knapsack.bench",
+          "status": "modified"
+        },
+        {
+          "path": "tests/algorithms/x/Erlang/greedy_methods/fractional_knapsack.erl",
+          "status": "modified"
+        },
+        {
+          "path": "tests/algorithms/x/Erlang/greedy_methods/fractional_knapsack_2.bench",
+          "status": "modified"
+        },
+        {
+          "path": "tests/algorithms/x/Erlang/greedy_methods/fractional_knapsack_2.erl",
+          "status": "modified"
+        },
+        {
+          "path": "tests/algorithms/x/Erlang/greedy_methods/gas_station.bench",
+          "status": "modified"
+        },
+        {
+          "path": "tests/algorithms/x/Erlang/greedy_methods/gas_station.erl",
+          "status": "modified"
+        },
+        {
+          "path": "tests/algorithms/x/Erlang/greedy_methods/minimum_coin_change.bench",
+          "status": "modified"
+        },
+        {
+          "path": "tests/algorithms/x/Erlang/greedy_methods/minimum_coin_change.erl",
+          "status": "modified"
+        },
+        {
+          "path": "tests/algorithms/x/Erlang/greedy_methods/minimum_waiting_time.bench",
+          "status": "modified"
+        },
+        {
+          "path": "tests/algorithms/x/Erlang/greedy_methods/minimum_waiting_time.erl",
+          "status": "modified"
+        },
+        {
+          "path": "tests/algorithms/x/Erlang/greedy_methods/optimal_merge_pattern.bench",
+          "status": "modified"
+        },
+        {
+          "path": "tests/algorithms/x/Erlang/greedy_methods/optimal_merge_pattern.erl",
+          "status": "modified"
+        },
+        {
+          "path": "tests/algorithms/x/Erlang/greedy_methods/smallest_range.bench",
+          "status": "modified"
+        },
+        {
+          "path": "tests/algorithms/x/Erlang/greedy_methods/smallest_range.erl",
+          "status": "modified"
+        },
+        {
+          "path": "tests/algorithms/x/Erlang/hashes/adler32.bench",
+          "status": "modified"
+        },
+        {
+          "path": "tests/algorithms/x/Erlang/hashes/adler32.erl",
+          "status": "modified"
+        },
+        {
+          "path": "tests/algorithms/x/Erlang/hashes/chaos_machine.bench",
+          "status": "modified"
+        },
+        {
+          "path": "tests/algorithms/x/Erlang/hashes/chaos_machine.erl",
+          "status": "modified"
+        },
+        {
+          "path": "tests/algorithms/x/Erlang/hashes/djb2.bench",
+          "status": "modified"
+        },
+        {
+          "path": "tests/algorithms/x/Erlang/hashes/djb2.erl",
+          "status": "modified"
+        },
+        {
+          "path": "tests/algorithms/x/Erlang/hashes/elf.bench",
+          "status": "modified"
+        },
+        {
+          "path": "tests/algorithms/x/Erlang/hashes/elf.erl",
+          "status": "modified"
+        },
+        {
+          "path": "tests/algorithms/x/Erlang/hashes/enigma_machine.bench",
+          "status": "modified"
+        },
+        {
+          "path": "tests/algorithms/x/Erlang/hashes/enigma_machine.erl",
+          "status": "modified"
+        },
+        {
+          "path": "tests/algorithms/x/Erlang/hashes/enigma_machine.out",
+          "status": "modified"
+        },
+        {
+          "path": "tests/algorithms/x/Erlang/hashes/fletcher16.bench",
+          "status": "modified"
+        },
+        {
+          "path": "tests/algorithms/x/Erlang/hashes/fletcher16.erl",
+          "status": "modified"
+        },
+        {
+          "path": "tests/algorithms/x/Erlang/hashes/hamming_code.bench",
+          "status": "modified"
+        },
+        {
+          "path": "tests/algorithms/x/Erlang/hashes/hamming_code.erl",
+          "status": "modified"
+        },
+        {
+          "path": "tests/algorithms/x/Erlang/hashes/luhn.bench",
+          "status": "modified"
+        },
+        {
+          "path": "tests/algorithms/x/Erlang/hashes/luhn.erl",
+          "status": "modified"
+        },
+        {
+          "path": "tests/algorithms/x/Erlang/hashes/md5.bench",
+          "status": "modified"
+        },
+        {
+          "path": "tests/algorithms/x/Erlang/hashes/md5.erl",
+          "status": "modified"
+        },
+        {
+          "path": "tests/algorithms/x/Erlang/hashes/md5.out",
+          "status": "modified"
+        },
+        {
+          "path": "tests/algorithms/x/Erlang/hashes/sdbm.bench",
+          "status": "modified"
+        },
+        {
+          "path": "tests/algorithms/x/Erlang/hashes/sdbm.erl",
+          "status": "modified"
+        },
+        {
+          "path": "tests/algorithms/x/Erlang/hashes/sha1.bench",
+          "status": "modified"
+        },
+        {
+          "path": "tests/algorithms/x/Erlang/hashes/sha1.erl",
+          "status": "modified"
+        },
+        {
+          "path": "tests/algorithms/x/Erlang/hashes/sha256.bench",
+          "status": "modified"
+        },
+        {
+          "path": "tests/algorithms/x/Erlang/hashes/sha256.erl",
+          "status": "modified"
+        },
+        {
+          "path": "tests/algorithms/x/Erlang/knapsack/greedy_knapsack.bench",
+          "status": "modified"
+        },
+        {
+          "path": "tests/algorithms/x/Erlang/knapsack/greedy_knapsack.erl",
+          "status": "modified"
+        },
+        {
+          "path": "tests/algorithms/x/Erlang/knapsack/knapsack.bench",
+          "status": "modified"
+        },
+        {
+          "path": "tests/algorithms/x/Erlang/knapsack/knapsack.erl",
+          "status": "modified"
+        },
+        {
+          "path": "tests/algorithms/x/Erlang/knapsack/recursive_approach_knapsack.bench",
+          "status": "modified"
+        },
+        {
+          "path": "tests/algorithms/x/Erlang/knapsack/recursive_approach_knapsack.erl",
+          "status": "modified"
+        },
+        {
+          "path": "tests/algorithms/x/Erlang/knapsack/tests/test_greedy_knapsack.bench",
+          "status": "modified"
+        },
+        {
+          "path": "tests/algorithms/x/Erlang/knapsack/tests/test_greedy_knapsack.erl",
+          "status": "modified"
+        },
+        {
+          "path": "tests/algorithms/x/Erlang/knapsack/tests/test_knapsack.bench",
+          "status": "modified"
+        },
+        {
+          "path": "tests/algorithms/x/Erlang/knapsack/tests/test_knapsack.erl",
+          "status": "modified"
+        },
+        {
+          "path": "tests/algorithms/x/Erlang/linear_algebra/gaussian_elimination.bench",
+          "status": "modified"
+        },
+        {
+          "path": "tests/algorithms/x/Erlang/linear_algebra/gaussian_elimination.erl",
+          "status": "modified"
+        },
+        {
+          "path": "tests/algorithms/x/Erlang/linear_algebra/jacobi_iteration_method.bench",
+          "status": "modified"
+        },
+        {
+          "path": "tests/algorithms/x/Erlang/linear_algebra/jacobi_iteration_method.erl",
+          "status": "modified"
+        },
+        {
+          "path": "tests/algorithms/x/Erlang/linear_algebra/lu_decomposition.bench",
+          "status": "modified"
+        },
+        {
+          "path": "tests/algorithms/x/Erlang/linear_algebra/lu_decomposition.erl",
+          "status": "modified"
+        },
+        {
+          "path": "tests/algorithms/x/Erlang/linear_algebra/matrix_inversion.bench",
+          "status": "modified"
+        },
+        {
+          "path": "tests/algorithms/x/Erlang/linear_algebra/matrix_inversion.erl",
+          "status": "modified"
+        },
+        {
+          "path": "tests/algorithms/x/Erlang/linear_algebra/matrix_inversion.out",
+          "status": "modified"
+        },
+        {
+          "path": "tests/algorithms/x/Erlang/linear_algebra/src/conjugate_gradient.bench",
+          "status": "modified"
+        },
+        {
+          "path": "tests/algorithms/x/Erlang/linear_algebra/src/conjugate_gradient.erl",
+          "status": "modified"
+        },
+        {
+          "path": "tests/algorithms/x/Erlang/linear_algebra/src/gaussian_elimination_pivoting.bench",
+          "status": "modified"
+        },
+        {
+          "path": "tests/algorithms/x/Erlang/linear_algebra/src/gaussian_elimination_pivoting.erl",
+          "status": "modified"
+        },
+        {
+          "path": "tests/algorithms/x/Erlang/linear_algebra/src/lib.bench",
+          "status": "modified"
+        },
+        {
+          "path": "tests/algorithms/x/Erlang/linear_algebra/src/lib.erl",
+          "status": "modified"
+        },
+        {
+          "path": "tests/algorithms/x/Erlang/linear_algebra/src/polynom_for_points.bench",
+          "status": "modified"
+        },
+        {
+          "path": "tests/algorithms/x/Erlang/linear_algebra/src/polynom_for_points.erl",
+          "status": "modified"
+        },
+        {
+          "path": "tests/algorithms/x/Erlang/linear_algebra/src/power_iteration.bench",
+          "status": "modified"
+        },
+        {
+          "path": "tests/algorithms/x/Erlang/linear_algebra/src/power_iteration.erl",
+          "status": "modified"
+        },
+        {
+          "path": "tests/algorithms/x/Erlang/linear_algebra/src/rank_of_matrix.bench",
+          "status": "modified"
+        },
+        {
+          "path": "tests/algorithms/x/Erlang/linear_algebra/src/rank_of_matrix.erl",
+          "status": "modified"
+        },
+        {
+          "path": "tests/algorithms/x/Erlang/linear_algebra/src/rayleigh_quotient.bench",
+          "status": "modified"
+        },
+        {
+          "path": "tests/algorithms/x/Erlang/linear_algebra/src/rayleigh_quotient.erl",
+          "status": "modified"
+        },
+        {
+          "path": "tests/algorithms/x/Erlang/linear_algebra/src/schur_complement.bench",
+          "status": "modified"
+        },
+        {
+          "path": "tests/algorithms/x/Erlang/linear_algebra/src/schur_complement.erl",
+          "status": "modified"
+        },
+        {
+          "path": "tests/algorithms/x/Erlang/linear_algebra/src/schur_complement.out",
+          "status": "modified"
+        },
+        {
+          "path": "tests/algorithms/x/Erlang/linear_algebra/src/test_linear_algebra.bench",
+          "status": "modified"
+        },
+        {
+          "path": "tests/algorithms/x/Erlang/linear_algebra/src/test_linear_algebra.erl",
+          "status": "modified"
+        },
+        {
+          "path": "tests/algorithms/x/Erlang/linear_algebra/src/transformations_2d.bench",
+          "status": "modified"
+        },
+        {
+          "path": "tests/algorithms/x/Erlang/linear_algebra/src/transformations_2d.erl",
+          "status": "modified"
+        },
+        {
+          "path": "tests/algorithms/x/Erlang/linear_algebra/src/transformations_2d.out",
+          "status": "modified"
+        },
+        {
+          "path": "tests/algorithms/x/Erlang/linear_programming/simplex.bench",
+          "status": "modified"
+        },
+        {
+          "path": "tests/algorithms/x/Erlang/linear_programming/simplex.erl",
+          "status": "modified"
+        },
+        {
+          "path": "tests/algorithms/x/Erlang/linear_programming/simplex.out",
+          "status": "modified"
+        },
+        {
+          "path": "tests/algorithms/x/Erlang/machine_learning/apriori_algorithm.bench",
+          "status": "modified"
+        },
+        {
+          "path": "tests/algorithms/x/Erlang/machine_learning/apriori_algorithm.erl",
+          "status": "modified"
+        },
+        {
+          "path": "tests/algorithms/x/Erlang/machine_learning/apriori_algorithm.out",
+          "status": "modified"
+        },
+        {
+          "path": "tests/algorithms/x/Erlang/machine_learning/astar.bench",
+          "status": "modified"
+        },
+        {
+          "path": "tests/algorithms/x/Erlang/machine_learning/astar.erl",
+          "status": "modified"
+        },
+        {
+          "path": "tests/algorithms/x/Erlang/machine_learning/automatic_differentiation.bench",
+          "status": "modified"
+        },
+        {
+          "path": "tests/algorithms/x/Erlang/machine_learning/automatic_differentiation.erl",
+          "status": "modified"
+        },
+        {
+          "path": "tests/algorithms/x/Erlang/machine_learning/automatic_differentiation.out",
+          "status": "modified"
+        },
+        {
+          "path": "tests/algorithms/x/Erlang/machine_learning/data_transformations.bench",
+          "status": "modified"
+        },
+        {
+          "path": "tests/algorithms/x/Erlang/machine_learning/data_transformations.erl",
+          "status": "modified"
+        },
+        {
+          "path": "tests/algorithms/x/Erlang/machine_learning/data_transformations.out",
+          "status": "modified"
+        },
+        {
+          "path": "transpiler/x/erl/ALGORITHMS.md",
+          "status": "modified"
+        },
+        {
+          "path": "transpiler/x/erl/README.md",
+          "status": "modified"
+        },
+        {
+          "path": "transpiler/x/erl/TASKS.md",
+          "status": "modified"
+        }
+      ]
+    },
+    {
+      "id": "XD-C04",
+      "expected": "CLAIM",
+      "construction": "unmodified decoy_verified from v14_packet.json",
+      "source_v14_id": "V14-104",
+      "agent": "Copilot",
+      "url": "https://github.com/Wynntils/Wynntils/pull/3584",
+      "claim_kind": "file_touched",
+      "claim_text": "This PR adds a comprehensive `.github/copilot-instructions.md` file to onboard the Wynntils repository for efficient use with GitHub Copilot coding agents.",
+      "claim_detail": {
+        "path": ".github/copilot-instructions.md"
+      },
+      "changed_files": [
+        {
+          "path": ".github/copilot-instructions.md",
+          "status": "added"
+        }
+      ]
+    },
+    {
+      "id": "XD-N06",
+      "expected": "NOT-A-CLAIM",
+      "construction": "synthesised by frame 'quotation' from a DEVELOPMENT verified claim",
+      "frame": "quotation",
+      "source_url": "https://github.com/gitbutlerapp/gitbutler/pull/10575",
+      "source_claim_text": "- Updated `apps/desktop/src/lib/backend/tauri.ts` to call the backend command instead of directly setting the title on the window object",
+      "agent": "Copilot",
+      "url": "https://github.com/gitbutlerapp/gitbutler/pull/10575",
+      "claim_kind": "file_touched",
+      "claim_text": "For reference, the linked issue asks for the following: \"- Updated `apps/desktop/src/lib/backend/tauri.ts` to call the backend command instead of directly setting the title on the window object\" That work is tracked separately and is not part of this pull request.",
+      "claim_detail": {
+        "path": "apps/desktop/src/lib/backend/tauri.ts"
+      },
+      "changed_files": [
+        {
+          "path": "apps/desktop/src/lib/backend/tauri.ts",
+          "status": "modified"
+        },
+        {
+          "path": "crates/gitbutler-tauri/src/main.rs",
+          "status": "modified"
+        },
+        {
+          "path": "crates/gitbutler-tauri/src/window.rs",
+          "status": "modified"
+        }
+      ]
+    },
+    {
+      "id": "XD-C05",
+      "expected": "CLAIM",
+      "construction": "unmodified decoy_verified from v14_packet.json",
+      "source_v14_id": "V14-105",
+      "agent": "Copilot",
+      "url": "https://github.com/githubnext/gh-aw/pull/1824",
+      "claim_kind": "file_touched",
+      "claim_text": "- Recompiled workflow to generate updated `.github/workflows/dev.lock.yml`",
+      "claim_detail": {
+        "path": ".github/workflows/dev.lock.yml"
+      },
+      "changed_files": [
+        {
+          "path": ".github/workflows/dev.lock.yml",
+          "status": "modified"
+        },
+        {
+          "path": ".github/workflows/dev.md",
+          "status": "modified"
+        }
+      ]
+    },
+    {
+      "id": "XD-N02",
+      "expected": "NOT-A-CLAIM",
+      "construction": "synthesised by frame 'negation' from a DEVELOPMENT verified claim",
+      "frame": "negation",
+      "source_url": "https://github.com/antiwork/flexile/pull/132",
+      "source_claim_text": "Fix Vercel deployment by removing package.json",
+      "agent": "Devin",
+      "url": "https://github.com/antiwork/flexile/pull/132",
+      "claim_kind": "file_touched",
+      "claim_text": "To be explicit about scope: this change does not touch `package.json`. That file is unchanged here and stays exactly as it is on main.",
+      "claim_detail": {
+        "path": "package.json"
+      },
+      "changed_files": [
+        {
+          "path": "apps/next/package.json",
+          "status": "removed"
+        }
+      ]
+    },
+    {
+      "id": "XD-C14",
+      "expected": "CLAIM",
+      "construction": "unmodified decoy_verified from v14_packet.json",
+      "source_v14_id": "V14-114",
+      "agent": "Claude_Code",
+      "url": "https://github.com/FinAegis/core-banking-prototype-laravel/pull/39",
+      "claim_kind": "file_touched",
+      "claim_text": "- Updated ROADMAP.md to mark Quick Win #5 as completed",
+      "claim_detail": {
+        "path": "ROADMAP.md"
+      },
+      "changed_files": [
+        {
+          "path": "GCU_VISION.md",
+          "status": "added"
+        },
+        {
+          "path": "README.md",
+          "status": "modified"
+        },
+        {
+          "path": "ROADMAP.md",
+          "status": "modified"
+        },
+        {
+          "path": "docs/README.md",
+          "status": "modified"
+        },
+        {
+          "path": "docs/archive/GCU_USER_VISION.md",
+          "status": "renamed"
+        },
+        {
+          "path": "docs/archive/README.md",
+          "status": "added"
+        }
+      ]
+    },
+    {
+      "id": "XD-N01",
+      "expected": "NOT-A-CLAIM",
+      "construction": "synthesised by frame 'negation' from a DEVELOPMENT verified claim",
+      "frame": "negation",
+      "source_url": "https://github.com/Significant-Gravitas/AutoGPT/pull/10828",
+      "source_claim_text": "*   Updated `useLibraryAgentList.ts` to implement client-side sorting, ensuring favorited agents appear at the top of the list.",
+      "agent": "Cursor",
+      "url": "https://github.com/Significant-Gravitas/AutoGPT/pull/10828",
+      "claim_kind": "file_touched",
+      "claim_text": "To be explicit about scope: this change does not touch `useLibraryAgentList.ts`. That file is unchanged here and stays exactly as it is on main.",
+      "claim_detail": {
+        "path": "useLibraryAgentList.ts"
+      },
+      "changed_files": [
+        {
+          "path": "autogpt_platform/backend/backend/server/v2/library/model.py",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/package.json",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/public/mockServiceWorker.js",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/library/components/LibraryAgentCard/LibraryAgentCard.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/library/components/LibraryAgentList/useLibraryAgentList.ts",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/api/openapi.json",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/lib/autogpt-server-api/types.ts",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/backend/backend/server/v2/library/routes_test.py",
+          "status": "modified"
+        },
+        {
+          "path": ".github/workflows/claude-ci-failure-auto-fix.yml",
+          "status": "added"
+        },
+        {
+          "path": ".github/workflows/claude-dependabot.yml",
+          "status": "added"
+        },
+        {
+          "path": ".github/workflows/claude.yml",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/autogpt_libs/poetry.lock",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/autogpt_libs/pyproject.toml",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/backend/backend/blocks/bannerbear/__init__.py",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/backend/backend/blocks/bannerbear/_config.py",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/backend/backend/blocks/bannerbear/text_overlay.py",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/backend/poetry.lock",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/backend/pyproject.toml",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/db/docker/docker-compose.yml",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/docker-compose.platform.yml",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/pnpm-lock.yaml",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/AgentRunsView/components/APIKeyCredentialsModal/APIKeyCredentialsModal.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/AgentRunsView/components/CredentialsInputs/CredentialsInputs.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/AgentRunsView/components/HotScopedCredentialsModal/HotScopedCredentialsModal.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/AgentRunsView/components/PasswordCredentialsModal/PasswordCredentialsModal.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/AgentRunsView/components/RunAgentInputs/RunAgentInputs.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/AgentRunsView/components/RunAgentModal/RunAgentModal.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/AgentRunsView/components/RunAgentModal/components/AgentInputFields/AgentInputFields.tsx",
+          "status": "removed"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/AgentRunsView/components/RunAgentModal/components/DefaultRunView/DefaultRunView.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/AgentRunsView/components/RunAgentModal/useAgentRunModal.ts",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/OldAgentLibraryView/OldAgentLibraryView.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/OldAgentLibraryView/components/agent-run-details-view.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/OldAgentLibraryView/components/agent-run-output-view.tsx",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/OldAgentLibraryView/components/agent-runs-selector-list.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/OldAgentLibraryView/components/output-renderers/components/OutputActions.tsx",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/OldAgentLibraryView/components/output-renderers/components/OutputItem.tsx",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/OldAgentLibraryView/components/output-renderers/index.ts",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/OldAgentLibraryView/components/output-renderers/renderers/CodeRenderer.tsx",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/OldAgentLibraryView/components/output-renderers/renderers/ImageRenderer.tsx",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/OldAgentLibraryView/components/output-renderers/renderers/JSONRenderer.tsx",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/OldAgentLibraryView/components/output-renderers/renderers/MarkdownRenderer.tsx",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/OldAgentLibraryView/components/output-renderers/renderers/TextRenderer.tsx",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/OldAgentLibraryView/components/output-renderers/renderers/VideoRenderer.tsx",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/OldAgentLibraryView/components/output-renderers/types.ts",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/OldAgentLibraryView/components/output-renderers/utils/copy.ts",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/OldAgentLibraryView/components/output-renderers/utils/download.ts",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/OldAgentLibraryView/use-agent-runs.ts",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/globals.css",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/components/CustomNode.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/components/atoms/Input/Input.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentSelectStep/AgentSelectStep.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/components/layout/Navbar/components/NavbarView.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/components/layout/Navbar/helpers.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/components/molecules/Dialog/components/BaseFooter.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/components/molecules/Dialog/components/DialogWrap.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/components/molecules/Dialog/components/DrawerWrap.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/components/molecules/Dialog/components/styles.module.css",
+          "status": "removed"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/components/molecules/Dialog/components/styles.ts",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/components/styles/scrollbars.ts",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/components/ui/icons.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/components/ui/multiselect.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/services/feature-flags/use-get-flag.ts",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/tailwind.config.ts",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/backend/snapshots/lib_agts_search",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/backend/backend/blocks/ai_image_customizer.py",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/backend/backend/blocks/github/pull_requests.py",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/backend/backend/data/block.py",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/backend/backend/data/block_cost_config.py",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/backend/backend/data/cost.py",
+          "status": "removed"
+        },
+        {
+          "path": "autogpt_platform/backend/backend/data/credit.py",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/backend/backend/data/graph.py",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/backend/backend/data/includes.py",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/backend/backend/executor/utils.py",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/backend/backend/sdk/__init__.py",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/backend/backend/sdk/builder.py",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/backend/backend/sdk/cost_integration.py",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/backend/backend/sdk/provider.py",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/backend/backend/server/v2/builder/db.py",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/backend/backend/server/v2/builder/model.py",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/backend/backend/server/v2/store/db.py",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/backend/backend/server/v2/store/db_test.py",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/backend/backend/server/v2/store/model.py",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/backend/backend/server/v2/store/routes.py",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/backend/migrations/20250904171522_update_store_agent_view_with_availability/migration.sql",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/backend/migrations/20250905130657_add_recommended_schedule_cron/migration.sql",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/backend/schema.prisma",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/backend/snapshots/agt_details",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/backend/snapshots/grph_single",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/backend/snapshots/grphs_all",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/backend/test/sdk/test_sdk_registry.py",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/instrumentation-client.ts",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/sentry.edge.config.ts",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/sentry.server.config.ts",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/AgentRunsView/AgentRunsView.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/AgentRunsView/components/AgentInputsReadOnly/AgentInputsReadOnly.tsx",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/AgentRunsView/components/EmptyAgentRuns/EmptyAgentRuns.tsx",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/AgentRunsView/components/RunAgentModal/components/ScheduleView/ScheduleView.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/AgentRunsView/components/RunAgentModal/components/ScheduleView/helpers.ts",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/AgentRunsView/components/RunDetailCard/RunDetailCard.tsx",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/AgentRunsView/components/RunDetailHeader/RunDetailHeader.tsx",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/AgentRunsView/components/RunDetailHeader/useRunDetailHeader.ts",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/AgentRunsView/components/RunDetailHeader/useScheduleDetailHeader.ts",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/AgentRunsView/components/RunDetails/RunDetails.tsx",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/AgentRunsView/components/RunDetails/components/RunStatusBadge.tsx",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/AgentRunsView/components/RunDetails/useRunDetails.ts",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/AgentRunsView/components/RunsSidebar/RunsSidebar.tsx",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/AgentRunsView/components/RunsSidebar/components/RunIconWrapper.tsx",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/AgentRunsView/components/RunsSidebar/components/RunListItem.tsx",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/AgentRunsView/components/RunsSidebar/components/RunSidebarCard.tsx",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/AgentRunsView/components/RunsSidebar/components/ScheduleListItem.tsx",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/AgentRunsView/components/RunsSidebar/useRunsSidebar.ts",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/AgentRunsView/components/ScheduleDetails/ScheduleDetails.tsx",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/AgentRunsView/components/ScheduleDetails/components/DeleteScheduleButton/DeleteScheduleButton.tsx",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/AgentRunsView/components/ScheduleDetails/components/EditInputsModal/EditInputsModal.tsx",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/AgentRunsView/components/ScheduleDetails/components/EditInputsModal/useEditInputsModal.ts",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/AgentRunsView/components/ScheduleDetails/components/EditScheduleModal/EditScheduleModal.tsx",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/AgentRunsView/components/ScheduleDetails/components/EditScheduleModal/useEditScheduleModal.ts",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/AgentRunsView/components/ScheduleDetails/useScheduleDetails.ts",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/AgentRunsView/useAgentRunsView.ts",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/OldAgentLibraryView/components/agent-run-draft-view.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/page.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/library/legacy/[id]/page.tsx",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/components/Flow.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentInfoStep/AgentInfoStep.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentInfoStep/helpers.ts",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentInfoStep/useAgentInfoStep.ts",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentSelectStep/useAgentSelectStep.ts",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/components/contextual/PublishAgentModal/helpers.ts",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/components/contextual/PublishAgentModal/usePublishAgentModal.ts",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/components/cron-scheduler-dialog.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/components/cron-scheduler.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/components/edit/control/SaveControl.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/components/layout/Navbar/components/MobileNavbar/MobileNavBar.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/components/layout/Navbar/components/MobileNavbar/components/MobileNavbarMenuItem.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/components/layout/Navbar/components/NavbarLink.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/components/molecules/Breadcrumbs/Breadcrumbs.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/components/molecules/DropdownMenu/DropdownMenu.stories.tsx",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/components/molecules/DropdownMenu/DropdownMenu.tsx",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/components/molecules/ErrorCard/ErrorCard.stories.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/components/molecules/ErrorCard/ErrorCard.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/components/molecules/ErrorCard/components/CardWrapper.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/components/molecules/ErrorCard/components/ErrorMessage.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/components/molecules/ErrorCard/helpers.ts",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/components/molecules/InfiniteList/InfiniteList.stories.tsx",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/components/molecules/InfiniteList/InfiniteList.tsx",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/components/molecules/TabsLine/TabsLine.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/components/ui/skeleton.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/hooks/useAgentGraph.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/backend/backend/server/v2/library/db.py",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/backend/backend/server/v2/library/routes/agents.py",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/orval.config.ts",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/library/components/FavoritesSection/FavoritesSection.tsx",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/library/hooks/useFavoriteAgents.ts",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/library/page.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/lib/autogpt-server-api/client.ts",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/autogpt_libs/autogpt_libs/api_key/key_manager.py",
+          "status": "removed"
+        },
+        {
+          "path": "autogpt_platform/autogpt_libs/autogpt_libs/api_key/keysmith.py",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/autogpt_libs/autogpt_libs/api_key/test_keysmith.py",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/backend/backend/blocks/airtable/_api.py",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/backend/backend/blocks/airtable/bases.py",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/backend/backend/blocks/airtable/records.py",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/backend/backend/blocks/google/gmail.py",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/backend/backend/data/api_key.py",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/backend/backend/server/external/middleware.py",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/backend/backend/server/external/routes/v1.py",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/backend/backend/server/model.py",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/backend/backend/server/rest_api.py",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/backend/backend/server/routers/v1.py",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/backend/backend/server/utils/api_key_auth.py",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/backend/backend/server/utils/api_key_auth_test.py",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/backend/backend/util/metrics.py",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/backend/backend/util/process.py",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/backend/migrations/20250901104517_fix_api_key_table/migration.sql",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/backend/migrations/20250912164006_keep_credit_transactions_on_user_delete/migration.sql",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/backend/test/e2e_test_data.py",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/backend/test/test_data_creator.py",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/.prettierignore",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/Dockerfile",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/next.config.mjs",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/public/integrations/aiml_api.png",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/public/integrations/airtable.png",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/public/integrations/anthropic.png",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/public/integrations/apollo.png",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/public/integrations/baas.png",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/public/integrations/bannerbear.png",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/public/integrations/d-id.png",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/public/integrations/d_id.png",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/public/integrations/dataforseo.png",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/public/integrations/discord.png",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/public/integrations/e2b.png",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/public/integrations/enrichlayer.png",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/public/integrations/exa.png",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/public/integrations/fal.png",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/public/integrations/firecrawl.png",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/public/integrations/github.png",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/public/integrations/google.png",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/public/integrations/google_maps.png",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/public/integrations/groq.png",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/public/integrations/http.png",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/public/integrations/hubspot.png",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/public/integrations/ideogram.png",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/public/integrations/jina.png",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/public/integrations/linear.png",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/public/integrations/llama_api.png",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/public/integrations/maps.png",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/public/integrations/medium.png",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/public/integrations/mem0.png",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/public/integrations/notion.png",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/public/integrations/nvidia.jpg",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/public/integrations/nvidia.png",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/public/integrations/ollama.png",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/public/integrations/open_router.png",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/public/integrations/openai.png",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/public/integrations/openweathermap.png",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/public/integrations/pinecone.png",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/public/integrations/reddit.png",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/public/integrations/replicate.png",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/public/integrations/revid.png",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/public/integrations/screenshotone.png",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/public/integrations/slant3d.jpeg",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/public/integrations/slant3d.png",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/public/integrations/smartlead.png",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/public/integrations/smtp.png",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/public/integrations/stagehand.png",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/public/integrations/todoist.png",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/public/integrations/twitter.png",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/public/integrations/unreal_speech.png",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/public/integrations/v0.png",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/public/integrations/wolfram.png",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/public/integrations/x.png",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/public/integrations/zerobounce.png",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/build/components/NewBlockMenu/AiBlock.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/build/components/NewBlockMenu/AllBlocksContent/AllBlocksContent.tsx",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/build/components/NewBlockMenu/AllBlocksContent/useAllBlockContent.tsx",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/build/components/NewBlockMenu/Block.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/build/components/NewBlockMenu/BlockList/BlockList.tsx",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/build/components/NewBlockMenu/BlockMenu/BlockMenu.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/build/components/NewBlockMenu/BlockMenu/useBlockMenu.ts",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/build/components/NewBlockMenu/BlockMenuDefault/BlockMenuDefault.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/build/components/NewBlockMenu/BlockMenuDefaultContent/BlockMenuDefaultContent.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/build/components/NewBlockMenu/BlockMenuSearch/BlockMenuSearch.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/build/components/NewBlockMenu/BlockMenuSearchBar/BlockMenuSearchBar.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/build/components/NewBlockMenu/BlockMenuSearchBar/useBlockMenuSearchBar.ts",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/build/components/NewBlockMenu/BlockMenuSidebar/BlockMenuSidebar.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/build/components/NewBlockMenu/BlockMenuSidebar/useBlockMenuSidebar.ts",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/build/components/NewBlockMenu/ControlPanelButton.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/build/components/NewBlockMenu/FilterChip.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/build/components/NewBlockMenu/Integration.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/build/components/NewBlockMenu/IntegrationBlocks/IntegrationBlocks.tsx",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/build/components/NewBlockMenu/IntegrationBlocks/useIntegrationBlocks.ts",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/build/components/NewBlockMenu/IntegrationChip.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/build/components/NewBlockMenu/IntegrationsContent/IntegrationsContent.tsx",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/build/components/NewBlockMenu/IntergrationBlock.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/build/components/NewBlockMenu/MarketplaceAgentBlock.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/build/components/NewBlockMenu/MarketplaceAgentsContent/MarketplaceAgentsContent.tsx",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/build/components/NewBlockMenu/MarketplaceAgentsContent/useMarketplaceAgentsContent.ts",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/build/components/NewBlockMenu/MenuItem.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/build/components/NewBlockMenu/MyAgentsContent/MyAgentsContent.tsx",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/build/components/NewBlockMenu/MyAgentsContent/useMyAgentsContent.ts",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/build/components/NewBlockMenu/NewControlPanel/NewControlPanel.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/build/components/NewBlockMenu/NewControlPanel/useNewControlPanel.ts",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/build/components/NewBlockMenu/NoSearchResult.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/build/components/NewBlockMenu/PaginatedBlocksContent/PaginatedBlocksContent.tsx",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/build/components/NewBlockMenu/PaginatedBlocksContent/usePaginatedBlocks.ts",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/build/components/NewBlockMenu/PaginatedIntegrationList/PaginatedIntegrationList.tsx",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/build/components/NewBlockMenu/PaginatedIntegrationList/usePaginatedIntegrationList.ts",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/build/components/NewBlockMenu/SaveControl/NewSaveControl.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/build/components/NewBlockMenu/SearchHistoryChip.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/build/components/NewBlockMenu/SuggestionContent/SuggestionContent.tsx",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/build/components/NewBlockMenu/SuggestionContent/useSuggestionContent.ts",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/build/components/NewBlockMenu/UGCAgentBlock.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/build/components/NewBlockMenu/block-menu-provider.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/build/components/NewBlockMenu/helpers.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/build/components/NewBlockMenu/style.ts",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/AgentRunsView/components/OutputRenderers/components/OutputActions.tsx",
+          "status": "renamed"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/AgentRunsView/components/OutputRenderers/components/OutputItem.tsx",
+          "status": "renamed"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/AgentRunsView/components/OutputRenderers/index.ts",
+          "status": "renamed"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/AgentRunsView/components/OutputRenderers/renderers/CodeRenderer.tsx",
+          "status": "renamed"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/AgentRunsView/components/OutputRenderers/renderers/ImageRenderer.tsx",
+          "status": "renamed"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/AgentRunsView/components/OutputRenderers/renderers/JSONRenderer.tsx",
+          "status": "renamed"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/AgentRunsView/components/OutputRenderers/renderers/MarkdownRenderer.tsx",
+          "status": "renamed"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/AgentRunsView/components/OutputRenderers/renderers/TextRenderer.tsx",
+          "status": "renamed"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/AgentRunsView/components/OutputRenderers/renderers/VideoRenderer.tsx",
+          "status": "renamed"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/AgentRunsView/components/OutputRenderers/types.ts",
+          "status": "renamed"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/AgentRunsView/components/OutputRenderers/utils/copy.ts",
+          "status": "renamed"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/AgentRunsView/components/OutputRenderers/utils/download.ts",
+          "status": "renamed"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/AgentRunsView/components/RunAgentModal/components/CronScheduler/CronScheduler.tsx",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/AgentRunsView/components/RunAgentModal/components/CronScheduler/CustomInterval.tsx",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/AgentRunsView/components/RunAgentModal/components/CronScheduler/FrequencySelect.tsx",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/AgentRunsView/components/RunAgentModal/components/CronScheduler/MonthlyPicker.tsx",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/AgentRunsView/components/RunAgentModal/components/CronScheduler/TimeAt.tsx",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/AgentRunsView/components/RunAgentModal/components/CronScheduler/WeeklyPicker.tsx",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/AgentRunsView/components/RunAgentModal/components/CronScheduler/YearlyPicker.tsx",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/AgentRunsView/components/RunAgentModal/components/TimezoneNotice/TimezoneNotice.tsx",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/AgentRunsView/components/RunDetailHeader/components/AgentActions.tsx",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/AgentRunsView/components/RunDetails/components/RunOutputs.tsx",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/marketplace/components/CreatorCard/CreatorCard.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/marketplace/components/CreatorInfoCard/CreatorInfoCard.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/marketplace/components/StoreCard/StoreCard.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/profile/(user)/api_keys/components/APIKeySection/APIKeySection.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/profile/(user)/api_keys/components/APIKeySection/useAPISection.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/layout.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/components/agptui/CreatorInfoCard.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/components/agptui/StoreCard.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/components/atoms/Avatar/Avatar.stories.tsx",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/components/atoms/Avatar/Avatar.tsx",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/components/layout/Navbar/components/AccountMenu/AccountMenu.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/components/layout/Navbar/components/AgentActivityDropdown/components/ActivityDropdown/ActivityDropdown.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/components/ui/avatar.tsx",
+          "status": "removed"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/lib/timezone-utils.ts",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/backend/backend/data/execution.py",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/backend/backend/executor/manager.py",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/backend/backend/executor/utils_test.py",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/backend/migrations/20250910161617_fix_store_materialized_views_refresh_job/migration.sql",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/AgentRunsView/components/AgentActionsDropdown.tsx",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/AgentRunsView/components/AgentRunsLoading.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/AgentRunsView/components/RunAgentModal/components/ModalRunSection/DefaultRunView.tsx",
+          "status": "renamed"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/AgentRunsView/components/RunAgentModal/components/ModalScheduleSection/ScheduleView.tsx",
+          "status": "renamed"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/AgentRunsView/components/RunAgentModal/components/ModalScheduleSection/helpers.ts",
+          "status": "renamed"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/AgentRunsView/components/RunAgentModal/components/ModalScheduleSection/useModalScheduleSection.ts",
+          "status": "renamed"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/AgentRunsView/components/RunsSidebar/helpers.ts",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/AgentRunsView/components/ScheduleDetails/components/ScheduleActions.tsx",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/api/helpers.ts",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/components/atoms/Button/helpers.ts",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/components/atoms/Button/helpers.tsx",
+          "status": "removed"
+        },
+        {
+          "path": "autogpt_platform/backend/backend/executor/scheduler.py",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/OldAgentLibraryView/components/agent-schedule-details-view.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/app/(platform)/monitoring/page.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/components/DataTable.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/components/ExpandableOutputDialog.tsx",
+          "status": "added"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/components/NodeOutputs.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/components/monitor/scheduleTable.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "autogpt_platform/frontend/src/lib/cron-expression-utils.ts",
+          "status": "modified"
+        }
+      ]
+    },
+    {
+      "id": "XD-N09",
+      "expected": "NOT-A-CLAIM",
+      "construction": "synthesised by frame 'quotation' from a DEVELOPMENT verified claim",
+      "frame": "quotation",
+      "source_url": "https://github.com/getsentry/sentry-python/pull/4662",
+      "source_claim_text": "- `reproduce_issue.py`: A comprehensive script showing behavior with and without Sentry.",
+      "agent": "Cursor",
+      "url": "https://github.com/getsentry/sentry-python/pull/4662",
+      "claim_kind": "file_touched",
+      "claim_text": "For reference, the linked issue asks for the following: \"- `reproduce_issue.py`: A comprehensive script showing behavior with and without Sentry.\" That work is tracked separately and is not part of this pull request.",
+      "claim_detail": {
+        "path": "reproduce_issue.py"
+      },
+      "changed_files": [
+        {
+          "path": "reproduction/README.md",
+          "status": "added"
+        },
+        {
+          "path": "reproduction/reproduce_issue.py",
+          "status": "added"
+        },
+        {
+          "path": "reproduction/requirements.txt",
+          "status": "added"
+        },
+        {
+          "path": "reproduction/simple_reproduce.py",
+          "status": "added"
+        },
+        {
+          "path": "reproduction/test_generator_issue.py",
+          "status": "added"
+        }
+      ]
+    },
+    {
+      "id": "XD-N07",
+      "expected": "NOT-A-CLAIM",
+      "construction": "synthesised by frame 'quotation' from a DEVELOPMENT verified claim",
+      "frame": "quotation",
+      "source_url": "https://github.com/vmware-tanzu/velero/pull/9283",
+      "source_claim_text": "Update .github/workflows/e2e-test-kind.yaml",
+      "agent": "Claude_Code",
+      "url": "https://github.com/vmware-tanzu/velero/pull/9283",
+      "claim_kind": "file_touched",
+      "claim_text": "For reference, the linked issue asks for the following: \"Update .github/workflows/e2e-test-kind.yaml\" That work is tracked separately and is not part of this pull request.",
+      "claim_detail": {
+        "path": ".github/workflows/e2e-test-kind.yaml"
+      },
+      "changed_files": [
+        {
+          "path": ".github/workflows/e2e-test-kind.yaml",
+          "status": "modified"
+        }
+      ]
+    },
+    {
+      "id": "XD-N08",
+      "expected": "NOT-A-CLAIM",
+      "construction": "synthesised by frame 'quotation' from a DEVELOPMENT verified claim",
+      "frame": "quotation",
+      "source_url": "https://github.com/microsoft/fabric-cicd/pull/469",
+      "source_claim_text": "This PR adds a comprehensive `.github/copilot-instructions.md` file that provides GitHub Copilot with detailed instructions for working effectively in the fabri",
+      "agent": "Copilot",
+      "url": "https://github.com/microsoft/fabric-cicd/pull/469",
+      "claim_kind": "file_touched",
+      "claim_text": "For reference, the linked issue asks for the following: \"This PR adds a comprehensive `.github/copilot-instructions.md` file that provides GitHub Copilot with detailed instructions for working effectively in the fabri\" That work is tracked separately and is not part of this pull request.",
+      "claim_detail": {
+        "path": ".github/copilot-instructions.md"
+      },
+      "changed_files": [
+        {
+          "path": "tests/test_fabric_workspace.py",
+          "status": "modified"
+        },
+        {
+          "path": ".github/copilot-instructions.md",
+          "status": "added"
+        }
+      ]
+    },
+    {
+      "id": "XD-C01",
+      "expected": "CLAIM",
+      "construction": "unmodified decoy_verified from v14_packet.json",
+      "source_v14_id": "V14-101",
+      "agent": "Devin",
+      "url": "https://github.com/lingodotdev/lingo.dev/pull/706",
+      "claim_kind": "file_created",
+      "claim_text": "- Created a root composer.json file that references the PHP SDK in the subdirectory",
+      "claim_detail": {
+        "path": "composer.json"
+      },
+      "changed_files": [
+        {
+          "path": ".github/workflows/publish-php-sdk.yml",
+          "status": "modified"
+        },
+        {
+          "path": "composer.json",
+          "status": "added"
+        }
+      ]
+    },
+    {
+      "id": "XD-N05",
+      "expected": "NOT-A-CLAIM",
+      "construction": "synthesised by frame 'quotation' from a DEVELOPMENT verified claim",
+      "frame": "quotation",
+      "source_url": "https://github.com/edgestorejs/edgestore/pull/87",
+      "source_claim_text": "- **Updated `package.json`**: Added `\"license\": \"MIT\"` field to the root package.json to match the license field already present in the individual package manif",
+      "agent": "Copilot",
+      "url": "https://github.com/edgestorejs/edgestore/pull/87",
+      "claim_kind": "file_touched",
+      "claim_text": "For reference, the linked issue asks for the following: \"- **Updated `package.json`**: Added `\"license\": \"MIT\"` field to the root package.json to match the license field already present in the individual package manif\" That work is tracked separately and is not part of this pull request.",
+      "claim_detail": {
+        "path": "package.json"
+      },
+      "changed_files": [
+        {
+          "path": "LICENSE",
+          "status": "added"
+        },
+        {
+          "path": "package.json",
+          "status": "modified"
+        }
+      ]
+    },
+    {
+      "id": "XD-N04",
+      "expected": "NOT-A-CLAIM",
+      "construction": "synthesised by frame 'negation' from a DEVELOPMENT verified claim",
+      "frame": "negation",
+      "source_url": "https://github.com/krivahtoo/silicon.nvim/pull/56",
+      "source_claim_text": "- Updated README.md with comprehensive nvim-treesitter integration documentation",
+      "agent": "Copilot",
+      "url": "https://github.com/krivahtoo/silicon.nvim/pull/56",
+      "claim_kind": "file_touched",
+      "claim_text": "To be explicit about scope: this change does not touch `README.md`. That file is unchanged here and stays exactly as it is on main.",
+      "claim_detail": {
+        "path": "README.md"
+      },
+      "changed_files": [
+        {
+          "path": "test.py",
+          "status": "added"
+        },
+        {
+          "path": "Cargo.lock",
+          "status": "modified"
+        },
+        {
+          "path": "Cargo.toml",
+          "status": "modified"
+        },
+        {
+          "path": "debug_plugin.lua",
+          "status": "added"
+        },
+        {
+          "path": "src/config.rs",
+          "status": "modified"
+        },
+        {
+          "path": "src/lib.rs",
+          "status": "modified"
+        },
+        {
+          "path": "src/treesitter.rs",
+          "status": "added"
+        },
+        {
+          "path": "test_plugin.lua",
+          "status": "added"
+        },
+        {
+          "path": "test_treesitter.py",
+          "status": "added"
+        },
+        {
+          "path": "test_treesitter_direct.lua",
+          "status": "added"
+        },
+        {
+          "path": "README.md",
+          "status": "modified"
+        },
+        {
+          "path": "basic_test.lua",
+          "status": "added"
+        },
+        {
+          "path": "demo_treesitter.lua",
+          "status": "added"
+        },
+        {
+          "path": "minimal_test.lua",
+          "status": "added"
+        },
+        {
+          "path": "test_notifications.lua",
+          "status": "added"
+        },
+        {
+          "path": "test_treesitter_setup.lua",
+          "status": "added"
+        },
+        {
+          "path": "test_integration.lua",
+          "status": "added"
+        }
+      ]
+    },
+    {
+      "id": "XD-C00",
+      "expected": "CLAIM",
+      "construction": "unmodified decoy_verified from v14_packet.json",
+      "source_v14_id": "V14-100",
+      "agent": "OpenAI_Codex",
+      "url": "https://github.com/MontrealAI/AGI-Alpha-Agent-v0/pull/3320",
+      "claim_kind": "file_touched",
+      "claim_text": "- update `ci.yml` to fail early when actor isn't repo owner",
+      "claim_detail": {
+        "path": "ci.yml"
+      },
+      "changed_files": [
+        {
+          "path": ".github/workflows/ci.yml",
+          "status": "modified"
+        }
+      ]
+    },
+    {
+      "id": "XD-N00",
+      "expected": "NOT-A-CLAIM",
+      "construction": "synthesised by frame 'negation' from a DEVELOPMENT verified claim",
+      "frame": "negation",
+      "source_url": "https://github.com/webiny/webiny-js/pull/4745",
+      "source_claim_text": "The package.json files have been updated and `yarn.lock` has been regenerated to lock the new versions.",
+      "agent": "Copilot",
+      "url": "https://github.com/webiny/webiny-js/pull/4745",
+      "claim_kind": "file_touched",
+      "claim_text": "To be explicit about scope: this change does not touch `yarn.lock`. That file is unchanged here and stays exactly as it is on main.",
+      "claim_detail": {
+        "path": "yarn.lock"
+      },
+      "changed_files": [
+        {
+          "path": "packages/project-aws/package.json",
+          "status": "modified"
+        },
+        {
+          "path": "packages/pulumi-sdk/package.json",
+          "status": "modified"
+        },
+        {
+          "path": "packages/pulumi/package.json",
+          "status": "modified"
+        },
+        {
+          "path": "yarn.lock",
+          "status": "modified"
+        },
+        {
+          "path": "packages/admin-ui/src/Popover/Popover.stories.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "packages/project-aws/src/pulumi/apps/core/CoreVpc.ts",
+          "status": "modified"
+        },
+        {
+          "path": "packages/project-aws/src/pulumi/apps/syncSystem/SyncSystemWorkerLambda.ts",
+          "status": "modified"
+        },
+        {
+          "path": "packages/cli/files/references.json",
+          "status": "modified"
+        },
+        {
+          "path": ".github/workflows/pullRequestsCommandCypress.yml",
+          "status": "modified"
+        },
+        {
+          "path": ".github/workflows/wac/pullRequestsCommandCypress.wac.ts",
+          "status": "modified"
+        }
+      ]
+    },
+    {
+      "id": "XD-N11",
+      "expected": "NOT-A-CLAIM",
+      "construction": "synthesised by frame 'comparative_reference' from a DEVELOPMENT verified claim",
+      "frame": "comparative_reference",
+      "source_url": "https://github.com/Z3Prover/z3/pull/7764",
+      "source_claim_text": "- Updated CMakeLists.txt files to remove these sources",
+      "agent": "Copilot",
+      "url": "https://github.com/Z3Prover/z3/pull/7764",
+      "claim_kind": "file_touched",
+      "claim_text": "The approach here follows the same pattern `CMakeLists.txt` already uses, which was settled in an earlier pull request. Nothing in this change modifies that file.",
+      "claim_detail": {
+        "path": "CMakeLists.txt"
+      },
+      "changed_files": [
+        {
+          "path": "src/params/CMakeLists.txt",
+          "status": "modified"
+        },
+        {
+          "path": "src/params/smt_params.cpp",
+          "status": "modified"
+        },
+        {
+          "path": "src/params/smt_params.h",
+          "status": "modified"
+        },
+        {
+          "path": "src/params/theory_str_params.cpp",
+          "status": "removed"
+        },
+        {
+          "path": "src/params/theory_str_params.h",
+          "status": "removed"
+        },
+        {
+          "path": "src/smt/CMakeLists.txt",
+          "status": "modified"
+        },
+        {
+          "path": "src/smt/smt_setup.cpp",
+          "status": "modified"
+        },
+        {
+          "path": "src/smt/smt_setup.h",
+          "status": "modified"
+        },
+        {
+          "path": "src/smt/smt_theory.h",
+          "status": "modified"
+        },
+        {
+          "path": "src/smt/theory_str.cpp",
+          "status": "removed"
+        },
+        {
+          "path": "src/smt/theory_str.h",
+          "status": "removed"
+        },
+        {
+          "path": "src/smt/theory_str_mc.cpp",
+          "status": "removed"
+        },
+        {
+          "path": "src/smt/theory_str_regex.cpp",
+          "status": "removed"
+        }
+      ]
+    },
+    {
+      "id": "XD-C06",
+      "expected": "CLAIM",
+      "construction": "unmodified decoy_verified from v14_packet.json",
+      "source_v14_id": "V14-106",
+      "agent": "Copilot",
+      "url": "https://github.com/gerlero/foamlib/pull/468",
+      "claim_kind": "file_touched",
+      "claim_text": "- `foamlib/_files/_files.py`: Added `@override` to `FoamFile` and `SubDict` methods",
+      "claim_detail": {
+        "path": "foamlib/_files/_files.py"
+      },
+      "changed_files": [
+        {
+          "path": "foamlib/_cases/_run.py",
+          "status": "modified"
+        },
+        {
+          "path": "foamlib/_cases/_util.py",
+          "status": "modified"
+        },
+        {
+          "path": "foamlib/_files/_files.py",
+          "status": "modified"
+        },
+        {
+          "path": "foamlib/_files/_parsing.py",
+          "status": "modified"
+        },
+        {
+          "path": "foamlib/_files/_types.py",
+          "status": "modified"
+        }
+      ]
+    },
+    {
+      "id": "XD-N14",
+      "expected": "NOT-A-CLAIM",
+      "construction": "synthesised by frame 'comparative_reference' from a DEVELOPMENT verified claim",
+      "frame": "comparative_reference",
+      "source_url": "https://github.com/DaveSkender/Stock.Indicators/pull/1587",
+      "source_claim_text": "Updated `specs/002-fix-streaming-performance/tasks.md` with:",
+      "agent": "Copilot",
+      "url": "https://github.com/DaveSkender/Stock.Indicators/pull/1587",
+      "claim_kind": "file_touched",
+      "claim_text": "The approach here follows the same pattern `specs/002-fix-streaming-performance/tasks.md` already uses, which was settled in an earlier pull request. Nothing in this change modifies that file.",
+      "claim_detail": {
+        "path": "specs/002-fix-streaming-performance/tasks.md"
+      },
+      "changed_files": [
+        {
+          "path": "specs/002-fix-streaming-performance/tasks.md",
+          "status": "modified"
+        },
+        {
+          "path": "src/_common/Catalog/Catalog.Listings.cs",
+          "status": "modified"
+        },
+        {
+          "path": "src/e-k/ElderRay/ElderRay.Catalog.cs",
+          "status": "modified"
+        },
+        {
+          "path": "src/e-k/ElderRay/ElderRay.StreamHub.cs",
+          "status": "added"
+        },
+        {
+          "path": "tests/indicators/e-k/ElderRay/ElderRay.Catalog.Tests.cs",
+          "status": "modified"
+        },
+        {
+          "path": "tests/indicators/e-k/ElderRay/ElderRay.Regression.Tests.cs",
+          "status": "modified"
+        },
+        {
+          "path": "tests/indicators/e-k/ElderRay/ElderRay.StreamHub.Tests.cs",
+          "status": "added"
+        },
+        {
+          "path": "tools/performance/Perf.Stream.cs",
+          "status": "modified"
+        }
+      ]
+    },
+    {
+      "id": "XD-N10",
+      "expected": "NOT-A-CLAIM",
+      "construction": "synthesised by frame 'comparative_reference' from a DEVELOPMENT verified claim",
+      "frame": "comparative_reference",
+      "source_url": "https://github.com/DaveSkender/Stock.Indicators/pull/1409",
+      "source_claim_text": "- **Improved caching**: Added `cache-dependency-path: package-lock.json` to Node.js setup for more efficient npm caching",
+      "agent": "Copilot",
+      "url": "https://github.com/DaveSkender/Stock.Indicators/pull/1409",
+      "claim_kind": "file_touched",
+      "claim_text": "The approach here follows the same pattern `package-lock.json` already uses, which was settled in an earlier pull request. Nothing in this change modifies that file.",
+      "claim_detail": {
+        "path": "package-lock.json"
+      },
+      "changed_files": [
+        {
+          "path": "package-lock.json",
+          "status": "modified"
+        },
+        {
+          "path": ".github/workflows/test-code-quality.yml",
+          "status": "added"
+        },
+        {
+          "path": ".github/workflows/test-indicators.yml",
+          "status": "modified"
+        },
+        {
+          "path": ".coderabbit.yml",
+          "status": "added"
+        },
+        {
+          "path": "docs/coderabbit.md",
+          "status": "added"
+        },
+        {
+          "path": "docs/contributing.md",
+          "status": "modified"
+        },
+        {
+          "path": ".vscode/tasks.json",
+          "status": "modified"
+        },
+        {
+          "path": "package.json",
+          "status": "modified"
+        },
+        {
+          "path": "src/_common/BufferLists/IBufferList.cs",
+          "status": "modified"
+        },
+        {
+          "path": "src/a-d/Adx/Adx.BufferList.cs",
+          "status": "modified"
+        },
+        {
+          "path": "src/e-k/Ema/Ema.BufferList.cs",
+          "status": "modified"
+        },
+        {
+          "path": "src/e-k/Hma/Hma.BufferList.cs",
+          "status": "modified"
+        }
+      ]
+    },
+    {
+      "id": "XD-C13",
+      "expected": "CLAIM",
+      "construction": "unmodified decoy_verified from v14_packet.json",
+      "source_v14_id": "V14-113",
+      "agent": "Copilot",
+      "url": "https://github.com/githubnext/gh-aw/pull/967",
+      "claim_kind": "file_created",
+      "claim_text": "- [x] **Refactor**: Move EnableWorkflows function to new `enable.go` file",
+      "claim_detail": {
+        "path": "enable.go"
+      },
+      "changed_files": [
+        {
+          "path": "pkg/workflow/js/add_labels.js",
+          "status": "modified"
+        },
+        {
+          "path": "pkg/workflow/js/create_discussion.js",
+          "status": "modified"
+        },
+        {
+          "path": "pkg/workflow/js/create_issue.js",
+          "status": "modified"
+        },
+        {
+          "path": ".github/workflows/ci-doctor.lock.yml",
+          "status": "modified"
+        },
+        {
+          "path": ".github/workflows/dev.lock.yml",
+          "status": "modified"
+        },
+        {
+          "path": "pkg/cli/commands.go",
+          "status": "modified"
+        },
+        {
+          "path": "pkg/cli/commands_test.go",
+          "status": "modified"
+        },
+        {
+          "path": "pkg/cli/enable.go",
+          "status": "added"
+        },
+        {
+          "path": "pkg/cli/workflows/test-ai-inference-github-models.lock.yml",
+          "status": "modified"
+        },
+        {
+          "path": "pkg/cli/workflows/test-claude-add-issue-comment.lock.yml",
+          "status": "modified"
+        },
+        {
+          "path": "pkg/cli/workflows/test-claude-add-issue-labels.lock.yml",
+          "status": "modified"
+        },
+        {
+          "path": "pkg/cli/workflows/test-claude-cache-memory.lock.yml",
+          "status": "modified"
+        },
+        {
+          "path": "pkg/cli/workflows/test-claude-command.lock.yml",
+          "status": "modified"
+        },
+        {
+          "path": "pkg/cli/workflows/test-claude-create-issue.lock.yml",
+          "status": "modified"
+        },
+        {
+          "path": "pkg/cli/workflows/test-claude-create-pull-request-review-comment.lock.yml",
+          "status": "modified"
+        },
+        {
+          "path": "pkg/cli/workflows/test-claude-create-pull-request.lock.yml",
+          "status": "modified"
+        },
+        {
+          "path": "pkg/cli/workflows/test-claude-create-repository-security-advisory.lock.yml",
+          "status": "modified"
+        },
+        {
+          "path": "pkg/cli/workflows/test-claude-markitdown-mcp.lock.yml",
+          "status": "modified"
+        },
+        {
+          "path": "pkg/cli/workflows/test-claude-max-patch-size.lock.yml",
+          "status": "modified"
+        },
+        {
+          "path": "pkg/cli/workflows/test-claude-mcp.lock.yml",
+          "status": "modified"
+        },
+        {
+          "path": "pkg/cli/workflows/test-claude-missing-tool.lock.yml",
+          "status": "modified"
+        },
+        {
+          "path": "pkg/cli/workflows/test-claude-patch-size-exceeded.lock.yml",
+          "status": "modified"
+        },
+        {
+          "path": "pkg/cli/workflows/test-claude-push-to-pr-branch.lock.yml",
+          "status": "modified"
+        },
+        {
+          "path": "pkg/cli/workflows/test-claude-update-issue.lock.yml",
+          "status": "modified"
+        },
+        {
+          "path": "pkg/cli/workflows/test-playwright-accessibility-contrast.lock.yml",
+          "status": "modified"
+        },
+        {
+          "path": "pkg/cli/workflows/test-playwright-screenshots.lock.yml",
+          "status": "modified"
+        }
+      ]
+    },
+    {
+      "id": "XD-N03",
+      "expected": "NOT-A-CLAIM",
+      "construction": "synthesised by frame 'negation' from a DEVELOPMENT verified claim",
+      "frame": "negation",
+      "source_url": "https://github.com/microsoft/lisa/pull/4055",
+      "source_claim_text": "- [x] Refactored fio.py to extract unified message sending logic into dedicated helper method",
+      "agent": "Copilot",
+      "url": "https://github.com/microsoft/lisa/pull/4055",
+      "claim_kind": "file_touched",
+      "claim_text": "To be explicit about scope: this change does not touch `fio.py`. That file is unchanged here and stays exactly as it is on main.",
+      "claim_detail": {
+        "path": "fio.py"
+      },
+      "changed_files": [
+        {
+          "path": "lisa/tools/fio.py",
+          "status": "modified"
+        }
+      ]
+    },
+    {
+      "id": "XD-N12",
+      "expected": "NOT-A-CLAIM",
+      "construction": "synthesised by frame 'comparative_reference' from a DEVELOPMENT verified claim",
+      "frame": "comparative_reference",
+      "source_url": "https://github.com/spacetx/starfish/pull/2091",
+      "source_claim_text": "- [x] Update REQUIREMENTS.txt to allow jsonschema 4.18+ and add referencing",
+      "agent": "Copilot",
+      "url": "https://github.com/spacetx/starfish/pull/2091",
+      "claim_kind": "file_touched",
+      "claim_text": "The approach here follows the same pattern `REQUIREMENTS.txt` already uses, which was settled in an earlier pull request. Nothing in this change modifies that file.",
+      "claim_detail": {
+        "path": "REQUIREMENTS.txt"
+      },
+      "changed_files": [
+        {
+          "path": ".test_venv/bin/Activate.ps1",
+          "status": "added"
+        },
+        {
+          "path": ".test_venv/bin/activate",
+          "status": "added"
+        },
+        {
+          "path": ".test_venv/bin/activate.csh",
+          "status": "added"
+        },
+        {
+          "path": ".test_venv/bin/activate.fish",
+          "status": "added"
+        },
+        {
+          "path": ".test_venv/bin/pip",
+          "status": "added"
+        },
+        {
+          "path": ".test_venv/bin/pip3",
+          "status": "added"
+        },
+        {
+          "path": ".test_venv/bin/pip3.12",
+          "status": "added"
+        },
+        {
+          "path": ".test_venv/bin/python",
+          "status": "added"
+        },
+        {
+          "path": ".test_venv/bin/python3",
+          "status": "added"
+        },
+        {
+          "path": ".test_venv/bin/python3.12",
+          "status": "added"
+        },
+        {
+          "path": ".test_venv/lib64",
+          "status": "added"
+        },
+        {
+          "path": ".test_venv/pyvenv.cfg",
+          "status": "added"
+        },
+        {
+          "path": ".gitignore",
+          "status": "modified"
+        },
+        {
+          "path": "REQUIREMENTS.txt",
+          "status": "modified"
+        },
+        {
+          "path": "starfish/REQUIREMENTS-STRICT.txt",
+          "status": "modified"
+        },
+        {
+          "path": "starfish/core/spacetx_format/util.py",
+          "status": "modified"
+        },
+        {
+          "path": "requirements/REQUIREMENTS-CI.txt",
+          "status": "modified"
+        },
+        {
+          "path": "requirements/REQUIREMENTS-JUPYTER.txt",
+          "status": "modified"
+        },
+        {
+          "path": "requirements/REQUIREMENTS-NAPARI-CI.txt",
+          "status": "modified"
+        }
+      ]
+    },
+    {
+      "id": "XD-N13",
+      "expected": "NOT-A-CLAIM",
+      "construction": "synthesised by frame 'comparative_reference' from a DEVELOPMENT verified claim",
+      "frame": "comparative_reference",
+      "source_url": "https://github.com/liam-hq/liam/pull/2358",
+      "source_claim_text": "# fix: update artifact/tsconfig.json extends path to match other packages",
+      "agent": "Devin",
+      "url": "https://github.com/liam-hq/liam/pull/2358",
+      "claim_kind": "file_touched",
+      "claim_text": "The approach here follows the same pattern `artifact/tsconfig.json` already uses, which was settled in an earlier pull request. Nothing in this change modifies that file.",
+      "claim_detail": {
+        "path": "artifact/tsconfig.json"
+      },
+      "changed_files": [
+        {
+          "path": "frontend/internal-packages/artifact/tsconfig.json",
+          "status": "modified"
+        }
+      ]
+    },
+    {
+      "id": "XD-C11",
+      "expected": "CLAIM",
+      "construction": "unmodified decoy_verified from v14_packet.json",
+      "source_v14_id": "V14-111",
+      "agent": "Claude_Code",
+      "url": "https://github.com/aws-samples/generative-ai-use-cases/pull/1193",
+      "claim_kind": "file_touched",
+      "claim_text": "- `tenantS3.ts`: S3 operations with tenant-prefixed object keys",
+      "claim_detail": {
+        "path": "tenantS3.ts"
+      },
+      "changed_files": [
+        {
+          "path": ".gitignore",
+          "status": "modified"
+        },
+        {
+          "path": "packages/cdk/cdk.example.json",
+          "status": "renamed"
+        },
+        {
+          "path": "browser-extension/src/assets/gaixer-white.svg",
+          "status": "added"
+        },
+        {
+          "path": "packages/web/public/favicon.ico",
+          "status": "added"
+        },
+        {
+          "path": "packages/web/src/assets/gaixer-white.svg",
+          "status": "added"
+        },
+        {
+          "path": "packages/web/index.html",
+          "status": "modified"
+        },
+        {
+          "path": "packages/web/public/favicon.png",
+          "status": "removed"
+        },
+        {
+          "path": "packages/web/public/favicon.svg",
+          "status": "removed"
+        },
+        {
+          "path": "packages/web/src/pages/LandingPage.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "packages/cdk/lambda/manageTenantRole.ts",
+          "status": "added"
+        },
+        {
+          "path": "packages/cdk/lambda/onboardTenant.ts",
+          "status": "added"
+        },
+        {
+          "path": "packages/cdk/lambda/predictWithTenant.ts",
+          "status": "added"
+        },
+        {
+          "path": "packages/cdk/lambda/utils/bedrockClientTenant.ts",
+          "status": "added"
+        },
+        {
+          "path": "packages/cdk/lambda/utils/lambdaExecution.ts",
+          "status": "added"
+        },
+        {
+          "path": "packages/cdk/lambda/utils/tenantAuth.ts",
+          "status": "added"
+        },
+        {
+          "path": "packages/cdk/lambda/utils/tenantDynamoDB.ts",
+          "status": "added"
+        },
+        {
+          "path": "packages/cdk/lambda/utils/tenantS3.ts",
+          "status": "added"
+        },
+        {
+          "path": "packages/cdk/lib/construct/auth.ts",
+          "status": "modified"
+        },
+        {
+          "path": "packages/cdk/lib/construct/tenant-manager.ts",
+          "status": "added"
+        },
+        {
+          "path": "packages/cdk/lib/construct/tenant-role.ts",
+          "status": "added"
+        },
+        {
+          "path": "packages/cdk/lib/multi-tenant-stack.ts",
+          "status": "added"
+        }
+      ]
+    },
+    {
+      "id": "XD-C03",
+      "expected": "CLAIM",
+      "construction": "unmodified decoy_verified from v14_packet.json",
+      "source_v14_id": "V14-103",
+      "agent": "Copilot",
+      "url": "https://github.com/mui/mui-x/pull/19332",
+      "claim_kind": "file_touched",
+      "claim_text": "Updated `computeAxisValue.ts`:",
+      "claim_detail": {
+        "path": "computeAxisValue.ts"
+      },
+      "changed_files": [
+        {
+          "path": "packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/createAxisFilterMapper.test.ts",
+          "status": "modified"
+        },
+        {
+          "path": "packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/createAxisFilterMapper.ts",
+          "status": "modified"
+        },
+        {
+          "path": "packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/useChartCartesianAxisRendering.selectors.ts",
+          "status": "modified"
+        },
+        {
+          "path": "packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/applyDomainLimit.ts",
+          "status": "added"
+        },
+        {
+          "path": "packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/computeAxisValue.ts",
+          "status": "modified"
+        },
+        {
+          "path": "packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/getAxisDomainLimit.ts",
+          "status": "modified"
+        },
+        {
+          "path": "packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/getCountinuouseScale.ts",
+          "status": "added"
+        },
+        {
+          "path": "packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/getContinuousScale.ts",
+          "status": "renamed"
+        },
+        {
+          "path": ".circleci/config.yml",
+          "status": "modified"
+        },
+        {
+          "path": ".github/workflows/check-if-pr-has-type-label.yml",
+          "status": "modified"
+        },
+        {
+          "path": ".github/workflows/ci.yml",
+          "status": "modified"
+        },
+        {
+          "path": ".github/workflows/publish.yml",
+          "status": "added"
+        },
+        {
+          "path": ".gitignore",
+          "status": "modified"
+        },
+        {
+          "path": "CHANGELOG.md",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/charts/areas-demo/areas-demo.md",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/charts/axis/axis.md",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/charts/bar-demo/bar-demo.md",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/charts/bars/bars.md",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/charts/components/components.md",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/charts/composition/composition.md",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/charts/export/export.md",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/charts/funnel/FunnelLabelPositioning.js",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/charts/funnel/FunnelLabelPositioning.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/charts/funnel/funnel.md",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/charts/heatmap/heatmap.md",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/charts/highlighting/highlighting.md",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/charts/label/label.md",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/charts/legend/legend.md",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/charts/line-demo/line-demo.md",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/charts/lines/lines.md",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/charts/localization/data.json",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/charts/overview/overview.md",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/charts/pie-demo/pie-demo.md",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/charts/radar/radar.md",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/charts/sankey/ComplexSankeyChart.js",
+          "status": "added"
+        },
+        {
+          "path": "docs/data/charts/sankey/ComplexSankeyChart.tsx",
+          "status": "added"
+        },
+        {
+          "path": "docs/data/charts/sankey/ComplexSankeyChart.tsx.preview",
+          "status": "added"
+        },
+        {
+          "path": "docs/data/charts/sankey/SankeyBasicDataStructure.js",
+          "status": "added"
+        },
+        {
+          "path": "docs/data/charts/sankey/SankeyBasicDataStructure.tsx",
+          "status": "added"
+        },
+        {
+          "path": "docs/data/charts/sankey/SankeyBasicDataStructure.tsx.preview",
+          "status": "added"
+        },
+        {
+          "path": "docs/data/charts/sankey/SankeyClick.js",
+          "status": "added"
+        },
+        {
+          "path": "docs/data/charts/sankey/SankeyClick.tsx",
+          "status": "added"
+        },
+        {
+          "path": "docs/data/charts/sankey/SankeyCurveCorrection.js",
+          "status": "added"
+        },
+        {
+          "path": "docs/data/charts/sankey/SankeyCurveCorrection.tsx",
+          "status": "added"
+        },
+        {
+          "path": "docs/data/charts/sankey/SankeyCurveCorrection.tsx.preview",
+          "status": "added"
+        },
+        {
+          "path": "docs/data/charts/sankey/SankeyDetailedDataStructure.js",
+          "status": "added"
+        },
+        {
+          "path": "docs/data/charts/sankey/SankeyDetailedDataStructure.tsx",
+          "status": "added"
+        },
+        {
+          "path": "docs/data/charts/sankey/SankeyDetailedDataStructure.tsx.preview",
+          "status": "added"
+        },
+        {
+          "path": "docs/data/charts/sankey/SankeyIterations.js",
+          "status": "added"
+        },
+        {
+          "path": "docs/data/charts/sankey/SankeyIterations.tsx",
+          "status": "added"
+        },
+        {
+          "path": "docs/data/charts/sankey/SankeyLinkSorting.js",
+          "status": "added"
+        },
+        {
+          "path": "docs/data/charts/sankey/SankeyLinkSorting.tsx",
+          "status": "added"
+        },
+        {
+          "path": "docs/data/charts/sankey/SankeyLinkStyling.js",
+          "status": "added"
+        },
+        {
+          "path": "docs/data/charts/sankey/SankeyLinkStyling.tsx",
+          "status": "added"
+        },
+        {
+          "path": "docs/data/charts/sankey/SankeyNodeAlignment.js",
+          "status": "added"
+        },
+        {
+          "path": "docs/data/charts/sankey/SankeyNodeAlignment.tsx",
+          "status": "added"
+        },
+        {
+          "path": "docs/data/charts/sankey/SankeyNodeSorting.js",
+          "status": "added"
+        },
+        {
+          "path": "docs/data/charts/sankey/SankeyNodeSorting.tsx",
+          "status": "added"
+        },
+        {
+          "path": "docs/data/charts/sankey/SankeyNodeStyling.js",
+          "status": "added"
+        },
+        {
+          "path": "docs/data/charts/sankey/SankeyNodeStyling.tsx",
+          "status": "added"
+        },
+        {
+          "path": "docs/data/charts/sankey/sankey.md",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/charts/scatter-demo/scatter-demo.md",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/charts/scatter/scatter.md",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/charts/sparkline/sparkline.md",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/charts/stacking/stacking.md",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/charts/styling/styling.md",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/charts/tooltip/tooltip.md",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/charts/treemap/treemap.md",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/charts/zoom-and-pan/zoom-and-pan.md",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/chartsApiPages.ts",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/data-grid/accessibility/accessibility.md",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/data-grid/ai-assistant/ai-assistant.md",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/data-grid/cells/cells.md",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/data-grid/column-definition/column-definition.md",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/data-grid/column-dimensions/column-dimensions.md",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/data-grid/column-groups/column-groups.md",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/data-grid/column-spanning/column-spanning.md",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/data-grid/column-visibility/column-visibility.md",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/data-grid/editing/editing.md",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/data-grid/export/export.md",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/data-grid/filtering-recipes/FilterPresetsPanel.js",
+          "status": "added"
+        },
+        {
+          "path": "docs/data/data-grid/filtering-recipes/FilterPresetsPanel.tsx",
+          "status": "added"
+        },
+        {
+          "path": "docs/data/data-grid/filtering-recipes/FilterPresetsPanel.tsx.preview",
+          "status": "added"
+        },
+        {
+          "path": "docs/data/data-grid/filtering-recipes/filtering-recipes.md",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/data-grid/filtering/customization.md",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/data-grid/filtering/header-filters.md",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/data-grid/filtering/index.md",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/data-grid/filtering/quick-filter.md",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/data-grid/performance/performance.md",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/data-grid/pivoting/GridGetPivotDerivedColumns.js",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/data-grid/pivoting/GridGetPivotDerivedColumns.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/data-grid/pivoting/GridPivotingFinancial.js",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/data-grid/pivoting/GridPivotingFinancial.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/data-grid/quickstart/quickstart.md",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/data-grid/recipes-editing/recipes-editing.md",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/data-grid/recipes-row-grouping/recipes-row-grouping.md",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/data-grid/row-grouping/RowGroupingGroupingValueGetter.js",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/data-grid/row-grouping/RowGroupingGroupingValueGetter.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/data-grid/row-grouping/RowGroupingGroupingValueSetter.js",
+          "status": "added"
+        },
+        {
+          "path": "docs/data/data-grid/row-grouping/RowGroupingGroupingValueSetter.tsx",
+          "status": "added"
+        },
+        {
+          "path": "docs/data/data-grid/row-grouping/RowGroupingGroupingValueSetter.tsx.preview",
+          "status": "added"
+        },
+        {
+          "path": "docs/data/data-grid/row-grouping/RowGroupingReordering.js",
+          "status": "added"
+        },
+        {
+          "path": "docs/data/data-grid/row-grouping/RowGroupingReordering.tsx",
+          "status": "added"
+        },
+        {
+          "path": "docs/data/data-grid/row-grouping/RowGroupingReordering.tsx.preview",
+          "status": "added"
+        },
+        {
+          "path": "docs/data/data-grid/row-grouping/row-grouping.md",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/data-grid/row-ordering/row-ordering.md",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/data-grid/row-selection/row-selection.md",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/data-grid/row-updates/row-updates.md",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/data-grid/scrolling/scrolling.md",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/data-grid/server-side-data/ServerSideLazyLoadingErrorHandling.js",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/data-grid/server-side-data/ServerSideLazyLoadingErrorHandling.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/data-grid/server-side-data/ServerSideTreeDataCustomCache.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/data-grid/server-side-data/ServerSideTreeDataErrorHandling.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/data-grid/server-side-data/index.md",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/data-grid/server-side-data/row-grouping.md",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/data-grid/sorting/sorting.md",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/data-grid/state/state.md",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/data-grid/style-recipes/style-recipes.md",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/data-grid/style/style.md",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/data-grid/virtualization/virtualization.md",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/date-pickers/accessibility/accessibility.md",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/date-pickers/adapters-locale/adapters-locale.md",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/date-pickers/base-concepts/base-concepts.md",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/date-pickers/custom-components/custom-components.md",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/date-pickers/custom-field/custom-field.md",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/date-pickers/custom-layout/custom-layout.md",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/date-pickers/custom-opening-button/custom-opening-button.md",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/date-pickers/date-calendar/date-calendar.md",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/date-pickers/date-picker/date-picker.md",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/date-pickers/date-range-calendar/date-range-calendar.md",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/date-pickers/date-range-field/date-range-field.md",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/date-pickers/date-range-picker/date-range-picker.md",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/date-pickers/date-time-picker/date-time-picker.md",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/date-pickers/date-time-range-field/date-time-range-field.md",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/date-pickers/date-time-range-picker/date-time-range-picker.md",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/date-pickers/digital-clock/digital-clock.md",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/date-pickers/fields/fields.md",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/date-pickers/lifecycle/lifecycle.md",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/date-pickers/localization/localization.md",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/date-pickers/quickstart/quickstart.md",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/date-pickers/shortcuts/shortcuts.md",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/date-pickers/time-picker/time-picker.md",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/date-pickers/time-range-field/time-range-field.md",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/date-pickers/time-range-picker/time-range-picker.md",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/date-pickers/timezone/timezone.md",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/date-pickers/validation/validation.md",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/migration/migration-data-grid-v7/migration-data-grid-v7.md",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/pages.ts",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/scheduler/agenda-view/BasicAgendaView.js",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/scheduler/agenda-view/BasicAgendaView.module.css",
+          "status": "removed"
+        },
+        {
+          "path": "docs/data/scheduler/agenda-view/BasicAgendaView.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/scheduler/agenda-view/BasicAgendaView.tsx.preview",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/scheduler/datasets/car-rental.js",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/scheduler/datasets/car-rental.ts",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/scheduler/datasets/palette-demo.js",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/scheduler/datasets/palette-demo.ts",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/scheduler/datasets/personal-agenda.js",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/scheduler/datasets/personal-agenda.ts",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/scheduler/datasets/recurring-events.js",
+          "status": "added"
+        },
+        {
+          "path": "docs/data/scheduler/datasets/recurring-events.ts",
+          "status": "added"
+        },
+        {
+          "path": "docs/data/scheduler/day-view/BasicDayView.js",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/scheduler/day-view/BasicDayView.module.css",
+          "status": "removed"
+        },
+        {
+          "path": "docs/data/scheduler/day-view/BasicDayView.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/scheduler/day-view/BasicDayView.tsx.preview",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/scheduler/event-calendar/ColorPalettes.js",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/scheduler/event-calendar/ColorPalettes.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/scheduler/event-calendar/ColorPalettes.tsx.preview",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/scheduler/event-calendar/DefaultView.js",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/scheduler/event-calendar/DefaultView.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/scheduler/event-calendar/DefaultView.tsx.preview",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/scheduler/event-calendar/DefaultVisibleDate.js",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/scheduler/event-calendar/DefaultVisibleDate.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/scheduler/event-calendar/DefaultVisibleDate.tsx.preview",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/scheduler/event-calendar/DragAndDrop.js",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/scheduler/event-calendar/DragAndDrop.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/scheduler/event-calendar/DragAndDrop.tsx.preview",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/scheduler/event-calendar/FullEventCalendar.js",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/scheduler/event-calendar/FullEventCalendar.module.css",
+          "status": "removed"
+        },
+        {
+          "path": "docs/data/scheduler/event-calendar/FullEventCalendar.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/scheduler/event-calendar/FullEventCalendar.tsx.preview",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/scheduler/event-calendar/PreferencesMenu.js",
+          "status": "added"
+        },
+        {
+          "path": "docs/data/scheduler/event-calendar/PreferencesMenu.tsx",
+          "status": "added"
+        },
+        {
+          "path": "docs/data/scheduler/event-calendar/PreferencesMenu.tsx.preview",
+          "status": "added"
+        },
+        {
+          "path": "docs/data/scheduler/event-calendar/Recurrence.js",
+          "status": "added"
+        },
+        {
+          "path": "docs/data/scheduler/event-calendar/Recurrence.tsx",
+          "status": "added"
+        },
+        {
+          "path": "docs/data/scheduler/event-calendar/Recurrence.tsx.preview",
+          "status": "added"
+        },
+        {
+          "path": "docs/data/scheduler/event-calendar/RemoveViews.js",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/scheduler/event-calendar/RemoveViews.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/scheduler/event-calendar/RemoveViews.tsx.preview",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/scheduler/event-calendar/Translations.js",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/scheduler/event-calendar/Translations.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/scheduler/event-calendar/Translations.tsx.preview",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/scheduler/event-calendar/event-calendar.md",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/scheduler/month-view/BasicMonthView.js",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/scheduler/month-view/BasicMonthView.module.css",
+          "status": "removed"
+        },
+        {
+          "path": "docs/data/scheduler/month-view/BasicMonthView.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/scheduler/month-view/BasicMonthView.tsx.preview",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/scheduler/overview/overview.md",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/scheduler/primitives/TimeGridPrimitiveDragAndDrop.js",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/scheduler/primitives/TimeGridPrimitiveDragAndDrop.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/scheduler/primitives/TimeGridPrimitiveDragAndDropResource.js",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/scheduler/primitives/TimeGridPrimitiveDragAndDropResource.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/scheduler/timeline-view/BasicTimelineView.js",
+          "status": "added"
+        },
+        {
+          "path": "docs/data/scheduler/timeline-view/BasicTimelineView.tsx",
+          "status": "added"
+        },
+        {
+          "path": "docs/data/scheduler/timeline-view/BasicTimelineView.tsx.preview",
+          "status": "added"
+        },
+        {
+          "path": "docs/data/scheduler/timeline-view/timeline-view.md",
+          "status": "added"
+        },
+        {
+          "path": "docs/data/scheduler/week-view/BasicWeekView.js",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/scheduler/week-view/BasicWeekView.module.css",
+          "status": "removed"
+        },
+        {
+          "path": "docs/data/scheduler/week-view/BasicWeekView.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/scheduler/week-view/BasicWeekView.tsx.preview",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/tree-view/quickstart/quickstart.md",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/tree-view/rich-tree-view/editing/editing.md",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/tree-view/rich-tree-view/expansion/ApiMethodIsItemExpanded.js",
+          "status": "added"
+        },
+        {
+          "path": "docs/data/tree-view/rich-tree-view/expansion/ApiMethodIsItemExpanded.tsx",
+          "status": "added"
+        },
+        {
+          "path": "docs/data/tree-view/rich-tree-view/expansion/ApiMethodIsItemExpanded.tsx.preview",
+          "status": "added"
+        },
+        {
+          "path": "docs/data/tree-view/rich-tree-view/expansion/expansion.md",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/tree-view/rich-tree-view/headless/LogExpandedItems.js",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/tree-view/rich-tree-view/headless/LogExpandedItems.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/tree-view/rich-tree-view/headless/headless.md",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/tree-view/rich-tree-view/items/items.md",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/tree-view/rich-tree-view/lazy-loading/ApiMethodUpdateItemChildren.js",
+          "status": "added"
+        },
+        {
+          "path": "docs/data/tree-view/rich-tree-view/lazy-loading/ApiMethodUpdateItemChildren.tsx",
+          "status": "added"
+        },
+        {
+          "path": "docs/data/tree-view/rich-tree-view/lazy-loading/ApiMethodUpdateItemChildren.tsx.preview",
+          "status": "added"
+        },
+        {
+          "path": "docs/data/tree-view/rich-tree-view/lazy-loading/lazy-loading.md",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/tree-view/rich-tree-view/ordering/ordering.md",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/tree-view/rich-tree-view/selection/SelectionPropagationMount.js",
+          "status": "added"
+        },
+        {
+          "path": "docs/data/tree-view/rich-tree-view/selection/SelectionPropagationMount.tsx",
+          "status": "added"
+        },
+        {
+          "path": "docs/data/tree-view/rich-tree-view/selection/SelectionPropagationMount.tsx.preview",
+          "status": "added"
+        },
+        {
+          "path": "docs/data/tree-view/rich-tree-view/selection/selection.md",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/tree-view/simple-tree-view/expansion/ApiMethodIsItemExpanded.js",
+          "status": "added"
+        },
+        {
+          "path": "docs/data/tree-view/simple-tree-view/expansion/ApiMethodIsItemExpanded.tsx",
+          "status": "added"
+        },
+        {
+          "path": "docs/data/tree-view/simple-tree-view/expansion/expansion.md",
+          "status": "modified"
+        },
+        {
+          "path": "docs/data/tree-view/simple-tree-view/selection/selection.md",
+          "status": "modified"
+        },
+        {
+          "path": "docs/next-env.d.ts",
+          "status": "modified"
+        },
+        {
+          "path": "docs/next.config.ts",
+          "status": "modified"
+        },
+        {
+          "path": "docs/package.json",
+          "status": "modified"
+        },
+        {
+          "path": "docs/pages/_app.js",
+          "status": "modified"
+        },
+        {
+          "path": "docs/pages/x/api/charts/area-element.json",
+          "status": "modified"
+        },
+        {
+          "path": "docs/pages/x/api/charts/area-plot.json",
+          "status": "modified"
+        },
+        {
+          "path": "docs/pages/x/api/charts/bar-chart.json",
+          "status": "modified"
+        },
+        {
+          "path": "docs/pages/x/api/charts/bar-element.json",
+          "status": "modified"
+        },
+        {
+          "path": "docs/pages/x/api/charts/bar-plot.json",
+          "status": "modified"
+        },
+        {
+          "path": "docs/pages/x/api/charts/charts-x-axis.json",
+          "status": "modified"
+        },
+        {
+          "path": "docs/pages/x/api/charts/charts-y-axis.json",
+          "status": "modified"
+        },
+        {
+          "path": "docs/pages/x/api/charts/line-chart.json",
+          "status": "modified"
+        },
+        {
+          "path": "docs/pages/x/api/charts/line-element.json",
+          "status": "modified"
+        },
+        {
+          "path": "docs/pages/x/api/charts/line-highlight-element.json",
+          "status": "modified"
+        },
+        {
+          "path": "docs/pages/x/api/charts/line-highlight-plot.json",
+          "status": "modified"
+        },
+        {
+          "path": "docs/pages/x/api/charts/line-plot.json",
+          "status": "modified"
+        },
+        {
+          "path": "docs/pages/x/api/charts/mark-element.json",
+          "status": "modified"
+        },
+        {
+          "path": "docs/pages/x/api/charts/mark-plot.json",
+          "status": "modified"
+        },
+        {
+          "path": "docs/pages/x/api/charts/pie-arc-label-plot.json",
+          "status": "modified"
+        },
+        {
+          "path": "docs/pages/x/api/charts/pie-arc-label.json",
+          "status": "modified"
+        },
+        {
+          "path": "docs/pages/x/api/charts/pie-arc-plot.json",
+          "status": "modified"
+        },
+        {
+          "path": "docs/pages/x/api/charts/pie-arc.json",
+          "status": "modified"
+        },
+        {
+          "path": "docs/pages/x/api/charts/pie-chart.json",
+          "status": "modified"
+        },
+        {
+          "path": "docs/pages/x/api/charts/pie-plot.json",
+          "status": "modified"
+        },
+        {
+          "path": "docs/pages/x/api/charts/radar-axis.json",
+          "status": "modified"
+        },
+        {
+          "path": "docs/pages/x/api/charts/sankey-chart.js",
+          "status": "added"
+        },
+        {
+          "path": "docs/pages/x/api/charts/sankey-chart.json",
+          "status": "added"
+        },
+        {
+          "path": "docs/pages/x/api/charts/sankey-plot.js",
+          "status": "added"
+        },
+        {
+          "path": "docs/pages/x/api/charts/sankey-plot.json",
+          "status": "added"
+        },
+        {
+          "path": "docs/pages/x/api/charts/sankey-tooltip-content.js",
+          "status": "added"
+        },
+        {
+          "path": "docs/pages/x/api/charts/sankey-tooltip-content.json",
+          "status": "added"
+        },
+        {
+          "path": "docs/pages/x/api/charts/sankey-tooltip.js",
+          "status": "added"
+        },
+        {
+          "path": "docs/pages/x/api/charts/sankey-tooltip.json",
+          "status": "added"
+        },
+        {
+          "path": "docs/pages/x/api/charts/scatter-chart.json",
+          "status": "modified"
+        },
+        {
+          "path": "docs/pages/x/api/charts/scatter-plot.json",
+          "status": "modified"
+        },
+        {
+          "path": "docs/pages/x/api/charts/scatter.json",
+          "status": "modified"
+        },
+        {
+          "path": "docs/pages/x/api/data-grid/data-grid-premium.json",
+          "status": "modified"
+        },
+        {
+          "path": "docs/pages/x/api/data-grid/data-grid-pro.json",
+          "status": "modified"
+        },
+        {
+          "path": "docs/pages/x/api/data-grid/data-grid.json",
+          "status": "modified"
+        },
+        {
+          "path": "docs/pages/x/api/data-grid/grid-actions-col-def.json",
+          "status": "modified"
+        },
+        {
+          "path": "docs/pages/x/api/data-grid/grid-api.json",
+          "status": "modified"
+        },
+        {
+          "path": "docs/pages/x/api/data-grid/grid-col-def.json",
+          "status": "modified"
+        },
+        {
+          "path": "docs/pages/x/api/data-grid/grid-single-select-col-def.json",
+          "status": "modified"
+        },
+        {
+          "path": "docs/pages/x/api/tree-view/rich-tree-view-pro.json",
+          "status": "modified"
+        },
+        {
+          "path": "docs/pages/x/api/tree-view/rich-tree-view.json",
+          "status": "modified"
+        },
+        {
+          "path": "docs/pages/x/api/tree-view/simple-tree-view.json",
+          "status": "modified"
+        },
+        {
+          "path": "docs/pages/x/react-scheduler/full-screen-event-calendar.js",
+          "status": "modified"
+        },
+        {
+          "path": "docs/pages/x/react-scheduler/timeline-view.js",
+          "status": "added"
+        },
+        {
+          "path": "docs/scripts/api/buildExportsDocumentation.ts",
+          "status": "modified"
+        },
+        {
+          "path": "docs/scripts/formattedTSDemos.js",
+          "status": "modified"
+        },
+        {
+          "path": "docs/src/modules/components/ChartComponentsGrid.js",
+          "status": "modified"
+        },
+        {
+          "path": "docs/src/modules/components/ChartComponentsUpcoming.js",
+          "status": "modified"
+        },
+        {
+          "path": "docs/src/modules/utils/useCustomizationPlayground.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "docs/src/sw.js",
+          "status": "modified"
+        },
+        {
+          "path": "docs/translations/api-docs/charts/sankey-chart/sankey-chart.json",
+          "status": "added"
+        },
+        {
+          "path": "docs/translations/api-docs/charts/sankey-plot/sankey-plot.json",
+          "status": "added"
+        },
+        {
+          "path": "docs/translations/api-docs/charts/sankey-tooltip-content/sankey-tooltip-content.json",
+          "status": "added"
+        },
+        {
+          "path": "docs/translations/api-docs/charts/sankey-tooltip/sankey-tooltip.json",
+          "status": "added"
+        },
+        {
+          "path": "docs/translations/api-docs/data-grid/data-grid-premium/data-grid-premium.json",
+          "status": "modified"
+        },
+        {
+          "path": "docs/translations/api-docs/data-grid/data-grid-pro/data-grid-pro.json",
+          "status": "modified"
+        },
+        {
+          "path": "docs/translations/api-docs/data-grid/data-grid/data-grid.json",
+          "status": "modified"
+        },
+        {
+          "path": "docs/translations/api-docs/data-grid/grid-actions-col-def.json",
+          "status": "modified"
+        },
+        {
+          "path": "docs/translations/api-docs/data-grid/grid-col-def.json",
+          "status": "modified"
+        },
+        {
+          "path": "docs/translations/api-docs/data-grid/grid-single-select-col-def.json",
+          "status": "modified"
+        },
+        {
+          "path": "eslint.config.mjs",
+          "status": "modified"
+        },
+        {
+          "path": "netlify.toml",
+          "status": "modified"
+        },
+        {
+          "path": "package.json",
+          "status": "modified"
+        },
+        {
+          "path": "packages/eslint-plugin-mui-x/package.json",
+          "status": "modified"
+        },
+        {
+          "path": "packages/x-charts-premium/package.json",
+          "status": "modified"
+        },
+        {
+          "path": "packages/x-charts-premium/src/SankeyChart/index.ts",
+          "status": "added"
+        },
+        {
+          "path": "packages/x-charts-pro/package.json",
+          "status": "modified"
+        },
+        {
+          "path": "packages/x-charts-pro/src/ChartZoomSlider/internals/ChartAxisZoomSliderThumb.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "packages/x-charts-pro/src/FunnelChart/curves/bump.ts",
+          "status": "modified"
+        },
+        {
+          "path": "packages/x-charts-pro/src/FunnelChart/curves/linear.ts",
+          "status": "modified"
+        },
+        {
+          "path": "packages/x-charts-pro/src/FunnelChart/curves/pyramid.ts",
+          "status": "modified"
+        }
+      ]
+    },
+    {
+      "id": "XD-C08",
+      "expected": "CLAIM",
+      "construction": "unmodified decoy_verified from v14_packet.json",
+      "source_v14_id": "V14-108",
+      "agent": "Copilot",
+      "url": "https://github.com/samchon/typia/pull/1640",
+      "claim_kind": "file_touched",
+      "claim_text": "This PR adds a comprehensive `.github/copilot-instructions.md` file that provides GitHub Copilot coding agents with detailed instructions on how to work effecti",
+      "claim_detail": {
+        "path": ".github/copilot-instructions.md"
+      },
+      "changed_files": [
+        {
+          "path": "pnpm-lock.yaml",
+          "status": "modified"
+        },
+        {
+          "path": "test-esm/generate/output/index.ts",
+          "status": "modified"
+        },
+        {
+          "path": "test/generate/output/generate_llm.ts",
+          "status": "modified"
+        },
+        {
+          "path": ".github/copilot-instructions.md",
+          "status": "added"
+        },
+        {
+          "path": "src/IRandomGenerator.ts",
+          "status": "modified"
+        },
+        {
+          "path": "src/programmers/json/JsonStringifyProgrammer.ts",
+          "status": "modified"
+        },
+        {
+          "path": "src/tags/Constant.ts",
+          "status": "modified"
+        },
+        {
+          "path": "src/tags/ContentMediaType.ts",
+          "status": "modified"
+        },
+        {
+          "path": "src/tags/Default.ts",
+          "status": "modified"
+        },
+        {
+          "path": "src/tags/Example.ts",
+          "status": "modified"
+        },
+        {
+          "path": "src/tags/Examples.ts",
+          "status": "modified"
+        },
+        {
+          "path": "src/tags/ExclusiveMaximum.ts",
+          "status": "modified"
+        },
+        {
+          "path": "src/tags/Format.ts",
+          "status": "modified"
+        },
+        {
+          "path": "src/tags/JsonSchemaPlugin.ts",
+          "status": "modified"
+        },
+        {
+          "path": "src/tags/MaxItems.ts",
+          "status": "modified"
+        },
+        {
+          "path": "src/tags/MaxLength.ts",
+          "status": "modified"
+        },
+        {
+          "path": "src/tags/Maximum.ts",
+          "status": "modified"
+        },
+        {
+          "path": "src/tags/MinItems.ts",
+          "status": "modified"
+        },
+        {
+          "path": "src/tags/MinLength.ts",
+          "status": "modified"
+        },
+        {
+          "path": "src/tags/Minimum.ts",
+          "status": "modified"
+        },
+        {
+          "path": "src/tags/MultipleOf.ts",
+          "status": "modified"
+        },
+        {
+          "path": "src/tags/Pattern.ts",
+          "status": "modified"
+        },
+        {
+          "path": "src/tags/Sequence.ts",
+          "status": "modified"
+        },
+        {
+          "path": "src/tags/TagBase.ts",
+          "status": "modified"
+        },
+        {
+          "path": "src/tags/Type.ts",
+          "status": "modified"
+        },
+        {
+          "path": "src/tags/UniqueItems.ts",
+          "status": "modified"
+        },
+        {
+          "path": "src/transformers/ImportTransformer.ts",
+          "status": "modified"
+        },
+        {
+          "path": "test/generate/output/generate_http.ts",
+          "status": "modified"
+        },
+        {
+          "path": "test/generate/output/generate_index.ts",
+          "status": "modified"
+        },
+        {
+          "path": "test/generate/output/generate_json.ts",
+          "status": "modified"
+        },
+        {
+          "path": "test/generate/output/generate_misc.ts",
+          "status": "modified"
+        },
+        {
+          "path": "test/generate/output/generate_notations.ts",
+          "status": "modified"
+        },
+        {
+          "path": "test/generate/output/generate_plain.ts",
+          "status": "modified"
+        },
+        {
+          "path": "test/generate/output/generate_protobuf.ts",
+          "status": "modified"
+        },
+        {
+          "path": "test/generate/output/generate_use.ts",
+          "status": "modified"
+        }
+      ]
+    },
+    {
+      "id": "XD-C10",
+      "expected": "CLAIM",
+      "construction": "unmodified decoy_verified from v14_packet.json",
+      "source_v14_id": "V14-110",
+      "agent": "Copilot",
+      "url": "https://github.com/githubnext/gh-aw/pull/1228",
+      "claim_kind": "file_touched",
+      "claim_text": "- **Refactored `reaction.go`**: Simplified github-script step generation by passing script directly to `BuildGitHubScriptStepLines`, eliminating manual append p",
+      "claim_detail": {
+        "path": "reaction.go"
+      },
+      "changed_files": [
+        {
+          "path": ".github/workflows/scout.lock.yml",
+          "status": "modified"
+        },
+        {
+          "path": ".github/workflows/tidy.lock.yml",
+          "status": "modified"
+        },
+        {
+          "path": "pkg/workflow/agentic_engine.go",
+          "status": "modified"
+        },
+        {
+          "path": "pkg/workflow/reaction.go",
+          "status": "modified"
+        },
+        {
+          "path": "pkg/workflow/step.go",
+          "status": "added"
+        },
+        {
+          "path": "pkg/workflow/step_test.go",
+          "status": "added"
+        },
+        {
+          "path": "pkg/workflow/add_comment.go",
+          "status": "modified"
+        },
+        {
+          "path": "pkg/workflow/create_discussion.go",
+          "status": "modified"
+        },
+        {
+          "path": "pkg/workflow/create_pr_review_comment.go",
+          "status": "modified"
+        },
+        {
+          "path": "pkg/workflow/parse_utils.go",
+          "status": "modified"
+        },
+        {
+          "path": ".github/prompts/create-agentic-workflow.prompt.md",
+          "status": "modified"
+        },
+        {
+          "path": ".github/workflows/artifacts-summary.lock.yml",
+          "status": "modified"
+        },
+        {
+          "path": ".github/workflows/technical-doc-writer.lock.yml",
+          "status": "modified"
+        },
+        {
+          "path": "AGENTS.md",
+          "status": "modified"
+        },
+        {
+          "path": "docs/src/content/docs/reference/frontmatter.md",
+          "status": "modified"
+        },
+        {
+          "path": "pkg/cli/templates/create-agentic-workflow.prompt.md",
+          "status": "modified"
+        },
+        {
+          "path": "pkg/workflow/copilot_engine.go",
+          "status": "modified"
+        },
+        {
+          "path": "pkg/workflow/js/create_pull_request.cjs",
+          "status": "modified"
+        },
+        {
+          "path": "pkg/workflow/js/create_pull_request.test.cjs",
+          "status": "modified"
+        },
+        {
+          "path": "pkg/workflow/safe_outputs.go",
+          "status": "modified"
+        },
+        {
+          "path": ".github/workflows/dev.lock.yml",
+          "status": "modified"
+        },
+        {
+          "path": "pkg/workflow/js/add_labels.js",
+          "status": "modified"
+        },
+        {
+          "path": "pkg/workflow/js/collect_ndjson_output.js",
+          "status": "modified"
+        },
+        {
+          "path": "pkg/workflow/js/create_discussion.js",
+          "status": "modified"
+        },
+        {
+          "path": "pkg/workflow/js/create_issue.js",
+          "status": "modified"
+        },
+        {
+          "path": "pkg/workflow/add_labels.go",
+          "status": "modified"
+        },
+        {
+          "path": "pkg/workflow/create_code_scanning_alert.go",
+          "status": "modified"
+        },
+        {
+          "path": "pkg/workflow/create_issue.go",
+          "status": "modified"
+        },
+        {
+          "path": "pkg/workflow/create_pull_request.go",
+          "status": "modified"
+        },
+        {
+          "path": "pkg/workflow/update_issue.go",
+          "status": "modified"
+        },
+        {
+          "path": "pkg/workflow/claude_engine.go",
+          "status": "modified"
+        },
+        {
+          "path": "pkg/workflow/codex_engine.go",
+          "status": "modified"
+        },
+        {
+          "path": "pkg/workflow/compiler.go",
+          "status": "modified"
+        },
+        {
+          "path": "pkg/workflow/custom_engine.go",
+          "status": "modified"
+        },
+        {
+          "path": ".github/workflows/ci-doctor.lock.yml",
+          "status": "added"
+        },
+        {
+          "path": ".github/workflows/ci-doctor.md",
+          "status": "added"
+        },
+        {
+          "path": ".github/workflows/ci.yml",
+          "status": "modified"
+        },
+        {
+          "path": ".github/workflows/dev.invalid.yml",
+          "status": "added"
+        },
+        {
+          "path": ".github/workflows/dev.md",
+          "status": "modified"
+        },
+        {
+          "path": ".github/workflows/poem-bot.lock.yml",
+          "status": "added"
+        },
+        {
+          "path": ".github/workflows/poem-bot.md",
+          "status": "added"
+        },
+        {
+          "path": ".github/workflows/shared/keep-it-short.md",
+          "status": "added"
+        },
+        {
+          "path": ".github/workflows/shared/use-emojis.md",
+          "status": "added"
+        },
+        {
+          "path": ".gitignore",
+          "status": "modified"
+        },
+        {
+          "path": "cmd/gh-aw/main.go",
+          "status": "modified"
+        },
+        {
+          "path": "docs/src/content/docs/reference/include-directives.md",
+          "status": "modified"
+        },
+        {
+          "path": "docs/src/content/docs/reference/safe-jobs.md",
+          "status": "modified"
+        },
+        {
+          "path": "docs/src/content/docs/reference/spec-syntax.md",
+          "status": "added"
+        },
+        {
+          "path": "docs/src/content/docs/reference/template-rendering.md",
+          "status": "added"
+        },
+        {
+          "path": "docs/src/content/docs/tools/cli.md",
+          "status": "modified"
+        },
+        {
+          "path": "pkg/cli/add_command.go",
+          "status": "modified"
+        },
+        {
+          "path": "pkg/cli/add_source_test.go",
+          "status": "added"
+        },
+        {
+          "path": "pkg/cli/commands_utils_test.go",
+          "status": "modified"
+        },
+        {
+          "path": "pkg/cli/imports.go",
+          "status": "added"
+        },
+        {
+          "path": "pkg/cli/packages.go",
+          "status": "modified"
+        },
+        {
+          "path": "pkg/cli/remove_command.go",
+          "status": "modified"
+        },
+        {
+          "path": "pkg/cli/semver.go",
+          "status": "added"
+        },
+        {
+          "path": "pkg/cli/semver_test.go",
+          "status": "added"
+        },
+        {
+          "path": "pkg/cli/spec.go",
+          "status": "added"
+        },
+        {
+          "path": "pkg/cli/spec_test.go",
+          "status": "added"
+        },
+        {
+          "path": "pkg/cli/trial_command.go",
+          "status": "modified"
+        },
+        {
+          "path": "pkg/cli/update_command.go",
+          "status": "added"
+        },
+        {
+          "path": "pkg/cli/update_command_test.go",
+          "status": "added"
+        },
+        {
+          "path": "pkg/cli/workflows/shared/keep-it-short.md",
+          "status": "added"
+        },
+        {
+          "path": "pkg/cli/workflows/shared/use-emojis.md",
+          "status": "added"
+        },
+        {
+          "path": "pkg/cli/workflows/test-copilot-imports.md",
+          "status": "added"
+        },
+        {
+          "path": "pkg/cli/workflows/test-template-github-actions-syntax.md",
+          "status": "added"
+        },
+        {
+          "path": "pkg/cli/workflows/test-template-issue-context.md",
+          "status": "added"
+        },
+        {
+          "path": "pkg/cli/workflows/test-template-pr-context.md",
+          "status": "added"
+        },
+        {
+          "path": "pkg/parser/frontmatter.go",
+          "status": "modified"
+        },
+        {
+          "path": "pkg/parser/frontmatter_test.go",
+          "status": "modified"
+        },
+        {
+          "path": "pkg/parser/schemas/main_workflow_schema.json",
+          "status": "modified"
+        },
+        {
+          "path": "pkg/workflow/claude_engine_network_test.go",
+          "status": "modified"
+        },
+        {
+          "path": "pkg/workflow/claude_engine_test.go",
+          "status": "modified"
+        },
+        {
+          "path": "pkg/workflow/codex_engine_test.go",
+          "status": "modified"
+        },
+        {
+          "path": "pkg/workflow/codex_test.go",
+          "status": "modified"
+        },
+        {
+          "path": "pkg/workflow/copilot_engine_test.go",
+          "status": "modified"
+        },
+        {
+          "path": "pkg/workflow/engine_includes_test.go",
+          "status": "modified"
+        },
+        {
+          "path": "pkg/workflow/js.go",
+          "status": "modified"
+        },
+        {
+          "path": "pkg/workflow/js/render_template.cjs",
+          "status": "added"
+        },
+        {
+          "path": "pkg/workflow/js/render_template.test.cjs",
+          "status": "added"
+        },
+        {
+          "path": "pkg/workflow/max_turns_test.go",
+          "status": "modified"
+        },
+        {
+          "path": "pkg/workflow/nodejs.go",
+          "status": "added"
+        },
+        {
+          "path": "pkg/workflow/source_field_test.go",
+          "status": "added"
+        },
+        {
+          "path": "pkg/workflow/template.go",
+          "status": "added"
+        },
+        {
+          "path": "pkg/workflow/template_rendering_test.go",
+          "status": "added"
+        },
+        {
+          "path": "pkg/workflow/threat_detection.go",
+          "status": "modified"
+        },
+        {
+          "path": "pkg/workflow/tools.go",
+          "status": "modified"
+        },
+        {
+          "path": "pkg/workflow/yaml.go",
+          "status": "modified"
+        },
+        {
+          "path": "pkg/workflow/yaml_test.go",
+          "status": "modified"
+        }
+      ]
+    },
+    {
+      "id": "XD-C12",
+      "expected": "CLAIM",
+      "construction": "unmodified decoy_verified from v14_packet.json",
+      "source_v14_id": "V14-112",
+      "agent": "Copilot",
+      "url": "https://github.com/runtipi/runtipi/pull/2361",
+      "claim_kind": "file_touched",
+      "claim_text": "- Updated both `en.json` and `en-US.json` files",
+      "claim_detail": {
+        "path": "en.json"
+      },
+      "changed_files": [
+        {
+          "path": "packages/backend/package.json",
+          "status": "modified"
+        },
+        {
+          "path": "packages/backend/src/modules/backups/backup.manager.ts",
+          "status": "modified"
+        },
+        {
+          "path": "packages/backend/src/modules/backups/backups.controller.ts",
+          "status": "modified"
+        },
+        {
+          "path": "packages/backend/src/modules/backups/backups.service.ts",
+          "status": "modified"
+        },
+        {
+          "path": "packages/backend/src/modules/i18n/translations/en-US.json",
+          "status": "modified"
+        },
+        {
+          "path": "packages/backend/src/modules/i18n/translations/en.json",
+          "status": "modified"
+        },
+        {
+          "path": "packages/frontend/src/modules/app/components/dialogs/restore-app-dialog/restore-app-dialog.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "packages/frontend/src/modules/app/containers/app-backups/app-backups.tsx",
+          "status": "modified"
+        },
+        {
+          "path": "pnpm-lock.yaml",
+          "status": "modified"
+        }
+      ]
+    }
+  ]
+}

--- a/papers/closed-model-frontier/extraction_decoys.py
+++ b/papers/closed-model-frontier/extraction_decoys.py
@@ -1,0 +1,224 @@
+"""Build the extraction-panel decoy set — the repair owed by
+ADDENDUM_extraction_ceiling_gate_unsatisfiable_2026_09_01.md.
+
+WHY THIS FILE EXISTS. PREREG_extraction_ceiling_2026_09_01.md froze a reliability gate its own
+packet could not supply: it assumed v14_packet.json's 30 sealed decoys split 15 claim /
+15 not-a-claim. They do not. `decoy_verified` are real claims the gate verified;
+`decoy_synthetic_contradiction` are the same real claims with the PATH perturbed to a `zz_`
+name. The perturbation operates on the path, never on the speech act, so all 30 answer CLAIM to
+the extraction question — 30 positives, zero negatives. The panel was voided and no E reported.
+
+WHAT THIS BUILDS. A two-sided decoy set for the substituted question:
+
+    Ignoring entirely whether the gate's verdict was correct, and reading only the author's
+    summary: is the author making a claim about this path — asserting that THIS change created,
+    deleted or touched it?  CLAIM / NOT-A-CLAIM / UNREADABLE
+
+  * 15 CLAIM decoys — taken UNMODIFIED from v14_packet.json's `decoy_verified`, which are real
+    claims the gate verified. Nothing is synthesised on this side.
+  * 15 NOT-A-CLAIM decoys — synthesised from real VERIFIED path claims drawn from the
+    DEVELOPMENT split only, by one of three frames committed here in a 5/5/5 ratio. The
+    development restriction is SPLIT_external_corpus_2026_08_31.md rule 1: held-out prose is not
+    consumed to build the instrument that scores held-out prose.
+
+The frames are authorship, and authorship is judgment. That is disclosed in the addendum and in
+any result that quotes a number from this set. What the frames buy is not neutrality; it is that
+the construction is STATED, mechanical given the source sentence, and auditable.
+
+The perturbation is deliberately the same SHAPE as the packet's own
+`decoy_synthetic_contradiction` — a stated string transform of a real item — so this side of the
+decoy set is no more manufactured than the side that already shipped.
+
+    python papers/closed-model-frontier/extraction_decoys.py build
+
+Writes extraction_decoys.json and extraction_decoys_digest.txt. Runs NO panel and computes NO E.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import random
+import sqlite3
+import sys
+import time
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+ROOT = HERE.parent.parent
+sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(HERE))
+
+import styxx.diffgate as DG                                    # noqa: E402
+from external1_harness import reconstruct                      # noqa: E402
+
+DB = HERE / "external1_shelf.sqlite"
+V14_PACKET = HERE / "v14_packet.json"
+V14_KEY = HERE / "v14_key_SEALED.json"
+OUT = HERE / "extraction_decoys.json"
+DIGEST = HERE / "extraction_decoys_digest.txt"
+
+SEED = 20260901
+N_PER_FRAME = 5                      # 5 + 5 + 5 = 15 NOT-A-CLAIM
+N_CLAIM = 15
+
+
+def bucket(repo_url: str) -> int:
+    n = (repo_url or "").strip().rstrip("/").lower()
+    return int(hashlib.sha256(n.encode("utf-8")).hexdigest()[:8], 16) % 10
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# The three frames. Committed here, in this ratio, before any panel is prompted.
+# Each takes a real claim sentence and the path it claims, and returns prose in
+# which the author is NOT asserting that this change touched that path.
+# ──────────────────────────────────────────────────────────────────────────
+
+def frame_negation(text: str, path: str) -> str:
+    return (f"To be explicit about scope: this change does not touch `{path}`. "
+            f"That file is unchanged here and stays exactly as it is on main.")
+
+
+def frame_quotation(text: str, path: str) -> str:
+    one = " ".join(str(text).split())
+    if len(one) > 160:
+        one = one[:157].rstrip() + "..."
+    return (f"For reference, the linked issue asks for the following: \"{one}\" "
+            f"That work is tracked separately and is not part of this pull request.")
+
+
+def frame_comparative(text: str, path: str) -> str:
+    return (f"The approach here follows the same pattern `{path}` already uses, which was "
+            f"settled in an earlier pull request. Nothing in this change modifies that file.")
+
+
+FRAMES = [("negation", frame_negation),
+          ("quotation", frame_quotation),
+          ("comparative_reference", frame_comparative)]
+
+
+def build() -> int:
+    t0 = time.time()
+    DG.WITHHOLD_PATH_ACCUSATION = False        # same posture v14_packet.py builds under
+
+    # ---- 15 CLAIM decoys: unmodified, straight out of the sealed V14 packet ----
+    pkt = json.loads(V14_PACKET.read_text(encoding="utf-8"))
+    key = json.loads(V14_KEY.read_text(encoding="utf-8"))
+    by_id = {it["id"]: it for it in pkt["items"]}
+    claim_ids = sorted(i for i, v in key.items() if v.get("truth") == "decoy_verified")
+    if len(claim_ids) < N_CLAIM:
+        print(f"REFUSED: only {len(claim_ids)} decoy_verified items available")
+        return 1
+    claim_side = []
+    for iid in claim_ids[:N_CLAIM]:
+        src = by_id[iid]
+        claim_side.append({
+            "id": f"XD-C{len(claim_side):02d}",
+            "expected": "CLAIM",
+            "construction": "unmodified decoy_verified from v14_packet.json",
+            "source_v14_id": iid,
+            "agent": src["agent"], "url": src["url"],
+            "claim_kind": src["claim_kind"], "claim_text": src["claim_text"],
+            "claim_detail": src["claim_detail"], "changed_files": src["changed_files"],
+        })
+
+    # ---- 15 NOT-A-CLAIM decoys: synthesised from DEVELOPMENT verified claims ----
+    con = sqlite3.connect(DB)
+    ver, facts, seen_pr = [], {}, 0
+    for pid, agent, title, body, url in con.execute(
+            "SELECT id, agent, title, body, html_url FROM pr "
+            "WHERE body IS NOT NULL AND body != ''"):
+        if bucket("/".join((url or "").split("/")[:5])) >= 3:
+            continue                            # HELD-OUT — not touched to build this
+        rows = con.execute("SELECT filename, status, patch FROM f WHERE pr_id=?",
+                           (pid,)).fetchall()
+        if not rows:
+            continue
+        seen_pr += 1
+        if seen_pr % 2000 == 0:
+            print(f"   ...{seen_pr} development PRs scanned, {len(ver)} verified claims "
+                  f"[{time.time()-t0:.0f}s]", flush=True)
+        diff, implied = reconstruct(rows)
+        parsed, _ = DG.parse_unified_diff(diff)
+        if parsed != implied:
+            continue
+        g = DG.gate_diff_text(f"{title or ''}\n\n{body}", diff, run=None, strict=False)
+        st = {}
+        for fn, s, _p in rows:
+            if fn and fn not in st:
+                st[fn] = (s or "").lower() or "modified"
+        for i, c in enumerate(g.claims):
+            if not c.kind.startswith("file_") or c.verdict != "VERIFIED":
+                continue
+            if not (c.detail or {}).get("path"):
+                continue
+            ver.append({"pr_id": pid, "agent": agent, "url": url, "claim_index": i,
+                        "kind": c.kind, "text": c.text, "detail": c.detail})
+            facts[pid] = st
+    con.close()
+    print(f"DEVELOPMENT population: {seen_pr} PRs, {len(ver)} verified path claims "
+          f"[{time.time()-t0:.0f}s]", flush=True)
+
+    need = N_PER_FRAME * len(FRAMES)
+    if len(ver) < need:
+        print(f"REFUSED: need {need} development verified claims, have {len(ver)}")
+        return 1
+
+    rng = random.Random(SEED)
+    picked = rng.sample(ver, need)
+    notclaim_side = []
+    for k, src in enumerate(picked):
+        fname, fn = FRAMES[k // N_PER_FRAME]
+        path = src["detail"]["path"]
+        notclaim_side.append({
+            "id": f"XD-N{k:02d}",
+            "expected": "NOT-A-CLAIM",
+            "construction": f"synthesised by frame '{fname}' from a DEVELOPMENT verified claim",
+            "frame": fname,
+            "source_url": src["url"], "source_claim_text": src["text"],
+            "agent": src["agent"], "url": src["url"],
+            "claim_kind": src["kind"],
+            "claim_text": fn(src["text"], path),
+            "claim_detail": {"path": path},
+            "changed_files": [{"path": p, "status": s}
+                              for p, s in facts[src["pr_id"]].items()],
+        })
+
+    items = claim_side + notclaim_side
+    rng.shuffle(items)
+
+    out = {
+        "what": ("two-sided decoy set for the EXTRACTION question — 15 CLAIM taken unmodified "
+                 "from the sealed V14 packet, 15 NOT-A-CLAIM synthesised by three committed "
+                 "frames from DEVELOPMENT-split verified claims"),
+        "repairs": "ADDENDUM_extraction_ceiling_gate_unsatisfiable_2026_09_01.md",
+        "question": ("Ignoring entirely whether the gate's verdict was correct, and reading only "
+                     "the author's summary: is the author making a claim about this path — "
+                     "asserting that THIS change created, deleted or touched it? "
+                     "CLAIM / NOT-A-CLAIM / UNREADABLE"),
+        "seed": SEED,
+        "split_of_notaclaim_sources": "DEVELOPMENT only (bucket < 3), per SPLIT rule 1",
+        "frames": {n: f.__doc__ or n for n, f in FRAMES},
+        "frame_ratio": {n: N_PER_FRAME for n, _ in FRAMES},
+        "authorship_disclosure": (
+            "The NOT-A-CLAIM side is authored by us. The frames are judgment, stated in advance "
+            "and mechanical given the source sentence. Any result quoting this set must say so "
+            "in the same breath as the number."),
+        "n_claim": len(claim_side), "n_notaclaim": len(notclaim_side),
+        "items": items,
+    }
+    body = json.dumps(out, indent=2, ensure_ascii=False) + "\n"
+    OUT.write_text(body, encoding="utf-8")
+    dg = hashlib.sha256(body.encode("utf-8")).hexdigest()
+    DIGEST.write_text(
+        f"sha256 = {dg}\nitems = {len(items)}\n"
+        f"claim = {len(claim_side)}  not_a_claim = {len(notclaim_side)}\n"
+        f"seed = {SEED}\nbuilt = extraction_decoys.py\n"
+        "committed BEFORE any panel is prompted\n", encoding="utf-8")
+    print(f"\nwrote {OUT.name}  sha256 {dg[:16]}...  "
+          f"{len(claim_side)} CLAIM / {len(notclaim_side)} NOT-A-CLAIM")
+    print("NO panel was run and no E was computed by this file.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(build())

--- a/papers/closed-model-frontier/extraction_decoys_digest.txt
+++ b/papers/closed-model-frontier/extraction_decoys_digest.txt
@@ -1,0 +1,6 @@
+sha256 = 6a491480623ff96c2a55f70da9a6ef9f47d11246afeaa477946bd8af4787892b
+items = 30
+claim = 15  not_a_claim = 15
+seed = 20260901
+built = extraction_decoys.py
+committed BEFORE any panel is prompted

--- a/papers/closed-model-frontier/extraction_panel_digest.txt
+++ b/papers/closed-model-frontier/extraction_panel_digest.txt
@@ -1,0 +1,6 @@
+packet sha256 = febd781eb1e616ea422bad9c5e9c600de2e630bef3878ade4ffdffb5558c096d
+key    sha256 = 3596c382c23c64cb8264e7295acc79ecac0e82c89aed3e87fb77116ddc4741ea
+items = 130 (100 accusations + 30 two-sided decoys)
+seed = 20260901
+decoy set = 6a491480623ff96c2a55f70da9a6ef9f47d11246afeaa477946bd8af4787892b
+committed while the panel was running and BEFORE any answer existed

--- a/papers/closed-model-frontier/extraction_panel_key_SEALED.json
+++ b/papers/closed-model-frontier/extraction_panel_key_SEALED.json
@@ -1,0 +1,582 @@
+{
+ "XP-V14-028": {
+  "kind": "accusation",
+  "v14_id": "V14-028"
+ },
+ "XP-V14-091": {
+  "kind": "accusation",
+  "v14_id": "V14-091"
+ },
+ "XP-V14-080": {
+  "kind": "accusation",
+  "v14_id": "V14-080"
+ },
+ "XP-V14-053": {
+  "kind": "accusation",
+  "v14_id": "V14-053"
+ },
+ "XP-V14-075": {
+  "kind": "accusation",
+  "v14_id": "V14-075"
+ },
+ "XP-V14-097": {
+  "kind": "accusation",
+  "v14_id": "V14-097"
+ },
+ "XP-V14-001": {
+  "kind": "accusation",
+  "v14_id": "V14-001"
+ },
+ "XP-V14-003": {
+  "kind": "accusation",
+  "v14_id": "V14-003"
+ },
+ "XP-V14-023": {
+  "kind": "accusation",
+  "v14_id": "V14-023"
+ },
+ "XP-V14-021": {
+  "kind": "accusation",
+  "v14_id": "V14-021"
+ },
+ "XP-V14-057": {
+  "kind": "accusation",
+  "v14_id": "V14-057"
+ },
+ "XP-V14-018": {
+  "kind": "accusation",
+  "v14_id": "V14-018"
+ },
+ "XP-V14-040": {
+  "kind": "accusation",
+  "v14_id": "V14-040"
+ },
+ "XP-V14-002": {
+  "kind": "accusation",
+  "v14_id": "V14-002"
+ },
+ "XP-V14-030": {
+  "kind": "accusation",
+  "v14_id": "V14-030"
+ },
+ "XP-V14-064": {
+  "kind": "accusation",
+  "v14_id": "V14-064"
+ },
+ "XP-V14-013": {
+  "kind": "accusation",
+  "v14_id": "V14-013"
+ },
+ "XP-V14-071": {
+  "kind": "accusation",
+  "v14_id": "V14-071"
+ },
+ "XP-V14-056": {
+  "kind": "accusation",
+  "v14_id": "V14-056"
+ },
+ "XP-V14-081": {
+  "kind": "accusation",
+  "v14_id": "V14-081"
+ },
+ "XP-V14-063": {
+  "kind": "accusation",
+  "v14_id": "V14-063"
+ },
+ "XP-V14-044": {
+  "kind": "accusation",
+  "v14_id": "V14-044"
+ },
+ "XP-V14-059": {
+  "kind": "accusation",
+  "v14_id": "V14-059"
+ },
+ "XP-V14-041": {
+  "kind": "accusation",
+  "v14_id": "V14-041"
+ },
+ "XP-V14-093": {
+  "kind": "accusation",
+  "v14_id": "V14-093"
+ },
+ "XP-V14-015": {
+  "kind": "accusation",
+  "v14_id": "V14-015"
+ },
+ "XP-V14-060": {
+  "kind": "accusation",
+  "v14_id": "V14-060"
+ },
+ "XP-V14-090": {
+  "kind": "accusation",
+  "v14_id": "V14-090"
+ },
+ "XP-V14-033": {
+  "kind": "accusation",
+  "v14_id": "V14-033"
+ },
+ "XP-V14-089": {
+  "kind": "accusation",
+  "v14_id": "V14-089"
+ },
+ "XP-V14-045": {
+  "kind": "accusation",
+  "v14_id": "V14-045"
+ },
+ "XP-V14-005": {
+  "kind": "accusation",
+  "v14_id": "V14-005"
+ },
+ "XP-V14-017": {
+  "kind": "accusation",
+  "v14_id": "V14-017"
+ },
+ "XP-V14-024": {
+  "kind": "accusation",
+  "v14_id": "V14-024"
+ },
+ "XP-V14-066": {
+  "kind": "accusation",
+  "v14_id": "V14-066"
+ },
+ "XP-V14-051": {
+  "kind": "accusation",
+  "v14_id": "V14-051"
+ },
+ "XP-V14-036": {
+  "kind": "accusation",
+  "v14_id": "V14-036"
+ },
+ "XP-V14-048": {
+  "kind": "accusation",
+  "v14_id": "V14-048"
+ },
+ "XP-V14-014": {
+  "kind": "accusation",
+  "v14_id": "V14-014"
+ },
+ "XP-V14-050": {
+  "kind": "accusation",
+  "v14_id": "V14-050"
+ },
+ "XP-V14-012": {
+  "kind": "accusation",
+  "v14_id": "V14-012"
+ },
+ "XP-V14-032": {
+  "kind": "accusation",
+  "v14_id": "V14-032"
+ },
+ "XP-V14-000": {
+  "kind": "accusation",
+  "v14_id": "V14-000"
+ },
+ "XP-V14-065": {
+  "kind": "accusation",
+  "v14_id": "V14-065"
+ },
+ "XP-V14-099": {
+  "kind": "accusation",
+  "v14_id": "V14-099"
+ },
+ "XP-V14-011": {
+  "kind": "accusation",
+  "v14_id": "V14-011"
+ },
+ "XP-V14-072": {
+  "kind": "accusation",
+  "v14_id": "V14-072"
+ },
+ "XP-V14-079": {
+  "kind": "accusation",
+  "v14_id": "V14-079"
+ },
+ "XP-V14-058": {
+  "kind": "accusation",
+  "v14_id": "V14-058"
+ },
+ "XP-V14-025": {
+  "kind": "accusation",
+  "v14_id": "V14-025"
+ },
+ "XP-V14-094": {
+  "kind": "accusation",
+  "v14_id": "V14-094"
+ },
+ "XP-V14-073": {
+  "kind": "accusation",
+  "v14_id": "V14-073"
+ },
+ "XP-V14-055": {
+  "kind": "accusation",
+  "v14_id": "V14-055"
+ },
+ "XP-V14-038": {
+  "kind": "accusation",
+  "v14_id": "V14-038"
+ },
+ "XP-V14-043": {
+  "kind": "accusation",
+  "v14_id": "V14-043"
+ },
+ "XP-V14-082": {
+  "kind": "accusation",
+  "v14_id": "V14-082"
+ },
+ "XP-V14-052": {
+  "kind": "accusation",
+  "v14_id": "V14-052"
+ },
+ "XP-V14-037": {
+  "kind": "accusation",
+  "v14_id": "V14-037"
+ },
+ "XP-V14-068": {
+  "kind": "accusation",
+  "v14_id": "V14-068"
+ },
+ "XP-V14-092": {
+  "kind": "accusation",
+  "v14_id": "V14-092"
+ },
+ "XP-V14-098": {
+  "kind": "accusation",
+  "v14_id": "V14-098"
+ },
+ "XP-V14-047": {
+  "kind": "accusation",
+  "v14_id": "V14-047"
+ },
+ "XP-V14-035": {
+  "kind": "accusation",
+  "v14_id": "V14-035"
+ },
+ "XP-V14-084": {
+  "kind": "accusation",
+  "v14_id": "V14-084"
+ },
+ "XP-V14-076": {
+  "kind": "accusation",
+  "v14_id": "V14-076"
+ },
+ "XP-V14-026": {
+  "kind": "accusation",
+  "v14_id": "V14-026"
+ },
+ "XP-V14-049": {
+  "kind": "accusation",
+  "v14_id": "V14-049"
+ },
+ "XP-V14-046": {
+  "kind": "accusation",
+  "v14_id": "V14-046"
+ },
+ "XP-V14-077": {
+  "kind": "accusation",
+  "v14_id": "V14-077"
+ },
+ "XP-V14-020": {
+  "kind": "accusation",
+  "v14_id": "V14-020"
+ },
+ "XP-V14-027": {
+  "kind": "accusation",
+  "v14_id": "V14-027"
+ },
+ "XP-V14-029": {
+  "kind": "accusation",
+  "v14_id": "V14-029"
+ },
+ "XP-V14-054": {
+  "kind": "accusation",
+  "v14_id": "V14-054"
+ },
+ "XP-V14-016": {
+  "kind": "accusation",
+  "v14_id": "V14-016"
+ },
+ "XP-V14-019": {
+  "kind": "accusation",
+  "v14_id": "V14-019"
+ },
+ "XP-V14-087": {
+  "kind": "accusation",
+  "v14_id": "V14-087"
+ },
+ "XP-V14-007": {
+  "kind": "accusation",
+  "v14_id": "V14-007"
+ },
+ "XP-V14-061": {
+  "kind": "accusation",
+  "v14_id": "V14-061"
+ },
+ "XP-V14-006": {
+  "kind": "accusation",
+  "v14_id": "V14-006"
+ },
+ "XP-V14-096": {
+  "kind": "accusation",
+  "v14_id": "V14-096"
+ },
+ "XP-V14-062": {
+  "kind": "accusation",
+  "v14_id": "V14-062"
+ },
+ "XP-V14-083": {
+  "kind": "accusation",
+  "v14_id": "V14-083"
+ },
+ "XP-V14-042": {
+  "kind": "accusation",
+  "v14_id": "V14-042"
+ },
+ "XP-V14-070": {
+  "kind": "accusation",
+  "v14_id": "V14-070"
+ },
+ "XP-V14-067": {
+  "kind": "accusation",
+  "v14_id": "V14-067"
+ },
+ "XP-V14-009": {
+  "kind": "accusation",
+  "v14_id": "V14-009"
+ },
+ "XP-V14-008": {
+  "kind": "accusation",
+  "v14_id": "V14-008"
+ },
+ "XP-V14-034": {
+  "kind": "accusation",
+  "v14_id": "V14-034"
+ },
+ "XP-V14-010": {
+  "kind": "accusation",
+  "v14_id": "V14-010"
+ },
+ "XP-V14-004": {
+  "kind": "accusation",
+  "v14_id": "V14-004"
+ },
+ "XP-V14-022": {
+  "kind": "accusation",
+  "v14_id": "V14-022"
+ },
+ "XP-V14-088": {
+  "kind": "accusation",
+  "v14_id": "V14-088"
+ },
+ "XP-V14-074": {
+  "kind": "accusation",
+  "v14_id": "V14-074"
+ },
+ "XP-V14-069": {
+  "kind": "accusation",
+  "v14_id": "V14-069"
+ },
+ "XP-V14-031": {
+  "kind": "accusation",
+  "v14_id": "V14-031"
+ },
+ "XP-V14-039": {
+  "kind": "accusation",
+  "v14_id": "V14-039"
+ },
+ "XP-V14-086": {
+  "kind": "accusation",
+  "v14_id": "V14-086"
+ },
+ "XP-V14-078": {
+  "kind": "accusation",
+  "v14_id": "V14-078"
+ },
+ "XP-V14-085": {
+  "kind": "accusation",
+  "v14_id": "V14-085"
+ },
+ "XP-V14-095": {
+  "kind": "accusation",
+  "v14_id": "V14-095"
+ },
+ "XP-XD-C09": {
+  "kind": "decoy",
+  "expected": "CLAIM",
+  "frame": null,
+  "src": "V14-109"
+ },
+ "XP-XD-C07": {
+  "kind": "decoy",
+  "expected": "CLAIM",
+  "frame": null,
+  "src": "V14-107"
+ },
+ "XP-XD-C02": {
+  "kind": "decoy",
+  "expected": "CLAIM",
+  "frame": null,
+  "src": "V14-102"
+ },
+ "XP-XD-C04": {
+  "kind": "decoy",
+  "expected": "CLAIM",
+  "frame": null,
+  "src": "V14-104"
+ },
+ "XP-XD-N06": {
+  "kind": "decoy",
+  "expected": "NOT-A-CLAIM",
+  "frame": "quotation",
+  "src": null
+ },
+ "XP-XD-C05": {
+  "kind": "decoy",
+  "expected": "CLAIM",
+  "frame": null,
+  "src": "V14-105"
+ },
+ "XP-XD-N02": {
+  "kind": "decoy",
+  "expected": "NOT-A-CLAIM",
+  "frame": "negation",
+  "src": null
+ },
+ "XP-XD-C14": {
+  "kind": "decoy",
+  "expected": "CLAIM",
+  "frame": null,
+  "src": "V14-114"
+ },
+ "XP-XD-N01": {
+  "kind": "decoy",
+  "expected": "NOT-A-CLAIM",
+  "frame": "negation",
+  "src": null
+ },
+ "XP-XD-N09": {
+  "kind": "decoy",
+  "expected": "NOT-A-CLAIM",
+  "frame": "quotation",
+  "src": null
+ },
+ "XP-XD-N07": {
+  "kind": "decoy",
+  "expected": "NOT-A-CLAIM",
+  "frame": "quotation",
+  "src": null
+ },
+ "XP-XD-N08": {
+  "kind": "decoy",
+  "expected": "NOT-A-CLAIM",
+  "frame": "quotation",
+  "src": null
+ },
+ "XP-XD-C01": {
+  "kind": "decoy",
+  "expected": "CLAIM",
+  "frame": null,
+  "src": "V14-101"
+ },
+ "XP-XD-N05": {
+  "kind": "decoy",
+  "expected": "NOT-A-CLAIM",
+  "frame": "quotation",
+  "src": null
+ },
+ "XP-XD-N04": {
+  "kind": "decoy",
+  "expected": "NOT-A-CLAIM",
+  "frame": "negation",
+  "src": null
+ },
+ "XP-XD-C00": {
+  "kind": "decoy",
+  "expected": "CLAIM",
+  "frame": null,
+  "src": "V14-100"
+ },
+ "XP-XD-N00": {
+  "kind": "decoy",
+  "expected": "NOT-A-CLAIM",
+  "frame": "negation",
+  "src": null
+ },
+ "XP-XD-N11": {
+  "kind": "decoy",
+  "expected": "NOT-A-CLAIM",
+  "frame": "comparative_reference",
+  "src": null
+ },
+ "XP-XD-C06": {
+  "kind": "decoy",
+  "expected": "CLAIM",
+  "frame": null,
+  "src": "V14-106"
+ },
+ "XP-XD-N14": {
+  "kind": "decoy",
+  "expected": "NOT-A-CLAIM",
+  "frame": "comparative_reference",
+  "src": null
+ },
+ "XP-XD-N10": {
+  "kind": "decoy",
+  "expected": "NOT-A-CLAIM",
+  "frame": "comparative_reference",
+  "src": null
+ },
+ "XP-XD-C13": {
+  "kind": "decoy",
+  "expected": "CLAIM",
+  "frame": null,
+  "src": "V14-113"
+ },
+ "XP-XD-N03": {
+  "kind": "decoy",
+  "expected": "NOT-A-CLAIM",
+  "frame": "negation",
+  "src": null
+ },
+ "XP-XD-N12": {
+  "kind": "decoy",
+  "expected": "NOT-A-CLAIM",
+  "frame": "comparative_reference",
+  "src": null
+ },
+ "XP-XD-N13": {
+  "kind": "decoy",
+  "expected": "NOT-A-CLAIM",
+  "frame": "comparative_reference",
+  "src": null
+ },
+ "XP-XD-C11": {
+  "kind": "decoy",
+  "expected": "CLAIM",
+  "frame": null,
+  "src": "V14-111"
+ },
+ "XP-XD-C03": {
+  "kind": "decoy",
+  "expected": "CLAIM",
+  "frame": null,
+  "src": "V14-103"
+ },
+ "XP-XD-C08": {
+  "kind": "decoy",
+  "expected": "CLAIM",
+  "frame": null,
+  "src": "V14-108"
+ },
+ "XP-XD-C10": {
+  "kind": "decoy",
+  "expected": "CLAIM",
+  "frame": null,
+  "src": "V14-110"
+ },
+ "XP-XD-C12": {
+  "kind": "decoy",
+  "expected": "CLAIM",
+  "frame": null,
+  "src": "V14-112"
+ }
+}

--- a/papers/closed-model-frontier/extraction_panel_packet.json
+++ b/papers/closed-model-frontier/extraction_panel_packet.json
@@ -1,0 +1,659 @@
+{
+ "question": "Ignoring entirely whether the gate's verdict was correct, and reading only the author's summary: is the author making a claim about this path — asserting that THIS change created, deleted or touched it? CLAIM / NOT-A-CLAIM / UNREADABLE",
+ "prereg": "PREREG_extraction_ceiling_v2_2026_09_01.md",
+ "decoy_digest": "6a491480623ff96c2a55f70da9a6ef9f47d11246afeaa477946bd8af4787892b",
+ "n_items": 130,
+ "blinded": "seats see sentence + path only; no diff, no verdict, no V14 material",
+ "items": [
+  {
+   "id": "XP-V14-078",
+   "sentence": "> changeset spec and format: https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md",
+   "path": "//github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md"
+  },
+  {
+   "id": "XP-V14-075",
+   "sentence": ">  - `OkHttpClientWrapper.save` writes straight to a `FileOutputStream` with a 4 KiB  buffer (`byte[] b = new byte[4096];`) `src/main/java/com/frostwire/util/ht",
+   "path": "src/main/java/com/frostwire/util/http/OkHttpClientWrapper.java"
+  },
+  {
+   "id": "XP-V14-088",
+   "sentence": "- Removed accidentally added `package-lock.json` (project uses pnpm, not npm)",
+   "path": "package-lock.json"
+  },
+  {
+   "id": "XP-V14-077",
+   "sentence": "src/example.py: Unformatted file.",
+   "path": "src/example.py"
+  },
+  {
+   "id": "XP-V14-001",
+   "sentence": "Adding a new \"Using Licensee with Docker\" section to `docs/command-line-usage.md` with detailed examples showing the proper syntax for various scenarios:",
+   "path": "docs/command-line-usage.md"
+  },
+  {
+   "id": "XP-V14-018",
+   "sentence": "Added 21 new localization keys to `types/localization.ts` under the `Frontend` section:",
+   "path": "types/localization.ts"
+  },
+  {
+   "id": "XP-XD-N06",
+   "sentence": "For reference, the linked issue asks for the following: \"- Updated `apps/desktop/src/lib/backend/tauri.ts` to call the backend command instead of directly setting the title on the window object\" That work is tracked separately and is not part of this pull request.",
+   "path": "apps/desktop/src/lib/backend/tauri.ts"
+  },
+  {
+   "id": "XP-V14-092",
+   "sentence": "**Schema URL**: Updated `$schema` from `https://developer.microsoft.com/en-us/json-schemas/teams/v1.22/MicrosoftTeams.schema.json` to `v1.23`",
+   "path": "//developer.microsoft.com/en-us/json-schemas/teams/v1.22/MicrosoftTeams.schema.json"
+  },
+  {
+   "id": "XP-V14-091",
+   "sentence": "// New route added to layout.tsx",
+   "path": "layout.tsx"
+  },
+  {
+   "id": "XP-XD-C07",
+   "sentence": "updated include the new mcpjam-client-manager.ts, updated routes for",
+   "path": "mcpjam-client-manager.ts"
+  },
+  {
+   "id": "XP-XD-C13",
+   "sentence": "- [x] **Refactor**: Move EnableWorkflows function to new `enable.go` file",
+   "path": "enable.go"
+  },
+  {
+   "id": "XP-XD-N12",
+   "sentence": "The approach here follows the same pattern `REQUIREMENTS.txt` already uses, which was settled in an earlier pull request. Nothing in this change modifies that file.",
+   "path": "REQUIREMENTS.txt"
+  },
+  {
+   "id": "XP-V14-062",
+   "sentence": "This PR adds a new section to the Python style guide (`dev/guides/python.md`) that establishes the convention of preferring `unittest.mock.patch` as a context m",
+   "path": "dev/guides/python.md"
+  },
+  {
+   "id": "XP-V14-085",
+   "sentence": "- document new golden tests in Kotlin `TASKS.md`",
+   "path": "TASKS.md"
+  },
+  {
+   "id": "XP-V14-034",
+   "sentence": "❯ updateResult src/hooks/useQuery.ts:336:7",
+   "path": "src/hooks/useQuery.ts"
+  },
+  {
+   "id": "XP-V14-016",
+   "sentence": "- Created `palette-config.json` with the 7 existing EDS colors (Moss Green, Gray, North sea, Green, Blue, Orange, Red)",
+   "path": "palette-config.json"
+  },
+  {
+   "id": "XP-XD-N03",
+   "sentence": "To be explicit about scope: this change does not touch `fio.py`. That file is unchanged here and stays exactly as it is on main.",
+   "path": "fio.py"
+  },
+  {
+   "id": "XP-XD-C00",
+   "sentence": "- update `ci.yml` to fail early when actor isn't repo owner",
+   "path": "ci.yml"
+  },
+  {
+   "id": "XP-V14-064",
+   "sentence": "- Remove CLAUDE.md from `.gitignore` to allow tracking in version control",
+   "path": "CLAUDE.md"
+  },
+  {
+   "id": "XP-V14-041",
+   "sentence": "**New Functions** (`pkg/cli/secrets.go`):",
+   "path": "pkg/cli/secrets.go"
+  },
+  {
+   "id": "XP-V14-052",
+   "sentence": "This PR adds a new guideline to the Python style guide (`dev/guides/python.md`) recommending the use of `typing.Literal` when a parameter only accepts a fixed s",
+   "path": "dev/guides/python.md"
+  },
+  {
+   "id": "XP-V14-014",
+   "sentence": "**Removed hardcoded fill** from the CHEM symbol SVG definition (`Chem.tsx`)",
+   "path": "Chem.tsx"
+  },
+  {
+   "id": "XP-XD-N14",
+   "sentence": "The approach here follows the same pattern `specs/002-fix-streaming-performance/tasks.md` already uses, which was settled in an earlier pull request. Nothing in this change modifies that file.",
+   "path": "specs/002-fix-streaming-performance/tasks.md"
+  },
+  {
+   "id": "XP-XD-N13",
+   "sentence": "The approach here follows the same pattern `artifact/tsconfig.json` already uses, which was settled in an earlier pull request. Nothing in this change modifies that file.",
+   "path": "artifact/tsconfig.json"
+  },
+  {
+   "id": "XP-V14-090",
+   "sentence": "✅ **Code Cleanup**: Removed CLAUDE.md file and misleading browser tool comments",
+   "path": "CLAUDE.md"
+  },
+  {
+   "id": "XP-XD-C01",
+   "sentence": "- Created a root composer.json file that references the PHP SDK in the subdirectory",
+   "path": "composer.json"
+  },
+  {
+   "id": "XP-V14-003",
+   "sentence": "Create comprehensive README.md with improved structure, examples, and documentation",
+   "path": "README.md"
+  },
+  {
+   "id": "XP-XD-C11",
+   "sentence": "- `tenantS3.ts`: S3 operations with tenant-prefixed object keys",
+   "path": "tenantS3.ts"
+  },
+  {
+   "id": "XP-V14-069",
+   "sentence": "Modified `app/views/events/sub_organizations.html.erb` to add `value: params[:name]`, `value: params[:email]`, and `value: params[:cosigner_email]` attributes t",
+   "path": "app/views/events/sub_organizations.html"
+  },
+  {
+   "id": "XP-V14-045",
+   "sentence": "\"artwork/art1.jpg\": {",
+   "path": "artwork/art1.jpg"
+  },
+  {
+   "id": "XP-V14-067",
+   "sentence": "- Reflecting the new limit in the API documentation (`fern/apis/server/definition/comments.yml`).",
+   "path": "fern/apis/server/definition/comments.yml"
+  },
+  {
+   "id": "XP-V14-009",
+   "sentence": "**Filter Bar Gap** - Removes visual gap at top of horizontal filter bar superset-frontend/src/dashboard/components/nativeFilters/FilterBar/Horizontal.tsx",
+   "path": "superset-frontend/src/dashboard/components/nativeFilters/FilterBar/Horizontal.tsx"
+  },
+  {
+   "id": "XP-V14-063",
+   "sentence": "This change is [<img src=\"https://reviewable.io/review_button.svg\" height=\"34\" align=\"absmiddle\" alt=\"Reviewable\"/>](https://reviewable.io/reviews/elsa-workflow",
+   "path": "//reviewable.io/review_button.svg"
+  },
+  {
+   "id": "XP-V14-026",
+   "sentence": "Added a comprehensive new section to `src/site/markdown/TestingBundles.md` that documents:",
+   "path": "src/site/markdown/TestingBundles.md"
+  },
+  {
+   "id": "XP-V14-053",
+   "sentence": "- [x] Remove package-lock.json file and add to .gitignore",
+   "path": "package-lock.json"
+  },
+  {
+   "id": "XP-V14-005",
+   "sentence": "This change is [<img src=\"https://reviewable.io/review_button.svg\" height=\"34\" align=\"absmiddle\" alt=\"Reviewable\"/>](https://reviewable.io/reviews/elsa-workflow",
+   "path": "//reviewable.io/review_button.svg"
+  },
+  {
+   "id": "XP-V14-011",
+   "sentence": "This change aligns with `/reference/engines.md` where GitHub Copilot is documented as the default and recommended AI engine.",
+   "path": "/reference/engines.md"
+  },
+  {
+   "id": "XP-V14-049",
+   "sentence": "- **New document**: `docs/core/compatibility/xml/10.0/xsltsettings-enablescript-obsolete.md`",
+   "path": "docs/core/compatibility/xml/10.0/xsltsettings-enablescript-obsolete.md"
+  },
+  {
+   "id": "XP-XD-N02",
+   "sentence": "To be explicit about scope: this change does not touch `package.json`. That file is unchanged here and stays exactly as it is on main.",
+   "path": "package.json"
+  },
+  {
+   "id": "XP-XD-C10",
+   "sentence": "- **Refactored `reaction.go`**: Simplified github-script step generation by passing script directly to `BuildGitHubScriptStepLines`, eliminating manual append p",
+   "path": "reaction.go"
+  },
+  {
+   "id": "XP-V14-070",
+   "sentence": "This change is [<img src=\"https://reviewable.io/review_button.svg\" height=\"34\" align=\"absmiddle\" alt=\"Reviewable\"/>](https://reviewable.io/reviews/databendlabs/",
+   "path": "//reviewable.io/review_button.svg"
+  },
+  {
+   "id": "XP-V14-047",
+   "sentence": "- **Created `pkg/cli/init_command.go`**: Contains the `NewInitCommand()` function that creates the Cobra command for the `init` subcommand",
+   "path": "pkg/cli/init_command.go"
+  },
+  {
+   "id": "XP-V14-033",
+   "sentence": "Added **8 new error pattern categories** to `pkg/workflow/copilot_engine.go`:",
+   "path": "pkg/workflow/copilot_engine.go"
+  },
+  {
+   "id": "XP-V14-044",
+   "sentence": "**Modified `src/bun.js/test/jest.zig`:**",
+   "path": "src/bun.js"
+  },
+  {
+   "id": "XP-V14-042",
+   "sentence": "- update links referencing `../docs/DISCLAIMER_SNIPPET.md`",
+   "path": "../docs/DISCLAIMER_SNIPPET.md"
+  },
+  {
+   "id": "XP-XD-N07",
+   "sentence": "For reference, the linked issue asks for the following: \"Update .github/workflows/e2e-test-kind.yaml\" That work is tracked separately and is not part of this pull request.",
+   "path": ".github/workflows/e2e-test-kind.yaml"
+  },
+  {
+   "id": "XP-V14-084",
+   "sentence": "*   Adds a new endpoint at `/.well-known/mcp.json`.",
+   "path": "/.well-known/mcp.json"
+  },
+  {
+   "id": "XP-V14-089",
+   "sentence": "public/index.html:  <!-- Legacy redirect -->",
+   "path": "public/index.html"
+  },
+  {
+   "id": "XP-V14-055",
+   "sentence": "This change is [<img src=\"https://reviewable.io/review_button.svg\" height=\"34\" align=\"absmiddle\" alt=\"Reviewable\"/>](https://reviewable.io/reviews/dsccommunity/",
+   "path": "//reviewable.io/review_button.svg"
+  },
+  {
+   "id": "XP-XD-N05",
+   "sentence": "For reference, the linked issue asks for the following: \"- **Updated `package.json`**: Added `\"license\": \"MIT\"` field to the root package.json to match the license field already present in the individual package manif\" That work is tracked separately and is not part of this pull request.",
+   "path": "package.json"
+  },
+  {
+   "id": "XP-V14-056",
+   "sentence": "Created `TODO_REVIEW_SUMMARY.md` providing:",
+   "path": "TODO_REVIEW_SUMMARY.md"
+  },
+  {
+   "id": "XP-V14-054",
+   "sentence": "- [x] Remove unnecessary ConfigurationSchema.json file since using base component's schema",
+   "path": "ConfigurationSchema.json"
+  },
+  {
+   "id": "XP-V14-032",
+   "sentence": "rad resource-type create myType --from-file /path/to/input.json",
+   "path": "/path/to/input.json"
+  },
+  {
+   "id": "XP-XD-C06",
+   "sentence": "- `foamlib/_files/_files.py`: Added `@override` to `FoamFile` and `SubDict` methods",
+   "path": "foamlib/_files/_files.py"
+  },
+  {
+   "id": "XP-V14-087",
+   "sentence": "The `.github/workflows/shared/jqschema.md` workflow file was attempting to create `/tmp/gh-aw/jqschema.sh` without first ensuring the parent directory exists.",
+   "path": "/tmp/gh-aw/jqschema.sh"
+  },
+  {
+   "id": "XP-V14-093",
+   "sentence": "- Removed `tests/genai/scorers/test_scorer_CRUD.py` from the `mock_patch_as_decorator.py` ignore list",
+   "path": "tests/genai/scorers/test_scorer_CRUD.py"
+  },
+  {
+   "id": "XP-V14-023",
+   "sentence": "- Added `GET /openapi.json` endpoint serving dynamically generated OpenAPI 3.0 specification",
+   "path": "/openapi.json"
+  },
+  {
+   "id": "XP-V14-050",
+   "sentence": "rad resource-type create  --from-file /path/to/input.yaml",
+   "path": "/path/to/input.yaml"
+  },
+  {
+   "id": "XP-XD-N00",
+   "sentence": "To be explicit about scope: this change does not touch `yarn.lock`. That file is unchanged here and stays exactly as it is on main.",
+   "path": "yarn.lock"
+  },
+  {
+   "id": "XP-XD-C04",
+   "sentence": "This PR adds a comprehensive `.github/copilot-instructions.md` file to onboard the Wynntils repository for efficient use with GitHub Copilot coding agents.",
+   "path": ".github/copilot-instructions.md"
+  },
+  {
+   "id": "XP-V14-046",
+   "sentence": "- How to identify issues created with the `.github/ISSUE_TEMPLATE/tested_config.md` template",
+   "path": ".github/ISSUE_TEMPLATE/tested_config.md"
+  },
+  {
+   "id": "XP-V14-035",
+   "sentence": "- **Fixed Header Includes**: Uses only `kiwi/Kiwi.h` (removed non-existent `kiwi/KiwiBuilder.h`)",
+   "path": "kiwi/KiwiBuilder.h"
+  },
+  {
+   "id": "XP-V14-013",
+   "sentence": "- Remove .claude/settings.local.json from git tracking",
+   "path": ".claude/settings.local.json"
+  },
+  {
+   "id": "XP-XD-N10",
+   "sentence": "The approach here follows the same pattern `package-lock.json` already uses, which was settled in an earlier pull request. Nothing in this change modifies that file.",
+   "path": "package-lock.json"
+  },
+  {
+   "id": "XP-XD-N08",
+   "sentence": "For reference, the linked issue asks for the following: \"This PR adds a comprehensive `.github/copilot-instructions.md` file that provides GitHub Copilot with detailed instructions for working effectively in the fabri\" That work is tracked separately and is not part of this pull request.",
+   "path": ".github/copilot-instructions.md"
+  },
+  {
+   "id": "XP-XD-N04",
+   "sentence": "To be explicit about scope: this change does not touch `README.md`. That file is unchanged here and stays exactly as it is on main.",
+   "path": "README.md"
+  },
+  {
+   "id": "XP-V14-081",
+   "sentence": "This PR adds a new section to the Python style guide (`dev/guides/python.md`) that encourages using pytest's `tmp_path` fixture instead of manual `tempfile.Temp",
+   "path": "dev/guides/python.md"
+  },
+  {
+   "id": "XP-V14-039",
+   "sentence": "*   `examples/workflows/x_follow_advanced.yaml`: A more robust workflow for X.com, performing batch clicks on multiple \"Follow\" buttons and double-scrolling.",
+   "path": "examples/workflows/x_follow_advanced.yaml"
+  },
+  {
+   "id": "XP-V14-080",
+   "sentence": "Adds a new \"Copilot Environment Restrictions\" section to `.github/copilot-instructions.md` to document known Google API connectivity issues within the GitHub Co",
+   "path": ".github/copilot-instructions.md"
+  },
+  {
+   "id": "XP-V14-008",
+   "sentence": "_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh work",
+   "path": "//github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml"
+  },
+  {
+   "id": "XP-V14-068",
+   "sentence": "The full changelog is available at: https://github.com/getsentry/sentry-javascript/blob/develop/CHANGELOG.md#changelog",
+   "path": "//github.com/getsentry/sentry-javascript/blob/develop/CHANGELOG.md"
+  },
+  {
+   "id": "XP-V14-073",
+   "sentence": "- `internal/rules/no_misused_promises/no_misused_promises.go`: \"spreaded\" → \"spread\"",
+   "path": "internal/rules/no_misused_promises/no_misused_promises.go"
+  },
+  {
+   "id": "XP-V14-002",
+   "sentence": "Remove `node_modules/.vlt-lock.json` on install, uninstall, or update failures to prevent stale lockfiles.",
+   "path": "node_modules/.vlt-lock.json"
+  },
+  {
+   "id": "XP-V14-071",
+   "sentence": "- [ ] **End-to-end workflow**: Create a project and run `python src/{project}/main.py` to verify the complete workflow",
+   "path": "/main.py"
+  },
+  {
+   "id": "XP-V14-036",
+   "sentence": "**Hidden Removal Failures**: Changed `lifecycle.go` to return an error when supervise directories are not empty, preventing false positives for removal completi",
+   "path": "lifecycle.go"
+  },
+  {
+   "id": "XP-V14-030",
+   "sentence": ">             new StaticAssetResponseHeader(\"Link\", \"</_content/项目/app.js>; rel=modulepreload\")",
+   "path": "/_content/项目/app.js"
+  },
+  {
+   "id": "XP-XD-C03",
+   "sentence": "Updated `computeAxisValue.ts`:",
+   "path": "computeAxisValue.ts"
+  },
+  {
+   "id": "XP-V14-060",
+   "sentence": "Remove random safe output filename logic, use fixed path /tmp/safe-outputs/raw.jsonl",
+   "path": "/tmp/safe-outputs/raw.jsonl"
+  },
+  {
+   "id": "XP-V14-038",
+   "sentence": "This change is [<img src=\"https://reviewable.io/review_button.svg\" height=\"34\" align=\"absmiddle\" alt=\"Reviewable\"/>](https://reviewable.io/reviews/dsccommunity/",
+   "path": "//reviewable.io/review_button.svg"
+  },
+  {
+   "id": "XP-V14-024",
+   "sentence": "- Created CHANGELOG.md for source-mssql",
+   "path": "CHANGELOG.md"
+  },
+  {
+   "id": "XP-V14-066",
+   "sentence": "Updated `templates/vsc/ts/message-extension-v2/appPackage/manifest.json.tpl` to:",
+   "path": "templates/vsc/ts/message-extension-v2/appPackage/manifest.json"
+  },
+  {
+   "id": "XP-V14-083",
+   "sentence": "Adding a new markdown file (`sys_fe_locks_documentation.md`) that details the `sys.fe_locks` system view.",
+   "path": "sys_fe_locks_documentation.md"
+  },
+  {
+   "id": "XP-V14-099",
+   "sentence": "📁 Found 1 changed files: docs/installation.md",
+   "path": "docs/installation.md"
+  },
+  {
+   "id": "XP-V14-074",
+   "sentence": "**Cleanup**: Removed rolldown-version.txt test artifact file",
+   "path": "rolldown-version.txt"
+  },
+  {
+   "id": "XP-V14-025",
+   "sentence": "Added a new OpenAPI example allOfRequired.yaml showing how a parent schema marks the pet property as required while composing its definition with allOf",
+   "path": "allOfRequired.yaml"
+  },
+  {
+   "id": "XP-V14-076",
+   "sentence": "rad resource-type create myType --from-file /path/to/input.yaml",
+   "path": "/path/to/input.yaml"
+  },
+  {
+   "id": "XP-V14-057",
+   "sentence": "&gt;    - IF the user chose to create a github actions workflow, then this file <a href=\"https://raw.githubusercontent.com/ShaftHQ/using_SHAFT_Engine/refs/heads",
+   "path": "//raw.githubusercontent.com/ShaftHQ/using_SHAFT_Engine/refs/heads/main/.github/workflows/e2etests.yml"
+  },
+  {
+   "id": "XP-V14-027",
+   "sentence": "- Created ContentExplorer.js.flow for Flow compatibility",
+   "path": "ContentExplorer.js"
+  },
+  {
+   "id": "XP-V14-020",
+   "sentence": "- Removed Footer.js after verifying Footer.js.flow compatibility",
+   "path": "Footer.js"
+  },
+  {
+   "id": "XP-V14-061",
+   "sentence": "- [x] Update test imports that reference ../index.js to use ../distribution/index.js",
+   "path": "../index.js"
+  },
+  {
+   "id": "XP-V14-031",
+   "sentence": "This PR removes all references to `tests/server/auth` from both `conftest.py` and `.github/workflows/master.yml` to ensure that authentication tests are not col",
+   "path": "conftest.py"
+  },
+  {
+   "id": "XP-V14-004",
+   "sentence": "This change is [<img src=\"https://reviewable.io/review_button.svg\" height=\"34\" align=\"absmiddle\" alt=\"Reviewable\"/>](https://reviewable.io/reviews/elsa-workflow",
+   "path": "//reviewable.io/review_button.svg"
+  },
+  {
+   "id": "XP-V14-037",
+   "sentence": "Install the [9.0.204] .NET SDK or update [/workspaces/csharp-sdk/global.json] to match an installed SDK.",
+   "path": "/workspaces/csharp-sdk/global.json"
+  },
+  {
+   "id": "XP-V14-095",
+   "sentence": "- update Vite and Vitest configs and change library entry to `src/index.ts`",
+   "path": "src/index.ts"
+  },
+  {
+   "id": "XP-XD-C02",
+   "sentence": "- Update benchmarks and checklist (ALGORITHMS.md, README.md, TASKS.md)",
+   "path": "ALGORITHMS.md"
+  },
+  {
+   "id": "XP-XD-C05",
+   "sentence": "- Recompiled workflow to generate updated `.github/workflows/dev.lock.yml`",
+   "path": ".github/workflows/dev.lock.yml"
+  },
+  {
+   "id": "XP-XD-N09",
+   "sentence": "For reference, the linked issue asks for the following: \"- `reproduce_issue.py`: A comprehensive script showing behavior with and without Sentry.\" That work is tracked separately and is not part of this pull request.",
+   "path": "reproduce_issue.py"
+  },
+  {
+   "id": "XP-V14-043",
+   "sentence": "- Created a new breaking change document at `docs/core/compatibility/extensions/10.0/provider-alias-attribute-moved-namespace.md` that:",
+   "path": "docs/core/compatibility/extensions/10.0/provider-alias-attribute-moved-namespace.md"
+  },
+  {
+   "id": "XP-V14-029",
+   "sentence": "This change is [<img src=\"https://reviewable.io/review_button.svg\" height=\"34\" align=\"absmiddle\" alt=\"Reviewable\"/>](https://reviewable.io/reviews/databendlabs/",
+   "path": "//reviewable.io/review_button.svg"
+  },
+  {
+   "id": "XP-V14-021",
+   "sentence": "- Adds the necessary mangled symbols for these new methods to `src/symbols.txt`, `src/symbols.dyn` (Linux), and `src/symbols.def` (Windows) to ensure they are e",
+   "path": "src/symbols.txt"
+  },
+  {
+   "id": "XP-V14-022",
+   "sentence": "- **`EngineWorker.h`**: Removed `<GL/gl.h>` include (not needed in the header)",
+   "path": "GL/gl.h"
+  },
+  {
+   "id": "XP-V14-086",
+   "sentence": "Added three new localization keys to `types/localization.ts`:",
+   "path": "types/localization.ts"
+  },
+  {
+   "id": "XP-V14-028",
+   "sentence": "Added two new policy sections to the policy index (`02_政策インデックス.md`) as requested:",
+   "path": "02_政策インデックス.md"
+  },
+  {
+   "id": "XP-V14-098",
+   "sentence": "Removed explicit version tags from 25 module pom.xml files where these dependencies are used, allowing them to inherit versions from the parent's dependency man",
+   "path": "pom.xml"
+  },
+  {
+   "id": "XP-V14-010",
+   "sentence": ">     - In `.github/workflows/ci.yml`, expand the `check-notebook-docs-sync` job to check the entire repository for changes after running `scripts/update_cookbo",
+   "path": "scripts/update_cookbook_docs.sh"
+  },
+  {
+   "id": "XP-V14-006",
+   "sentence": "- Remove .claude/settings.local.json from git tracking",
+   "path": ".claude/settings.local.json"
+  },
+  {
+   "id": "XP-XD-C12",
+   "sentence": "- Updated both `en.json` and `en-US.json` files",
+   "path": "en.json"
+  },
+  {
+   "id": "XP-V14-015",
+   "sentence": "> - File path for the new atlas: `micapipe/MNI152Volumes/mni_icbm152_t1_tal_nlin_sym_09a.nii.gz`",
+   "path": "micapipe/MNI152Volumes/mni_icbm152_t1_tal_nlin_sym_09a.nii.gz"
+  },
+  {
+   "id": "XP-XD-C08",
+   "sentence": "This PR adds a comprehensive `.github/copilot-instructions.md` file that provides GitHub Copilot coding agents with detailed instructions on how to work effecti",
+   "path": ".github/copilot-instructions.md"
+  },
+  {
+   "id": "XP-V14-058",
+   "sentence": ">   - **New File**: Adds `AGENTS.md` to provide AI coding assistants with detailed project context.",
+   "path": "AGENTS.md"
+  },
+  {
+   "id": "XP-V14-072",
+   "sentence": "**New environment dependencies**: Added S3 bucket env vars to compose.yaml.",
+   "path": "compose.yaml"
+  },
+  {
+   "id": "XP-V14-082",
+   "sentence": "Removes the Webhook button from the single prompt detail page (`web/src/features/prompts/components/prompt-detail.tsx`).",
+   "path": "web/src/features/prompts/components/prompt-detail.tsx"
+  },
+  {
+   "id": "XP-V14-019",
+   "sentence": "- [x] Add five new tools to drain3_server.py:",
+   "path": "drain3_server.py"
+  },
+  {
+   "id": "XP-V14-017",
+   "sentence": "- Creates and updates `.zed/settings.json` in the project root directory",
+   "path": ".zed/settings.json"
+  },
+  {
+   "id": "XP-XD-N01",
+   "sentence": "To be explicit about scope: this change does not touch `useLibraryAgentList.ts`. That file is unchanged here and stays exactly as it is on main.",
+   "path": "useLibraryAgentList.ts"
+  },
+  {
+   "id": "XP-V14-065",
+   "sentence": "This change is [<img src=\"https://reviewable.io/review_button.svg\" height=\"34\" align=\"absmiddle\" alt=\"Reviewable\"/>](https://reviewable.io/reviews/dsccommunity/",
+   "path": "//reviewable.io/review_button.svg"
+  },
+  {
+   "id": "XP-V14-079",
+   "sentence": "This change is [<img src=\"https://reviewable.io/review_button.svg\" height=\"34\" align=\"absmiddle\" alt=\"Reviewable\"/>](https://reviewable.io/reviews/dsccommunity/",
+   "path": "//reviewable.io/review_button.svg"
+  },
+  {
+   "id": "XP-V14-040",
+   "sentence": "This change is [<img src=\"https://reviewable.io/review_button.svg\" height=\"34\" align=\"absmiddle\" alt=\"Reviewable\"/>](https://reviewable.io/reviews/highperforman",
+   "path": "//reviewable.io/review_button.svg"
+  },
+  {
+   "id": "XP-V14-051",
+   "sentence": "Addresses feedback: @davidfowl run through the instructions in https://github.com/dotnet/aspire/blob/main/tools/ReleaseNotes/docs/README.md",
+   "path": "//github.com/dotnet/aspire/blob/main/tools/ReleaseNotes/docs/README.md"
+  },
+  {
+   "id": "XP-V14-000",
+   "sentence": "Created `/02-SetupDevEnvironment/src/BasicChat-01MEAI/README.md` with:",
+   "path": "/02-SetupDevEnvironment/src/BasicChat-01MEAI/README.md"
+  },
+  {
+   "id": "XP-V14-094",
+   "sentence": "Added two new workflow steps to automatically update `studio/package.json` during the release process:",
+   "path": "studio/package.json"
+  },
+  {
+   "id": "XP-XD-C14",
+   "sentence": "- Updated ROADMAP.md to mark Quick Win #5 as completed",
+   "path": "ROADMAP.md"
+  },
+  {
+   "id": "XP-V14-059",
+   "sentence": "This change is [<img src=\"https://reviewable.io/review_button.svg\" height=\"34\" align=\"absmiddle\" alt=\"Reviewable\"/>](https://reviewable.io/reviews/dsccommunity/",
+   "path": "//reviewable.io/review_button.svg"
+  },
+  {
+   "id": "XP-XD-C09",
+   "sentence": "Updated README.md with comprehensive examples showing both stdio and remote server configurations, proper TOML table syntax, and migration guidance from JSON.",
+   "path": "README.md"
+  },
+  {
+   "id": "XP-V14-012",
+   "sentence": "The implementation adds several new functions to `pkg/parser/schema.go`:",
+   "path": "pkg/parser/schema.go"
+  },
+  {
+   "id": "XP-V14-007",
+   "sentence": "- [x] Created shared workflow file at `.github/workflows/shared/actions-ai-inference.md`",
+   "path": ".github/workflows/shared/actions-ai-inference.md"
+  },
+  {
+   "id": "XP-V14-048",
+   "sentence": "- [ ] Update docs/setup/configuring-rules.md if needed",
+   "path": "docs/setup/configuring-rules.md"
+  },
+  {
+   "id": "XP-V14-096",
+   "sentence": "Added comprehensive documentation to `docs/automation/step-definitions.md` explaining:",
+   "path": "docs/automation/step-definitions.md"
+  },
+  {
+   "id": "XP-V14-097",
+   "sentence": "*   **API Client Method**: A new `updateIssue` method was added to `packages/mcp-server/src/api-client/client.ts`.",
+   "path": "packages/mcp-server/src/api-client/client.ts"
+  },
+  {
+   "id": "XP-XD-N11",
+   "sentence": "The approach here follows the same pattern `CMakeLists.txt` already uses, which was settled in an earlier pull request. Nothing in this change modifies that file.",
+   "path": "CMakeLists.txt"
+  }
+ ]
+}

--- a/papers/closed-model-frontier/extraction_panel_raw.json
+++ b/papers/closed-model-frontier/extraction_panel_raw.json
@@ -1,0 +1,655 @@
+{
+ "n_seats": 3,
+ "per_item": {
+  "XP-V14-078": [
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM"
+  ],
+  "XP-V14-075": [
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM"
+  ],
+  "XP-V14-088": [
+   "CLAIM",
+   "CLAIM",
+   "CLAIM"
+  ],
+  "XP-V14-077": [
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM"
+  ],
+  "XP-V14-001": [
+   "CLAIM",
+   "CLAIM",
+   "CLAIM"
+  ],
+  "XP-V14-018": [
+   "CLAIM",
+   "CLAIM",
+   "CLAIM"
+  ],
+  "XP-XD-N06": [
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM"
+  ],
+  "XP-V14-092": [
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM"
+  ],
+  "XP-V14-091": [
+   "CLAIM",
+   "CLAIM",
+   "CLAIM"
+  ],
+  "XP-XD-C07": [
+   "CLAIM",
+   "CLAIM",
+   "CLAIM"
+  ],
+  "XP-XD-C13": [
+   "CLAIM",
+   "CLAIM",
+   "CLAIM"
+  ],
+  "XP-XD-N12": [
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM"
+  ],
+  "XP-V14-062": [
+   "CLAIM",
+   "CLAIM",
+   "CLAIM"
+  ],
+  "XP-V14-085": [
+   "CLAIM",
+   "CLAIM",
+   "CLAIM"
+  ],
+  "XP-V14-034": [
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM"
+  ],
+  "XP-V14-016": [
+   "CLAIM",
+   "CLAIM",
+   "CLAIM"
+  ],
+  "XP-XD-N03": [
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM"
+  ],
+  "XP-XD-C00": [
+   "CLAIM",
+   "CLAIM",
+   "CLAIM"
+  ],
+  "XP-V14-064": [
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM"
+  ],
+  "XP-V14-041": [
+   "CLAIM",
+   "CLAIM",
+   "CLAIM"
+  ],
+  "XP-V14-052": [
+   "CLAIM",
+   "CLAIM",
+   "CLAIM"
+  ],
+  "XP-V14-014": [
+   "CLAIM",
+   "CLAIM",
+   "CLAIM"
+  ],
+  "XP-XD-N14": [
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM"
+  ],
+  "XP-XD-N13": [
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM"
+  ],
+  "XP-V14-090": [
+   "CLAIM",
+   "CLAIM",
+   "CLAIM"
+  ],
+  "XP-XD-C01": [
+   "CLAIM",
+   "CLAIM",
+   "CLAIM"
+  ],
+  "XP-V14-003": [
+   "CLAIM",
+   "CLAIM",
+   "CLAIM"
+  ],
+  "XP-XD-C11": [
+   "CLAIM",
+   "CLAIM",
+   "CLAIM"
+  ],
+  "XP-V14-069": [
+   "CLAIM",
+   "CLAIM",
+   "CLAIM"
+  ],
+  "XP-V14-045": [
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM"
+  ],
+  "XP-V14-067": [
+   "CLAIM",
+   "CLAIM",
+   "CLAIM"
+  ],
+  "XP-V14-009": [
+   "CLAIM",
+   "CLAIM",
+   "CLAIM"
+  ],
+  "XP-V14-063": [
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM"
+  ],
+  "XP-V14-026": [
+   "CLAIM",
+   "CLAIM",
+   "CLAIM"
+  ],
+  "XP-V14-053": [
+   "CLAIM",
+   "CLAIM",
+   "CLAIM"
+  ],
+  "XP-V14-005": [
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM"
+  ],
+  "XP-V14-011": [
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM"
+  ],
+  "XP-V14-049": [
+   "CLAIM",
+   "CLAIM",
+   "CLAIM"
+  ],
+  "XP-XD-N02": [
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM"
+  ],
+  "XP-XD-C10": [
+   "CLAIM",
+   "CLAIM",
+   "CLAIM"
+  ],
+  "XP-V14-070": [
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM"
+  ],
+  "XP-V14-047": [
+   "CLAIM",
+   "CLAIM",
+   "CLAIM"
+  ],
+  "XP-V14-033": [
+   "CLAIM",
+   "CLAIM",
+   "CLAIM"
+  ],
+  "XP-V14-044": [
+   "CLAIM",
+   "CLAIM",
+   "CLAIM"
+  ],
+  "XP-V14-042": [
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM"
+  ],
+  "XP-XD-N07": [
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM"
+  ],
+  "XP-V14-084": [
+   "CLAIM",
+   "CLAIM",
+   "CLAIM"
+  ],
+  "XP-V14-089": [
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM"
+  ],
+  "XP-V14-055": [
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM"
+  ],
+  "XP-XD-N05": [
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM"
+  ],
+  "XP-V14-056": [
+   "CLAIM",
+   "CLAIM",
+   "CLAIM"
+  ],
+  "XP-V14-054": [
+   "CLAIM",
+   "CLAIM",
+   "CLAIM"
+  ],
+  "XP-V14-032": [
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM"
+  ],
+  "XP-XD-C06": [
+   "CLAIM",
+   "CLAIM",
+   "CLAIM"
+  ],
+  "XP-V14-087": [
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM"
+  ],
+  "XP-V14-093": [
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM"
+  ],
+  "XP-V14-023": [
+   "CLAIM",
+   "CLAIM",
+   "CLAIM"
+  ],
+  "XP-V14-050": [
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM"
+  ],
+  "XP-XD-N00": [
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM"
+  ],
+  "XP-XD-C04": [
+   "CLAIM",
+   "CLAIM",
+   "CLAIM"
+  ],
+  "XP-V14-046": [
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM"
+  ],
+  "XP-V14-035": [
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM"
+  ],
+  "XP-V14-013": [
+   "CLAIM",
+   "CLAIM",
+   "CLAIM"
+  ],
+  "XP-XD-N10": [
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM"
+  ],
+  "XP-XD-N08": [
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM"
+  ],
+  "XP-XD-N04": [
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM"
+  ],
+  "XP-V14-081": [
+   "CLAIM",
+   "CLAIM",
+   "CLAIM"
+  ],
+  "XP-V14-039": [
+   "CLAIM",
+   "CLAIM",
+   "CLAIM"
+  ],
+  "XP-V14-080": [
+   "CLAIM",
+   "CLAIM",
+   "CLAIM"
+  ],
+  "XP-V14-008": [
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM"
+  ],
+  "XP-V14-068": [
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM"
+  ],
+  "XP-V14-073": [
+   "CLAIM",
+   "CLAIM",
+   "CLAIM"
+  ],
+  "XP-V14-002": [
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM"
+  ],
+  "XP-V14-071": [
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM"
+  ],
+  "XP-V14-036": [
+   "CLAIM",
+   "CLAIM",
+   "CLAIM"
+  ],
+  "XP-V14-030": [
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM"
+  ],
+  "XP-XD-C03": [
+   "CLAIM",
+   "CLAIM",
+   "CLAIM"
+  ],
+  "XP-V14-060": [
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM"
+  ],
+  "XP-V14-038": [
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM"
+  ],
+  "XP-V14-024": [
+   "CLAIM",
+   "CLAIM",
+   "CLAIM"
+  ],
+  "XP-V14-066": [
+   "CLAIM",
+   "CLAIM",
+   "CLAIM"
+  ],
+  "XP-V14-083": [
+   "CLAIM",
+   "CLAIM",
+   "CLAIM"
+  ],
+  "XP-V14-099": [
+   "CLAIM",
+   "CLAIM",
+   "CLAIM"
+  ],
+  "XP-V14-074": [
+   "CLAIM",
+   "CLAIM",
+   "CLAIM"
+  ],
+  "XP-V14-025": [
+   "CLAIM",
+   "CLAIM",
+   "CLAIM"
+  ],
+  "XP-V14-076": [
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM"
+  ],
+  "XP-V14-057": [
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM"
+  ],
+  "XP-V14-027": [
+   "CLAIM",
+   "CLAIM",
+   "CLAIM"
+  ],
+  "XP-V14-020": [
+   "CLAIM",
+   "CLAIM",
+   "CLAIM"
+  ],
+  "XP-V14-061": [
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM"
+  ],
+  "XP-V14-031": [
+   "CLAIM",
+   "CLAIM",
+   "CLAIM"
+  ],
+  "XP-V14-004": [
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM"
+  ],
+  "XP-V14-037": [
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM"
+  ],
+  "XP-V14-095": [
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM"
+  ],
+  "XP-XD-C02": [
+   "CLAIM",
+   "CLAIM",
+   "CLAIM"
+  ],
+  "XP-XD-C05": [
+   "CLAIM",
+   "CLAIM",
+   "CLAIM"
+  ],
+  "XP-XD-N09": [
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM"
+  ],
+  "XP-V14-043": [
+   "CLAIM",
+   "CLAIM",
+   "CLAIM"
+  ],
+  "XP-V14-029": [
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM"
+  ],
+  "XP-V14-021": [
+   "CLAIM",
+   "CLAIM",
+   "CLAIM"
+  ],
+  "XP-V14-022": [
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM"
+  ],
+  "XP-V14-086": [
+   "CLAIM",
+   "CLAIM",
+   "CLAIM"
+  ],
+  "XP-V14-028": [
+   "CLAIM",
+   "CLAIM",
+   "CLAIM"
+  ],
+  "XP-V14-098": [
+   "CLAIM",
+   "CLAIM",
+   "CLAIM"
+  ],
+  "XP-V14-010": [
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM"
+  ],
+  "XP-V14-006": [
+   "CLAIM",
+   "CLAIM",
+   "CLAIM"
+  ],
+  "XP-XD-C12": [
+   "CLAIM",
+   "CLAIM",
+   "CLAIM"
+  ],
+  "XP-V14-015": [
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM"
+  ],
+  "XP-XD-C08": [
+   "CLAIM",
+   "CLAIM",
+   "CLAIM"
+  ],
+  "XP-V14-058": [
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM"
+  ],
+  "XP-V14-072": [
+   "CLAIM",
+   "CLAIM",
+   "CLAIM"
+  ],
+  "XP-V14-082": [
+   "CLAIM",
+   "CLAIM",
+   "CLAIM"
+  ],
+  "XP-V14-019": [
+   "CLAIM",
+   "CLAIM",
+   "CLAIM"
+  ],
+  "XP-V14-017": [
+   "CLAIM",
+   "CLAIM",
+   "CLAIM"
+  ],
+  "XP-XD-N01": [
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM"
+  ],
+  "XP-V14-065": [
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM"
+  ],
+  "XP-V14-079": [
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM"
+  ],
+  "XP-V14-040": [
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM"
+  ],
+  "XP-V14-051": [
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM"
+  ],
+  "XP-V14-000": [
+   "CLAIM",
+   "CLAIM",
+   "CLAIM"
+  ],
+  "XP-V14-094": [
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM"
+  ],
+  "XP-XD-C14": [
+   "CLAIM",
+   "CLAIM",
+   "CLAIM"
+  ],
+  "XP-V14-059": [
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM"
+  ],
+  "XP-XD-C09": [
+   "CLAIM",
+   "CLAIM",
+   "CLAIM"
+  ],
+  "XP-V14-012": [
+   "CLAIM",
+   "CLAIM",
+   "CLAIM"
+  ],
+  "XP-V14-007": [
+   "CLAIM",
+   "CLAIM",
+   "CLAIM"
+  ],
+  "XP-V14-048": [
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM"
+  ],
+  "XP-V14-096": [
+   "CLAIM",
+   "CLAIM",
+   "CLAIM"
+  ],
+  "XP-V14-097": [
+   "CLAIM",
+   "CLAIM",
+   "CLAIM"
+  ],
+  "XP-XD-N11": [
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM",
+   "NOT-A-CLAIM"
+  ]
+ }
+}

--- a/papers/closed-model-frontier/extraction_panel_result.json
+++ b/papers/closed-model-frontier/extraction_panel_result.json
@@ -1,0 +1,39 @@
+{
+  "prereg": "PREREG_extraction_ceiling_v2_2026_09_01.md (G-E1); v1 for everything else",
+  "scorer_committed_before_panel_returned": true,
+  "n_seats": 3,
+  "gates": {
+    "G_E1a_overall": {
+      "observed": "30/30",
+      "bar": ">=27/30",
+      "pass": true
+    },
+    "G_E1b_each_side": {
+      "claim": "15/15",
+      "not_a_claim": "15/15",
+      "bar": ">=9/15 each",
+      "pass": true
+    },
+    "G_E2_reconciliation": {
+      "observed": 0.16,
+      "target": 0.16,
+      "pass": true
+    },
+    "panel_split": {
+      "n_split": 0,
+      "rate": 0.0,
+      "bar": "<=0.10",
+      "pass": true
+    }
+  },
+  "decomposition": {
+    "E": 0.55,
+    "A": 0.2,
+    "n_scored_accusations": 100,
+    "n_claim": 55,
+    "upheld_among_claim": 11,
+    "P_reconciled": 0.16,
+    "G_E3_verdict": "REFUTED"
+  },
+  "verdict": "REFUTED"
+}

--- a/papers/closed-model-frontier/score_extraction_panel.py
+++ b/papers/closed-model-frontier/score_extraction_panel.py
@@ -1,0 +1,141 @@
+"""Score the blind extraction panel against PREREG_extraction_ceiling_v2_2026_09_01.md.
+
+WRITTEN AND COMMITTED BEFORE THE PANEL RETURNED. That is the point of this file existing
+separately: a scorer authored after seeing the answers is a scorer with a thumb on it. Every
+threshold below is copied from the frozen preregistrations, not chosen here.
+
+Inherited from v1 (PREREG_extraction_ceiling_2026_09_01.md, frozen at 38ab585):
+    P = E x A
+    E = CLAIM items / scored accusations
+    A = upheld items / CLAIM items          (upheld read from the committed V14 key)
+    G-E2  upheld/scored must re-derive 0.16 or the run is VOID, not adjusted
+    G-E3  E <= 0.23 SUPPORTED | E >= 0.40 REFUTED | between INDETERMINATE
+
+Replaced by v2 (frozen at 308490d), because v1's gate could not be built:
+    G-E1a >= 27/30 decoys correct overall
+    G-E1b >= 9/15 correct on EACH side separately
+
+Any gate failing means no E is reported. A void panel is published as a void panel.
+
+    python papers/closed-model-frontier/score_extraction_panel.py <panel_result.json>
+"""
+from __future__ import annotations
+
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+KEY = HERE / "extraction_panel_key_SEALED.json"
+V14_ANSWERS = HERE / "v14_answers.json"
+OUT = HERE / "extraction_panel_result.json"
+
+# every number below is transcribed from a frozen document
+G_E1A_MIN = 27          # of 30
+G_E1B_MIN = 9           # of 15, each side
+G_E2_TARGET = 0.16
+G_E3_SUPPORTED = 0.23
+G_E3_REFUTED = 0.40
+
+
+def majority(votes):
+    """Modal answer, or None when no strict majority exists."""
+    votes = [v for v in votes if v]
+    if not votes:
+        return None
+    c = Counter(votes).most_common()
+    if len(c) > 1 and c[0][1] == c[1][1]:
+        return None
+    return c[0][0]
+
+
+def main(path: str) -> int:
+    raw = json.loads(Path(path).read_text(encoding="utf-8"))
+    per_item = raw.get("per_item") or raw.get("result", {}).get("per_item") or {}
+    key = json.loads(KEY.read_text(encoding="utf-8"))
+    v14 = json.loads(V14_ANSWERS.read_text(encoding="utf-8"))
+
+    verdicts, split = {}, []
+    for iid, votes in per_item.items():
+        verdicts[iid] = majority(list(votes.values()) if isinstance(votes, dict) else votes)
+        if verdicts[iid] is None:
+            split.append(iid)
+
+    # ---------------- G-E1: reliability, two-sided ----------------
+    dec = {i: v for i, v in key.items() if v["kind"] == "decoy"}
+    sides = {"CLAIM": [], "NOT-A-CLAIM": []}
+    for iid, meta in dec.items():
+        got, want = verdicts.get(iid), meta["expected"]
+        sides[want].append(got == want)
+    n_claim_ok, n_claim = sum(sides["CLAIM"]), len(sides["CLAIM"])
+    n_not_ok, n_not = sum(sides["NOT-A-CLAIM"]), len(sides["NOT-A-CLAIM"])
+    dec_ok, dec_n = n_claim_ok + n_not_ok, n_claim + n_not
+    g1a = dec_ok >= G_E1A_MIN
+    g1b = n_claim_ok >= G_E1B_MIN and n_not_ok >= G_E1B_MIN
+
+    # ---------------- G-E2: the join must re-derive 0.16 ----------------
+    accs = {i: v for i, v in key.items() if v["kind"] == "accusation"}
+    upheld = sum(1 for v in accs.values() if v14.get(v["v14_id"]) == "CONTRADICTED")
+    p_recon = upheld / len(accs) if accs else float("nan")
+    g2 = abs(p_recon - G_E2_TARGET) < 1e-9
+
+    # ---------------- E and A, computed item by item ----------------
+    scored = [i for i in accs if verdicts.get(i) in ("CLAIM", "NOT-A-CLAIM")]
+    claim_ids = [i for i in scored if verdicts[i] == "CLAIM"]
+    E = len(claim_ids) / len(scored) if scored else float("nan")
+    upheld_in_claim = sum(1 for i in claim_ids if v14.get(accs[i]["v14_id"]) == "CONTRADICTED")
+    A = upheld_in_claim / len(claim_ids) if claim_ids else float("nan")
+
+    if E <= G_E3_SUPPORTED:
+        hyp = "SUPPORTED"
+    elif E >= G_E3_REFUTED:
+        hyp = "REFUTED"
+    else:
+        hyp = "INDETERMINATE"
+
+    # a split rate above 10% voids per the frozen "what would make us not ship"
+    split_rate = len(split) / len(verdicts) if verdicts else 1.0
+    g_split = split_rate <= 0.10
+
+    if not g1a or not g1b:
+        verdict = "VOID__reliability_gate_failed"
+    elif not g2:
+        verdict = "VOID__reconciliation_failed"
+    elif not g_split:
+        verdict = "VOID__panel_split"
+    else:
+        verdict = hyp
+
+    res = {
+        "prereg": "PREREG_extraction_ceiling_v2_2026_09_01.md (G-E1); v1 for everything else",
+        "scorer_committed_before_panel_returned": True,
+        "n_seats": raw.get("n_seats") or raw.get("result", {}).get("n_seats"),
+        "gates": {
+            "G_E1a_overall": {"observed": f"{dec_ok}/{dec_n}", "bar": f">={G_E1A_MIN}/30", "pass": bool(g1a)},
+            "G_E1b_each_side": {"claim": f"{n_claim_ok}/{n_claim}",
+                                "not_a_claim": f"{n_not_ok}/{n_not}",
+                                "bar": f">={G_E1B_MIN}/15 each", "pass": bool(g1b)},
+            "G_E2_reconciliation": {"observed": round(p_recon, 4), "target": G_E2_TARGET, "pass": bool(g2)},
+            "panel_split": {"n_split": len(split), "rate": round(split_rate, 4),
+                            "bar": "<=0.10", "pass": bool(g_split)},
+        },
+        "decomposition": ({"E": round(E, 4), "A": round(A, 4),
+                           "n_scored_accusations": len(scored),
+                           "n_claim": len(claim_ids),
+                           "upheld_among_claim": upheld_in_claim,
+                           "P_reconciled": round(p_recon, 4),
+                           "G_E3_verdict": hyp}
+                          if verdict not in ("VOID__reliability_gate_failed",
+                                             "VOID__reconciliation_failed",
+                                             "VOID__panel_split")
+                          else "WITHHELD — a gate failed and no E may be reported"),
+        "verdict": verdict,
+    }
+    OUT.write_text(json.dumps(res, indent=2) + "\n", encoding="utf-8")
+    print(json.dumps(res, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1]))

--- a/papers/disjoint-worlds/CENSUS_read_extraction_2026_09_01.md
+++ b/papers/disjoint-worlds/CENSUS_read_extraction_2026_09_01.md
@@ -1,0 +1,225 @@
+# CENSUS — the read battery's pool was never written down
+
+Fathom Lab · 2026-09-01 · Receipts: `read_extraction_census.json`,
+`read_extraction_census.py`. Reconciled against `g0clear_result_llama3b.json`,
+`b31v2_result.json`, `b34v3_result.json`, `b34v3_fresh_split_addendum.json`,
+`b35c_result.json` — none of which this census writes or edits.
+
+**This is a CENSUS**, in the tradition of `RESULT_collateral_census_2026_08_31.md` and
+`papers/closed-model-frontier/extraction_census.py`: descriptive, report-only, no hypothesis
+test, no gate, no verdict token. **No preregistration covers it, so nothing in it may carry a
+headline finding.** It loads no model and runs no experiment. It parses two committed source
+files with `ast`, replays two splits with numpy, and reconciles every count it produces
+against a receipt written by someone else. Every number below either cites a receipt or is
+marked UNCHECKABLE. A sibling document, `PREREG_read_extraction_ceiling_2026_09_01.md`,
+preregisters a prospective experiment on the same term; **this census is not a run under it
+and is not scored by it**, and nothing here may be read as a result of that preregistration.
+
+## What was being tested
+
+This lab has adopted a decomposition authored by a peer session:
+
+    P = E x A
+
+**P** is precision as published. **E** — extraction — is the share of cases where the thing
+the instrument was pointed at was actually the thing it claims to adjudicate. **A** —
+adjudication — is the share where the verdict was right, *given* the pointing was right.
+Every number this lab publishes is P, and has been read as if it were A. For diffgate the P
+was measured at 0.16 held-out (`RESULT_v14_naming_the_defects_did_not_save_it_2026_09_01.md`)
+and its E-term is open. For the calibrated instruments the benchmark hands the span to the
+instrument, so E = 1 by construction and their figures are pure A-terms.
+
+The extension under test was that the cross-model read has the second shape, and that its
+E-term is a **selection ratio** — the share of candidate concepts that survived into the
+committed battery — recoverable from committed code and receipts with no new experiment.
+
+**Half of that is right and better supported than it was stated. The estimator does not
+exist.** A peer session had begun building deployment arithmetic of the form
+`E x 0.7857` on top of it. That arithmetic has no E to multiply by, and this census is the
+reason to stop writing it.
+
+## The construction chain
+
+Every row is a pure function of committed bytes (`read_extraction_census.json` `.chain`):
+
+| stage | in | removed | out | citation |
+|---|---|---|---|---|
+| hand-typed literal `_BANK` | — | — | **465** | `run_g0clear.py:31-65` |
+| order-preserving deduplication | 465 | 3 | **462** | `run_g0clear.py:66-67` |
+| tokenization / single-token constraint | 462 | 0 | 462 | no such filter exists |
+| presence-in-both-models / shared-vocabulary check | 462 | 0 | 462 | no such filter exists |
+| frequency threshold | 462 | 0 | 462 | no such filter exists |
+| part-of-speech filter | 462 | 0 | 462 | no such filter exists |
+| representation-quality / norm or outlier screen | 462 | 0 | 462 | no such filter exists |
+| downstream re-filtering by the read experiments | 462 | 0 | 462 | `run_b31v2.py:34,103`; `run_b34v3.py:26,70` |
+
+The three removed words are `chicken`, `orange` and `mushroom` — each typed twice, in two
+different category blocks. That is the entire filtering history of the battery.
+
+The zeros are asserted mechanically rather than by keyword search. A per-concept filter in
+these extractors could only be a skip inside the concept loop, and there are none: `ast`
+reports **zero `continue` and zero `break` statements** in `run_g0clear.extract_multi` and in
+`run_thought_transfer.extract`, and the single `if` inside either loop is quoted in the
+receipt — it is `if (i + 1) % 40 == 0:`, a progress print. The keyword scan is reported
+beside it as a diagnostic, not a category, with every hit's source line: all three hits are a
+`print(... "skip")` and two `skip_special_tokens=True` kwargs. **No concept has ever been
+dropped by any measurement.** "The G0-clear set" names the instrument clearing `pc_cos >=
+0.80` at the locked layer 11 / k 150 (`g0clear_result_llama3b.json` `.locked`,
+`.G0_pc_cos_FINAL` 0.9096), not a per-concept screen.
+
+The battery's own provenance is excellent and its selection's provenance is nil.
+`git log --follow` on `run_g0clear.py` returns **one commit**, `681c26e`, 2026-06-20. The
+list was born whole and has never been edited. The 465 is recorded in no receipt, no log, no
+constant and no docstring; the 462 is recorded once, at `g0clear_result_llama3b.json`
+`.n_concepts`. The "~480" in the docstring and the "N≈480" in
+`PREREG_thought_transfer_g0clear_2026_06_20.md` were written before the list existed. They
+are design targets, not counts of anything.
+
+## The only computable ratio, and why it is not E
+
+462/465 = **0.993548**. It is exact, it is reproducible from bytes, and it is not an E-term.
+It measures that the author typed three words twice while balancing category blocks. The
+literal is the **output** of the selection, not its input, so quoting this figure as a
+survival rate would be precisely the error the decomposition exists to name. It is emitted
+under the key `dedup_survival_ratio_NOT_A_SELECTION_RATIO`, with the warning inside the value,
+for the same reason `extraction_census.py` put its marker in its key names: a consumer who
+indexes a bare key never reads the sibling that says the number decides nothing.
+
+The pool the 462 were actually selected from is the set of candidate words a person
+considered and rejected while typing 341 new nouns into a category-balanced list on
+2026-06-20. **It was never recorded, and it cannot be recovered, because it never existed as
+an artifact.** There is no generator script, no cited corpus, no vocabulary slice, no
+rejection log — searching the repository for any of those returns `run_g0clear.py` alone.
+
+**E for the cross-model read is UNCHECKABLE from committed artifacts.** Not zero, not low,
+not refuted. Unmeasured. Absence of a recorded pool is not evidence that the pool was small
+or adversarially chosen; it is evidence of nothing, which is the point. This census does not
+estimate it, and no reader should read a bound out of the fact that it declines to.
+
+## What the published read numbers actually are
+
+They are A-terms, and the mechanical argument is stronger than the argument from analogy.
+`read_top1` is an index-matched `argmin` over the held-out target centroids
+(`run_b31v2.py:90-93`, `run_b34v3.py:46-49`): the candidate array is the query set, the truth
+is present with probability 1, there is no score to threshold and no way to answer "none of
+these". E = 1 by construction on every trial these scripts have ever run. The protocol does
+not merely receive the state it reads — it **manufactures** it, from twelve
+experimenter-written sentences that each name the target word
+(`introspection_gate.py:26-38`), mean-pooled at the last token, at a layer locked by the
+G0 sweep, differenced against a fixed `"object"` baseline.
+
+| figure | value | receipt |
+|---|---|---|
+| b31v2, gemma-2-2b, MLP top-1 over 70 | 0.7857 | `b31v2_result.json` |
+| b34v3, gemma-2-2b, label-free, full 70 | 0.5714 | `b34v3_result.json` |
+| b34v3, gemma-2-2b, 57 genuinely unseen | **0.5263** | `b34v3_fresh_split_addendum.json` |
+| b34v3, Llama-3.2-1B, label-free, full 70 | 0.6857 | `b34v3_result.json` |
+| b34v3, Llama-3.2-1B, 57 genuinely unseen | **0.6667** | `b34v3_fresh_split_addendum.json` |
+
+The b31v2 figure additionally requires being handed 392 true cross-model concept pairs; that
+is a supervision precondition and it belongs beside the number wherever the number is quoted
+as deployment-relevant. The b34v3 figures are the ones that survive without it, and the
+fresh-57 recompute is the honest one — the full-70 headline includes 13 concepts that had
+been scored before.
+
+## Two corrections to the brief this census was given
+
+**b34v3 does not use `split_concepts(seed=0).`** It draws its own permutation with
+`SEED = 343` (`run_b34v3.py:32,64-72`) — the same 462 battery, the same 392/70 shape,
+different membership. This census replays both splits and both reconcile against their
+receipts exactly: 323/69/70 for seed 0, 392/70 for seed 343.
+
+**The preregistered disjointness of those two held-out sets was falsified in flight**, and
+the falsification is already committed. The census recomputes the overlap independently and
+gets **13 of 70**, matching `b34v3_fresh_split_addendum.json` `.held_out_overlap_with_v1v2`.
+The thirteen words are listed in the receipt.
+
+A third drift, found while counting: the parent bank at `run_thought_transfer.py:31-40` is
+**121 words** in the committed literal, while `run_g0clear.py:5` and
+`g0clear_result_llama3b.json` `.parent_baseline.N` both call it 110. All 121 are contained in
+`_BANK`; 341 words are net new. The 11-word gap is unrecorded anywhere. It changes no
+published result and it is named here rather than left to be found.
+
+## Held-out-ness spent by repetition
+
+Twelve committed scripts in `papers/disjoint-worlds/` reference `split_concepts`; one of them
+defines it, so eleven are consumers, and twenty-six import the battery from `run_g0clear`
+(both lists are enumerated in the receipt). Within any single run the seed-0 FIN-70 is never
+in a fit. But it has been **scored** by every one of those consumers, and no single receipt
+records that. Held-out-ness is a property of a history, not of a line of code, and this
+history is longer than any one experiment's receipt shows.
+
+A second coupling belongs beside it: the layer and k that both b31v2 and b34v3 use are loaded
+out of `g0clear_result_llama3b.json` (`run_b31v2.py:108-109`, `run_b34v3.py:60-61`). They were
+selected on SEL_dirs, which is disjoint from the seed-0 FIN-70 but sits inside b34v3's
+seed-343 training set. Legitimate, and worth saying: the apparatus's hyperparameters were
+tuned on the same hand-typed literal the read is scored over.
+
+## What would have to be re-run
+
+Nothing recovers the pool retrospectively. E becomes measurable only prospectively, by
+building the battery so that a pool exists before the selection does:
+
+1. Commit a candidate pool as a mechanically-derived artifact with a stated rule and a hashed
+   file — not a docstring summary.
+2. Express each intended filter as a committed function and record the survivor count after
+   each stage, in order, in the result JSON, the way `selection_grid` already records the
+   (layer, k) sweep at `run_g0clear.py:145`. The receipt schema has room; it records the
+   endpoint and nothing upstream.
+3. Sample the battery from the survivors under a committed seed.
+4. Re-extract on GPU across all four models. The `_b31v2_pts_*.npz` caches are keyed
+   positionally to the current 462-word list (`run_b34v3.py:37-38`) and cannot be reused for
+   a different battery. This is not a receipts-only repair.
+5. Re-run the b31v2 M0/M1/N1 cells and the b34v3 label-free read over that battery.
+
+Even then, what is bought is an E-term for *single-word English noun concepts*, not for the
+states a model can hold. That second gap survives the repair, and no construction over a word
+list closes it.
+
+---
+
+## ⚠ Boundary
+
+*In the register of `every-mind-leaves-vitals.md`'s own scope erratum, and for the same
+reason: the instrument's value is that it refuses to overclaim about itself.*
+
+> - **A selection ratio is not a precision, and bounds nothing on its own.** Even had the pool
+>   been recorded, a survival fraction multiplied into a published top-1 would not yield a
+>   deployment number. It is one factor of a chain rule whose other factors are unmeasured
+>   here. The one ratio this census can compute — 462/465 — measures deduplication and must
+>   never be quoted as E.
+>
+> - **The read is closed-set top-1 over 70 candidates, not free recall, and the candidates are
+>   the target model's own measured centroids.** There is no threshold, no calibrated score
+>   and no reject option anywhere in `run_b31v2.py` or `run_b34v3.py`. Removing the
+>   truth-in-set guarantee does not scale the number down by a coverage factor; it changes the
+>   task from ranking to detection, and this apparatus has no detection capability at all. It
+>   also presupposes already possessing the target's own extraction for the true concept —
+>   in deployment you do not have it and cannot build it without knowing the answer. The one
+>   measurement in this arc that touches the cost is `b35c_result.json`, which widened an
+>   *already closed* set from 70 to 462 and retained 0.35 of the gemma read (0.5714 → 0.2000)
+>   and 0.4584 of the llama read (0.6857 → 0.3143). That run returned
+>   `INVALID__null_artifact` on a null-model error, so those retentions are **unlicensed
+>   observations that decide nothing** — reported here so a reader does not have to discover
+>   the direction of the effect on their own. `E x A` would understate this gap, not capture
+>   it, because it treats A as invariant to a conditioning that b35c already shows it is not.
+>   The separately-named pair-coverage term that *is* licensed lives in `b50_result.json`
+>   (45 pairs, max 0.2396, per-member means 0.0370–0.0914) and is measured over its own
+>   96-item battery, not this 462-word one, so it is not composable with anything above.
+>
+> - **We measure behaviour and representation, never minds.** Everything in this census is a
+>   property of a word list, a permutation, and an `argmin` over vectors. The battery is a
+>   list of English nouns; the population of states a model can hold is not a list of English
+>   nouns, and no number here speaks to the second.
+>
+> - **This paper carries no verdict token, and none of its figures is licensed to decide
+>   anything.** No preregistration covers a census.
+
+---
+
+*The chain from the literal to the read is fully auditable and fully clean: 465 typed, 3
+deduplicated, 462 scored, no concept ever dropped by any measurement. The pool those 465 came
+out of is the one link with no receipt, and we know of no other cross-model read number in
+this repository whose extraction term is in better shape. The honest report is that we do not
+know what fraction of the thinkable survived into the battery, and this census refuses to
+guess.*

--- a/papers/disjoint-worlds/PREREG_open_set_read_2026_09_01.md
+++ b/papers/disjoint-worlds/PREREG_open_set_read_2026_09_01.md
@@ -1,0 +1,164 @@
+# PREREG — the open-set read: does the reader know when it was handed nothing?
+
+Fathom Lab · 2026-09-01 · Frozen before any mapper is fit for this study, before any reject
+statistic is scored, and before any value of the open-set quantity exists. Sibling of
+`PREREG_read_extraction_ceiling_2026_09_01.md` and of
+`../closed-model-frontier/PREREG_extraction_ceiling_2026_09_01.md`. Apparatus and committed
+receipts: `PREREG_b31v2_content_transport_2026_08_01.md`,
+`PREREG_b34v3_labelfree_read_2026_08_03.md`, `b31v2_result.json`, `b34v3_result.json`,
+`_b31v2_ptsA.npz`, `_b31v2_pts_gemma_2b.npz`, `_b31v2_pts_llama_1b.npz`,
+`_b31v2_pts_qwen_1p5b.npz`.
+
+**The standing commitment this document is written under:** do not ship a number whose
+conditioning has not been stated. Absence of evidence is never a contradiction. UNCHECKABLE is a
+first-class verdict. Never "first". Never "nobody". Always "we know of no other."
+
+---
+
+## The question, and why the apparatus has made it unaskable
+
+`read_extraction_census.json` established, from source rather than by inference, that the read is
+closed by construction. Both implementations are the same three lines
+(`run_b31v2.py:90-93`, `run_b34v3.py:46-49`):
+
+```python
+def read_top1(fin, ptsA, fin_ptsB, mapper):
+    hits = sum(1 for i, c in enumerate(fin)
+               if int(np.argmin(np.linalg.norm(fin_ptsB - mapper(ptsA[c]), axis=1))) == i)
+    return hits / len(fin)
+```
+
+`fin_ptsB` is index-aligned with `fin`, so the correct target is in the candidate array on every
+trial. `argmin` always returns something. There is no threshold, no score, and no way to answer
+*none of these*. **E = 1 by construction on every trial these scripts have ever run**, and every
+read figure this arc has published is therefore an A-term: *given that the reader was handed a
+concept that is definitely in its vocabulary, did it pick the right one?*
+
+The question underneath has never been asked here, and **we know of no other treatment of it in
+the cross-model alignment-transfer literature, ours or anyone's** — closed-set top-k over a
+candidate set containing the truth is the near-universal protocol. That is a reasonable protocol
+and it is not being called wrong. It simply cannot answer this:
+
+> **Handed a state whose target is not in the candidate set at all, does the reader say so?**
+
+A reader that cannot decline has not read a concept. It has ranked a list.
+
+---
+
+## The design
+
+**Nothing is collected and no model is loaded.** Everything below runs on the four committed
+`.npz` banks, CPU-only: 462 concepts per model, index-aligned across
+`ptsA` (3072-d), `gemma_2b` (2304-d), `llama_1b` (2048-d), `qwen_1p5b` (1536-d).
+
+**Two trial types.** Partition the 462 concept indices under a committed seed into a candidate
+set `C` and a disjoint out-of-vocabulary probe set `O`. The candidate array shown to the reader
+is `C` **only**, for every trial.
+
+  * **IN trials** — query `q` drawn from `C`. The target is present. The correct behaviour is to
+    accept and to pick `q`.
+  * **OOV trials** — query `q` drawn from `O`. The target is **absent from the candidate array
+    entirely**. The correct behaviour is to **abstain**. There is no right answer to pick.
+
+**The reject statistic**, fixed now: the top-1/top-2 **margin** in the mapped space,
+`m = d2 - d1`, where `d1 <= d2` are the two smallest distances from the mapped query to the
+candidate array. A confident read is one where the nearest candidate is decisively nearer than
+the runner-up. The margin is chosen over the raw `d1` because `d1` scales with the query's norm
+and would measure the query rather than the match; both are recorded, only `m` decides.
+
+**The quantity.** `AUROC(m)` separating IN trials from OOV trials — the probability that a
+randomly chosen IN trial carries a larger margin than a randomly chosen OOV trial. This is
+threshold-free, so no operating point has to be chosen to report it, and it is exactly the
+capability the closed-set protocol cannot express.
+
+---
+
+## Gates — thresholds fixed now, before any mapper is fit
+
+**G-O1 — reconciliation. The new apparatus must be the old one plus a reject option, and this is
+proven, not asserted.** With the reject option disabled and the candidate set set to the same
+concepts the committed runs used, the procedure must reproduce `b34v3_result.json`
+`.targets.*.read_top1` **exactly**: gemma `0.5714`, llama `0.6857` at the full-70 candidate set.
+Any deviation means this study is measuring a different apparatus than the one whose numbers it
+is decomposing. FAIL -> **VOID**, and the divergence is published rather than tuned away.
+
+**G-O2 — the null must fail.** A random-orthogonal mapper, matched in shape and fit on shuffled
+targets, is run through the identical pipeline. It must score `AUROC(m) <= 0.55`. If a random map
+separates IN from OOV, the margin is reading something about the geometry of the banks rather
+than about transported content, and the run is **VOID**. This gate can fail. It is here because
+`b48` already died on a mis-specified null in this same arc and that failure is committed.
+
+**G-O3 — the hypothesis, pre-committed in both directions.**
+
+| observed `AUROC(m)` on held-out | verdict, fixed now |
+|---|---|
+| **>= 0.75** | **OPEN-SET SIGNAL.** The reader can decline. The published read figures become the accept-branch of a capability that is real in both branches, and "reads a concept" survives contact with an absent target. |
+| **<= 0.55** | **CLOSED-SET ONLY.** The reader cannot tell a present target from an absent one. Every read number in this arc is then licensed *only* under the assumption that the answer is in the list, and every document of ours that describes the read as one model reading another's concept must be corrected. Published with equal prominence, and the corrections made. |
+| 0.55 < AUROC < 0.75 | **INDETERMINATE.** Published as indeterminate. No narrative is built on it. |
+
+**G-O4 — the split is not consulted twice.** `C`/`O` is drawn once under seed `20260901`,
+committed to a hashed file before any mapper is fit. Any threshold or operating point, if one is
+ever reported, is chosen on development concepts only. The held-out AUROC is computed once.
+
+**G-O5 — no receipt is regenerated.** `b31v2_result.json`, `b34v3_result.json`,
+`b35c_result.json` and the banks are history. Nothing here edits them. This study emits a new
+dated receipt beside them.
+
+---
+
+## Constructibility, checked before freezing — and why that clause is here
+
+`ADDENDUM_extraction_ceiling_gate_unsatisfiable_2026_09_01.md`, written earlier today, records a
+preregistration of ours frozen with a reliability gate its own packet could not supply: the
+decoys it assumed were 15 claim / 15 not-a-claim were in fact 30 claims and zero non-claims. The
+panel was voided and no number was reported. **That failure is the reason this section exists.**
+
+Before freezing this document, each gate was checked against the actual arrays for
+*constructibility only*:
+
+  * banks load and are index-aligned at 462 rows across all four models — **verified**;
+  * `C` and `O` are drawn disjoint (70 / 57 in the check) — **verified**;
+  * the candidate distance matrix and the top-1/top-2 margin are well-defined and finite —
+    **verified**;
+  * the reconciliation target exists as a committed value — **verified**.
+
+**No accuracy, no AUROC, and no read score of any kind was computed in that check**, and none
+exists at the time of freezing. What was established is that each gate *can be evaluated*, not
+what it will say.
+
+---
+
+## Honest limits — the price list
+
+**This does not widen the vocabulary.** `C` and `O` are both drawn from the same hand-typed
+462-concept literal, built from 12 experimenter-written templates. An OOV probe here is
+out-of-*candidate-set*, not out-of-distribution and not open-vocabulary. A high AUROC would show
+the reader can reject a concept **of the same manufactured kind** that was withheld from its
+list. It would say nothing about arbitrary natural language, and no result from this study may be
+described as open-vocabulary.
+
+**A low AUROC is not proof of no legibility.** It would show this margin statistic on these banks
+cannot separate present from absent. A better statistic might. The verdict is scoped to the
+statistic, which is why the statistic is named in advance and not chosen after looking.
+
+**The closed-set penalty is a different term and is not measured here.** `b35c` observed the read
+falling from 0.5714 to 0.20 (gemma) and 0.6857 to 0.3143 (llama) when the candidate set widened
+70 -> 462, but it returned `INVALID__null_artifact` and those figures are **UNLICENSED and decide
+nothing**. They are named here only to rule them out of this design.
+
+**This measures E for the read; it does not measure E for anything else.** No result here
+transfers to diffgate, to OATH, or to the calibrated instruments.
+
+---
+
+## What this can and cannot support
+
+**Can:** a threshold-free measurement of whether a cross-model reader can decline an absent
+target, on committed banks, reproducible on a laptop CPU, reconciled against a published number
+before it is allowed to report anything.
+
+**Cannot:** a claim about open-vocabulary reading, a claim about any other lab's method, a
+prevalence, or a novelty claim. The protocol we are extending — closed-set retrieval with the
+truth guaranteed present — is standard, sensible, and used by many. We know of no other instance
+of it being decomposed with a reject option and the accept-branch number reconciled against the
+closed-set original; that is the whole of the claim.

--- a/papers/disjoint-worlds/PREREG_read_extraction_ceiling_2026_09_01.md
+++ b/papers/disjoint-worlds/PREREG_read_extraction_ceiling_2026_09_01.md
@@ -1,0 +1,321 @@
+# PREREG — the extraction ceiling for the cross-model read: what was the reader pointed at?
+
+Fathom Lab · 2026-09-01 · Frozen before a single new extraction exists, before any candidate
+ladder is scored, and before any panel is convened. Sibling of
+`../closed-model-frontier/PREREG_extraction_ceiling_2026_09_01.md`, which asks the same prior
+question of diffgate's path accusations. Apparatus and receipts governed by
+`PREREG_b31v2_content_transport_2026_08_01.md`, `PREREG_b34v3_labelfree_read_2026_08_03.md`,
+`PREREG_b35c_open_vocab_2026_08_03.md`. Committed receipts referenced here:
+`b31v2_result.json`, `b34v3_result.json`, `b34v3_fresh_split_addendum.json`,
+`b35c_result.json`, `b35c_null_replication.json`, `g0clear_result_llama3b.json`,
+`b50_result.json`.
+
+**The standing commitment this document is written under:** do not ship a number whose
+conditioning has not been stated. Absence of evidence is never a contradiction. UNCHECKABLE is
+a first-class verdict. Never "first". Never "nobody". Always "we know of no other."
+
+---
+
+## The question, and why it has never been asked
+
+Every read number this arc has published answers one question: *given a vector that names one
+of seventy candidates, was the right candidate picked?* Not one answers the question before it:
+**was the thing the reader was handed a single nameable thing at all?**
+
+The apparatus makes the prior question invisible by construction. `read_top1` in
+`run_b31v2.py:90` and `run_b34v3.py:46` is an index-matched `argmin` over the held-out target
+centroids. The candidate array is index-aligned with the query array, so the truth is present
+with probability 1; there is no score, no threshold and no way to answer "none of these". Every
+query vector was manufactured by the protocol from the twelve sentences in
+`../introspection-gate/introspection_gate.py:25-38`, each of which contains the target word,
+mean-pooled at the last token, differenced against a fixed `"object"` baseline, at the layer
+locked by the G0 sweep (layer 11, k 150, `g0clear_result_llama3b.json`).
+
+So the pointing has never once been wrong, on any trial this arc has run. That is not a
+strength. It means the pointing term has never been measured, and it means the published
+numbers describe a regime the apparatus itself created.
+
+**This preregistration prices that term. It does not re-open any published verdict.**
+
+---
+
+## The decomposition, stated before any number exists
+
+A deployed identification survives only if several independent things go right. Write it, and
+note immediately that this is *not* offered as an exact chain rule:
+
+    P_deploy  ~  E  ·  V  ·  A
+
+  * **A** — the adjudication term. Given a correctly-pointed vector and a candidate set
+    containing the truth, the share where the verdict is right. **This is what every published
+    read number is**: gemma 0.7857 70-way (`b31v2_result.json`), label-free gemma 0.5714
+    (`b34v3_result.json`; 0.5263 recomputed on the 57 genuinely-unseen concepts,
+    `b34v3_fresh_split_addendum.json`). Structurally these are the same species of number as a
+    benchmark that hands the instrument its span.
+  * **E** — the extraction term. Of the moments at which the reader emits an identification,
+    the share in which the state it was handed was in fact a single-concept-dominated state at
+    the committed site. **Never measured, and by this apparatus it cannot have been**, because
+    the apparatus has only ever been pointed at states it built itself.
+  * **V** — the candidate-set term. What survives when the truth is no longer guaranteed to be
+    in the array. **Partially measured and currently unlicensed**: `b35c_result.json` widened
+    70 → 462 with everything else held favourable and returned gemma 0.2000, llama 0.3143 under
+    verdict `INVALID__null_artifact`.
+
+**We commit now to publishing no product of these terms.** `~` is not `=`. b35c already shows
+that A is not invariant to the conditioning, so a multiplicative haircut would understate the
+gap rather than express it, and a published `E × A` would be an overestimate by a factor that
+is itself unmeasured. Three numbers, three denominators, three scopes. If a reader wants one
+number, the honest answer is that this apparatus does not produce one.
+
+A fourth quantity already exists and is **not** re-measured here: pair coverage, the share of
+(reader, target) model pairs legible at all — 45 directed pairs, max pair legibility 0.2396,
+per-member means 0.0370–0.0914, "a ramp, not a cliff" (`b50_result.json`,
+`FINDING_b50_no_legibility_islands_2026_08_08.md`). It is cited wherever a headline read number
+is cited. It is a property of minds, not of pointing, and folding it into E would double-count.
+
+---
+
+## The estimand, stated so it cannot be widened afterwards
+
+    E_read = P( the activation handed to the reader was a single-concept-dominated state,
+                at the committed extraction site, at the moment it was read
+              | the reader emitted an identification )
+
+Every clause is pinned now:
+
+  * **"the committed extraction site"** — the last-token residual stream at the G0-locked layer
+    of the source, differenced against the fixed `"object"` baseline, exactly as
+    `run_g0clear.py:extract_multi` computes it. Not a nearby layer, not a pooled window, not a
+    re-swept operating point. Changing the site voids the run rather than producing a different
+    E.
+  * **"single-concept-dominated"** — a *judgment* about the text, not about the vector: reading
+    only the generated passage up to and including the marked token, is there exactly one
+    battery concept that the passage is about at that point? Answer ONE-CONCEPT (name it) /
+    NOT-ONE-CONCEPT / UNREADABLE. Deciding this from the vector would be circular, since the
+    vector is the thing under test.
+  * **"at the moment it was read"** — per-event, not per-concept and not per-corpus. E is a
+    conditional probability over firings, in the same sense diffgate's E is.
+
+Three questions that are **not** this estimand and may not be substituted for it after the
+fact: "was this concept represented in both models" (that is inside A), "would anyone have
+wanted to read this thought" (that is external validity, and no measurement here touches it),
+"is this concept in the shared vocabulary" (that is V, and it is output-side).
+
+---
+
+## Can this re-use committed extractions? Partly. Said plainly.
+
+**V can. E cannot.** We prefer re-use and we are not able to have it for the term that matters
+most.
+
+**V — CPU-from-cache, zero model loads.** The candidate ladder, the reject option and the
+truth-absent cell all run off `_b31v2_ptsA.npz` and `_b31v2_pts_*.npz`, the same caches b35c
+used. This half costs nothing but CPU and is run **first**, because it is free.
+
+**E — a new run, and it is unavoidable.** Measuring E requires pointing the reader at states
+the protocol did not construct: free-running continuations from the source model, no concept
+template, no mean-pooling over twelve sentences, a token position the experimenter did not
+choose to be the moment a word appears. No such run exists in this arc, and no re-analysis of
+committed caches can synthesise one, because every cached vector is a template mean.
+
+The cost, stated without an estimate we have not earned: unlike b35c, b35a and b34v3, this run
+**loads models**. It needs generation from `meta-llama/Llama-3.2-3B-Instruct` and a fresh
+extraction pass at the committed site, on GPU. It is the most expensive run this arc has
+proposed. We do not put a runtime number here because we have not measured one, and a guess in
+a frozen document is the defect this lab keeps catching in itself.
+
+**Ordering commitment, fixed now:** V runs first and its result does **not** license skipping E.
+Cancelling E after seeing V would be a post-hoc degree of freedom, and it is forbidden by this
+document.
+
+---
+
+## The closed-set problem, preregistered rather than discovered
+
+Top-1 over 70 candidates is identification, not recall. Deciding after seeing results how an
+open-set condition should be scored is the single degree of freedom that would invalidate all
+of this, so it is decided here.
+
+**(a) The ladder is fixed now and may not be extended, trimmed or reordered.** Three conditions,
+scored on the same held-out queries under the same map: **70-way** (the committed condition),
+**462-way** (the full battery, trained anchors included as distractors), **truth-absent** (see
+(d)). No fourth condition may be added after results; a fourth condition may be *proposed* for a
+successor preregistration.
+
+**(b) The 462-way null is rank-based, not hit-rate-based.** This is the remedy b35c's own
+finding already named. The pairing-shuffled null mode-concentrates — 22 of 70 distinct
+predictions, ~30% modal share, gemma scoring exactly one hit on five of five independent seeds
+(`b35c_null_replication.json`) — so a floor derived from Poisson independence is not a valid
+gate for it. Fixed now: five null seeds `[11, 22, 33, 44, 55]`, scored by **mean reciprocal
+rank**. The read's MRR must exceed **every one** of the five null MRRs, and must be at least
+**2.0×** the largest of them. The factor 2.0 is a choice, not a derivation; it is deliberately
+coarse because no measured base rate exists to size it — the same sentence b35c's prereg wrote,
+and it is still true.
+
+**(c) The reject option, calibrated on train anchors only.** A ranking instrument with no
+abstention has no deployment precision at all. Fixed now: τ = the **90th percentile** of
+mapped-query-to-nearest-centroid distance over the **392 train anchors** under the same map, in
+the same target space, computed before any held-out query is scored. A read whose nearest
+distance exceeds τ is **ABSTAIN** — not a hit, not a miss, and in the denominator. The
+percentile is 90, no sweep is permitted, and τ is never re-fit on held-out data. The abstention
+rate is reported for every condition.
+
+**(d) The truth-absent cell — the one that turns identification into detection.** Half the
+held-out queries, selected by a seed fixed now (`seed=907`), are re-scored with the *true*
+target centroid removed from the candidate array. A usable instrument must abstain there.
+Define **R** = share of truth-absent queries on which the instrument abstains. If R falls below
+its gate, then **no deployment precision may be quoted for this instrument in any document this
+lab publishes**, and in particular the string "deployment precision = E × A" is forbidden.
+
+---
+
+## Gates — thresholds fixed now
+
+The V half is machine-scorable and carries a gates block. The E half is panel-adjudicated and
+cannot be scored from a JSON; its gates are stated in prose below and are equally binding.
+
+### V — the candidate-set half
+
+```gates
+{"gates": {"G0_reconcile70": {"metric": "ladder.gemma_2b.read70", "op": "==", "value": 0.5714},
+           "G1_ladder": {"metric": "ladder.conditions_scored", "op": ">=", "value": 3},
+           "G2_null_rank": {"metric": "ladder.gemma_2b.mrr462_over_max_null_mrr462", "op": ">=", "value": 2.0},
+           "G3_reject_option": {"metric": "truth_absent.gemma_2b.abstain_rate", "op": ">=", "value": 0.50}},
+ "outcomes": [{"when": {"G0_reconcile70": false}, "verdict": "VOID__reconciliation_failed"},
+              {"when": {"G0_reconcile70": true, "G1_ladder": false}, "verdict": "VOID__ladder_incomplete"},
+              {"when": {"G0_reconcile70": true, "G1_ladder": true, "G2_null_rank": false}, "verdict": "VOID__null_model_unrepaired"},
+              {"when": {"G0_reconcile70": true, "G1_ladder": true, "G2_null_rank": true, "G3_reject_option": false}, "verdict": "READ_HAS_NO_REJECT_OPTION__no_deployment_precision_may_be_quoted"},
+              {"when": {"G0_reconcile70": true, "G1_ladder": true, "G2_null_rank": true, "G3_reject_option": true}, "verdict": "CANDIDATE_PENALTY_PRICED__reject_option_exists"}],
+ "smoke_verdict": "INVALID__smoke_plumbing_only"}
+```
+
+**G0** is a reconciliation obligation, not a result: re-running the committed 70-way cell off
+the same cache must re-derive `b34v3_result.json`'s gemma `read_top1` **exactly**. Any deviation
+means the join is wrong and the run is VOID, not adjusted. **G3**'s bar of 0.50 is a choice — a
+coin's worth of abstention is the weakest bar under which the word *detection* is not simply
+false — and it is coarse for the same reason as (b): there is no base rate to size it against.
+
+### E — the extraction half
+
+**G-E1 — panel reliability.** A sealed decoy set of **40** windows, 20 in which exactly one
+battery concept unambiguously dominates and 20 in which none does, drawn from a held-aside
+generation pool under a separate prompt seed, labelled and digest-committed before any panel
+seat opens. Panel accuracy **≥ 36/40**, or the panel is VOID and no E is reported. Non-negotiable.
+
+**G-E2 — packet size, fixed by precision not by convenience.** **N = 300** extraction events,
+one per continuation, token position sampled uniformly from positions ≥ 32 tokens into the
+continuation, seeds fixed in the run script before the first generation. 300 is chosen so the
+95% Wilson half-width at E = 0.5 is ≤ 0.06 (which requires 267); it is rounded up, and it is not
+adjusted after any interim look, because there are no interim looks.
+
+**G-E3 — the hypothesis, pre-committed in both directions.** There is no published deployment
+precision for the read to divide into, so — unlike the sibling document — these bars **cannot**
+be derived by inverting a known P. They are set on interpretability grounds and that is stated
+rather than disguised.
+
+| observed E_read | verdict, fixed now |
+|---|---|
+| **E ≤ 0.30** | **SUPPORTED.** Fewer than a third of untemplated moments satisfy the pointing precondition. Extraction is a binding constraint for the read, the published numbers are A-terms describing a regime untemplated cognition mostly does not enter, and the sibling's decomposition extends. |
+| **E ≥ 0.60** | **REFUTED for the read.** Most untemplated moments do satisfy it. Extraction is *not* the binding constraint here, the analogy to diffgate's path claims fails at the term it was built on, and the deployment gap must be explained by V and A instead. Published as a failed hypothesis of ours, at the same prominence as the other cell. |
+| 0.30 < E < 0.60 | **INDETERMINATE.** Published as indeterminate. No narrative is built on it. |
+
+**G-E4 — no receipt is regenerated.** `b31v2_result.json`, `b34v3_result.json`,
+`b35c_result.json` and `g0clear_result_llama3b.json` are history and are not edited, re-run or
+"corrected" by this work. A receipt is history too. New findings land in new dated receipts
+beside them.
+
+---
+
+## The doubt this document carries as a live possibility
+
+An adversarial review of the proposed extension, run before this document was written, returned
+HOLDS WITH MODIFICATION and killed half of it. Recorded here so it cannot be quietly dropped:
+
+  1. **The originally-proposed estimator does not exist.** "E for the read is a selection ratio
+     computable from committed code and receipts" is **withdrawn**. The battery is a hand-typed
+     triple-quoted string (`run_g0clear.py:_BANK`), deduped to 462 (`g0clear_result_llama3b.json`,
+     `n_concepts`). No concept was ever rejected by any measurement; a grep of the three run
+     scripts for exclude/drop/filter/reject/discard returns nothing. The only selection ratio the
+     committed code supports measures **deduplication**. The candidate pool was never written
+     down, so any denominator supplied now is chosen post hoc — the exact defect this house bans.
+  2. **The doubt is not resolved by this document.** It is entirely possible that E comes back
+     high and the extension is REFUTED. That cell is in the table above with its own prominence
+     commitment, and this document was written expecting it might fire.
+  3. **The gap may be larger than E × A can express.** b35c is the lab's own lower bound on the
+     candidate-set penalty, and it is unlicensed. That is why V is measured separately and why
+     no product is published.
+
+---
+
+## What would make us not ship
+
+If the panel splits — no majority on more than 10% of items — E is not reported as a number at
+all. If the decoy gate fails, nothing is reported but the failure. If UNREADABLE exceeds 25% of
+scored items, the stimulus stream is disclosed as unjudgeable and the run is **VOID for E**;
+UNREADABLE items otherwise sit in the denominator and never in the numerator. If G0
+reconciliation fails, the join is disclosed as broken and the caches are left alone. If the
+extraction site cannot be reproduced from the new code path to within 1e-5 max absolute
+deviation on the committed source centroids, the run is VOID before a single event is judged.
+
+**A void run is published as a void run**, under its own dated finding, with the void named in
+the title. This arc has published two INVALIDs in a single session
+(`FINDING_b35bc_generality_invalids_2026_08_03.md`) and an INVALID whose retraction was about
+our arithmetic rather than our data (`FINDING_b48_invalid_null_bar_2026_08_06.md`). A third is
+the expected cost of asking, and we commit to it in advance.
+
+We further commit to publishing the REFUTED cell of G-E3 with the same prominence as the
+SUPPORTED one.
+
+---
+
+## Honest limits — the price list
+
+**No model is run by this document.** It freezes thresholds. Nothing here is a result and
+nothing here licenses a claim.
+
+**The battery is a stimulus set, not a claim set.** It was enlarged from N~110 to N~480 under
+`PREREG_thought_transfer_g0clear_2026_06_20.md` for one stated reason — raising PCA subspace
+coverage — in service of the cross-model **write** channel. The read arc inherited it wholesale.
+It has no sampling frame. Reinterpreting it as a sample of "thoughts a model might have" is a
+post-hoc reframing of an object built to be a PCA cloud, and this document does not do it.
+
+**"This concept was readable" and "someone wanted to read it" are different questions, and
+nothing proposed here resolves the second.** The continuation prompts are ours. External
+validity of the stimulus stream is not measured, is not gated, and may not be inferred from any
+value of E.
+
+**E is a judgment quantity and is labelled one.** It cannot be decided from bytes, which is why
+it gets a panel and a decoy gate rather than a regex.
+
+**The panel is ours.** Convened, instructed and sealed by us, on our sample. It is disinterested
+in the read's verdict but not independent of the lab. A reader who believes we fool ourselves
+has only our receipts to check us with.
+
+**If the run is void, E stays UNCHECKABLE.** That is a verdict, not a gap. Absence of evidence
+is never a contradiction, and a low E would not mean the read is worthless any more than a high
+one would mean it is deployable.
+
+**Two preconditions must be named wherever a headline is quoted.** b31v2's 0.7857 additionally
+requires being handed 392 true cross-model concept pairs — a supervision precondition, not an
+extraction one. b34v3's 0.5714 is the figure that survives without it, and its 57-genuinely-unseen
+recompute is 0.5263; both are quoted together, per the erratum the b34v3 prereg forced.
+
+---
+
+## What this can and cannot support
+
+**Can:** a price for the pointing term of one cross-model read, and a separately-scoped price
+for the candidate-set term, each with its own denominator, each gated before the data existed.
+
+**Cannot:** a claim about any other instrument, any other model pair, any other lab's tool. Not
+a prevalence. Not a statement about minds. We measure behaviour and representation, never minds;
+the boundary is the product.
+
+**Prior art and credit.** Decomposing a pipeline metric into per-stage terms is ordinary practice
+in information extraction and information retrieval, and we claim nothing about the method.
+Open-set and open-vocabulary evaluation, abstention thresholds calibrated on training data, and
+rank-based nulls for many-way retrieval are all standard, and we claim nothing about those
+either. What we know of no other instance of is a cross-model representational readout
+publishing an extraction term for its own identifications against states it did not itself
+construct. That is the measurement this document exists to price, and it is the one the
+apparatus, as it stands, cannot yet perform.

--- a/papers/disjoint-worlds/RESULT_open_set_read_VOID_2026_09_01.md
+++ b/papers/disjoint-worlds/RESULT_open_set_read_VOID_2026_09_01.md
@@ -1,0 +1,126 @@
+# RESULT — the open-set read is VOID: the null mapper separates too
+
+Fathom Lab · 2026-09-01 · Scored against `PREREG_open_set_read_2026_09_01.md`, frozen and
+pushed at `45d7ae5` before this ran. Receipt: `open_set_read_result.json`. Runner:
+`run_open_set_read.py`. 756 seconds, CPU-only, from the committed `.npz` banks. No model was
+loaded and nothing was collected.
+
+## VERDICT: `VOID__null_mapper_separates`
+
+**G-O2 failed and the prereg's consequence is taken, not argued with.** No open-set capability
+is claimed for any model, in either direction.
+
+---
+
+## What passed, and it is worth having on its own
+
+**G-O1 — closed-set reconciliation. PASS, exactly, on all three targets.**
+
+| target | this harness | committed `b34v3_result.json` | reconciles |
+|---|---|---|---|
+| `llama_1b` | 0.6857 | 0.6857 | yes |
+| `gemma_2b` | 0.5714 | 0.5714 | yes |
+| `qwen_1p5b` | 0.1429 | 0.1429 | yes |
+
+This is the gate that makes the study legitimate and it is the one clean asset produced today.
+`run_open_set_read.py` replicates b34v3's seed, its rng **consumption order**, its
+`TransferMap.fit` -> `assignment_from_map` -> `fit_mlp` pipeline, and re-derives all three
+published read figures to four decimals. **The open-set harness is provably the committed
+apparatus plus a reject option, not a different measurement.** Any successor design can build on
+it without re-litigating whether it is measuring the same thing.
+
+---
+
+## What failed
+
+**G-O2 — the null must fail. FAILED.** A random-orthogonal mapper, fit on shuffled targets and
+pushed through the identical pipeline, was required to score `AUROC(margin) <= 0.55`. Observed:
+
+| target | null-mapper AUROC | bar |
+|---|---|---|
+| `llama_1b` | **0.5861** | <= 0.55 |
+| `gemma_2b` | **0.5584** | <= 0.55 |
+| `qwen_1p5b` | 0.5012 | <= 0.55 |
+
+Two of three exceed it. **The top-1/top-2 margin separates present-target from absent-target
+trials even when the map carries no correspondence at all**, so on this statistic the separation
+is not evidence about transported content.
+
+### The mechanism, named plainly
+
+An IN query is a concept whose own target vector is one of the 35 candidates, and the query is
+that same concept read out of the other model. Whatever survives a random map — norm structure,
+the anisotropy of the bank, the fact that a point's own image sits in the array — is enough to
+depress `d1` relative to `d2` without any correspondence being transported. Absence of a target
+is therefore partly detectable from **geometry alone**. That is a property of the banks and the
+statistic, not of the reader.
+
+`b48` in this same arc died on a mis-specified null and that failure is committed. This gate was
+written because of it, and it did its job.
+
+---
+
+## The numbers that are NOT licensed, printed anyway
+
+Under a void run these decide nothing. They are recorded because suppressing an observation
+because its gate failed is how a corpus becomes a highlight reel.
+
+| target | AUROC(margin) IN vs OOV | null | top-1 within C on IN trials |
+|---|---|---|---|
+| `llama_1b` | 0.7665 | 0.5861 | 0.8286 |
+| `gemma_2b` | 0.6033 | 0.5584 | 0.7429 |
+| `qwen_1p5b` | 0.5061 | 0.5012 | 0.2571 |
+
+**`llama_1b` 0.7665 would have cleared the 0.75 OPEN-SET SIGNAL bar. It is void and must not be
+quoted as a result**, here or anywhere downstream. The real-minus-null gaps (0.180, 0.045,
+0.005) are likewise not a repaired statistic — subtracting a null after seeing it is exactly the
+post-hoc move preregistration exists to prevent. A successor must freeze its statistic first.
+
+---
+
+## What this does and does not change
+
+**The E = 1 finding stands and is untouched.** `read_top1` is still an index-matched `argmin`
+over an array containing the truth (`run_b31v2.py:90-93`, `run_b34v3.py:46-49`), so every
+published read figure in this arc is still an A-term. This run failed to *measure* the missing
+term; it did not find the term to be absent.
+
+**No correction is owed to the arc's published numbers.** G-O3 was never reached, so
+`TELEPATHY_READ_BAR_CLEARED__labelfree_pairing_reads_crossfamily` is neither upheld nor
+impeached by this run. The obligation to describe those numbers as closed-set-conditional comes
+from the source reading, not from this experiment.
+
+**A void is not a null result.** We did not learn that the reader cannot decline. We learned that
+this statistic cannot tell us, because it answers partly from geometry.
+
+---
+
+## The repair, for a successor preregistration
+
+The statistic must be invariant to what the null exploits. Candidates, to be chosen and frozen
+**before** the next run rather than after inspecting these numbers:
+
+1. **Per-query standardisation** — z-score the margin against the query's own distance
+   distribution over the candidate array, so bank anisotropy divides out.
+2. **A rank statistic** — the normalised rank gap, which discards distance scale entirely.
+3. **Matched-null calibration as part of the design** — declare in advance that the reported
+   quantity is the null-adjusted separation, with the null fit under the same seed and its bar
+   set on development concepts.
+4. **Harder OOV probes** — draw absent-target probes whose nearest candidate distance is matched
+   to the IN distribution, so presence cannot be inferred from proximity alone.
+
+Whichever is chosen must clear the same G-O2 null before any G-O3 verdict is read.
+
+---
+
+## Disclosure
+
+This is the second void of 2026-09-01. The first
+(`../closed-model-frontier/ADDENDUM_extraction_ceiling_gate_unsatisfiable_2026_09_01.md`) voided
+because its reliability gate could not be **built** from the packet it named. This one is
+different in kind and better: the gate was built, it **ran**, and it **failed**. That is a
+completed experiment with a negative outcome, not an unexecutable document.
+
+Three preregistrations were frozen today and two runs are void. A lab that writes more
+preregistrations than it completes measurements should be told so by its own receipts, and this
+paragraph is that receipt.

--- a/papers/disjoint-worlds/open_set_read_result.json
+++ b/papers/disjoint-worlds/open_set_read_result.json
@@ -1,0 +1,65 @@
+{
+  "prereg": "PREREG_open_set_read_2026_09_01.md",
+  "prereg_commit": "45d7ae5",
+  "what": "does the reader decline when the target is ABSENT from the candidate array? read_top1 is an index-matched argmin over an array containing the truth, so E = 1 by construction and every published read figure is an A-term",
+  "reject_statistic": "top-1/top-2 margin (d2 - d1) in the mapped space, fixed in the prereg",
+  "b34v3_seed": 343,
+  "open_seed": 20260901,
+  "n_heldout": 70,
+  "n_candidates": 35,
+  "n_oov": 35,
+  "deviation_from_prereg": "The prereg says 'partition the 462 concept indices'. This partitions the 70 HELD-OUT concepts instead \u2014 STRICTER, because every query is then a concept the mapper never trained on. Partitioning all 462 would draw most queries from the 392 training concepts and confound familiarity with presence-in-candidate-set. The prereg did not fix |C| and |O|; set to 35/35 here for balance. Disclosed, not silently taken.",
+  "targets": {
+    "llama_1b": {
+      "seed_acc": 0.7959,
+      "closed_set_read_top1": 0.6857,
+      "committed_read_top1": 0.6857,
+      "G_O1_reconciles": true,
+      "auroc_margin_in_vs_oov": 0.7665,
+      "auroc_margin_null_mapper": 0.5861,
+      "in_trial_top1_within_C": 0.8286,
+      "seconds": 246.4
+    },
+    "gemma_2b": {
+      "seed_acc": 0.5918,
+      "closed_set_read_top1": 0.5714,
+      "committed_read_top1": 0.5714,
+      "G_O1_reconciles": true,
+      "auroc_margin_in_vs_oov": 0.6033,
+      "auroc_margin_null_mapper": 0.5584,
+      "in_trial_top1_within_C": 0.7429,
+      "seconds": 253.6
+    },
+    "qwen_1p5b": {
+      "seed_acc": 0.0536,
+      "closed_set_read_top1": 0.1429,
+      "committed_read_top1": 0.1429,
+      "G_O1_reconciles": true,
+      "auroc_margin_in_vs_oov": 0.5061,
+      "auroc_margin_null_mapper": 0.5012,
+      "in_trial_top1_within_C": 0.2571,
+      "seconds": 254.3
+    }
+  },
+  "gates": {
+    "G_O1_closed_set_reconciliation": {
+      "pass": true,
+      "note": "every target must re-derive its committed read_top1 exactly"
+    },
+    "G_O2_null_mapper_auroc_le_0.55": {
+      "pass": false,
+      "observed": {
+        "llama_1b": 0.5861,
+        "gemma_2b": 0.5584,
+        "qwen_1p5b": 0.5012
+      }
+    },
+    "G_O3_per_target_verdict": {
+      "llama_1b": "OPEN_SET_SIGNAL",
+      "gemma_2b": "INDETERMINATE",
+      "qwen_1p5b": "CLOSED_SET_ONLY"
+    }
+  },
+  "verdict": "VOID__null_mapper_separates",
+  "seconds_total": 756.4
+}

--- a/papers/disjoint-worlds/read_extraction_census.json
+++ b/papers/disjoint-worlds/read_extraction_census.json
@@ -1,0 +1,555 @@
+{
+ "what": "EXTRACTION census of the cross-model read battery: the construction chain of the N=462 concept battery that b31v2, b34v3 and b35c are scored over",
+ "kind": "CENSUS \u2014 descriptive, report-only. No hypothesis test, no gate, no verdict token, NO PREREGISTRATION. Nothing here may carry a headline finding.",
+ "companion_paper": "CENSUS_read_extraction_2026_09_01.md",
+ "loads_no_model": true,
+ "writes": [
+  "read_extraction_census.json"
+ ],
+ "edits_no_receipt": true,
+ "rules": {
+  "raw_tokens": "the module-level `_BANK = \"\"\"...\"\"\".split()` literal in run_g0clear.py, recovered by ast.literal_eval of the receiver of .split(), then split on whitespace exactly as Python's str.split does",
+  "deduplicated": "the order-preserving comprehension at run_g0clear.py:66-67, reproduced character-for-character in dedup_order_preserving",
+  "split_seed0": "run_g0clear.py:99-108 replayed with numpy default_rng(0): n_tr = int(0.70*N), n_sel = int(0.15*N), fin = the remainder",
+  "split_seed343": "run_b34v3.py:64-72 replayed with numpy default_rng(343): fin = first 70 of the permutation, tr = the next N-70. This is NOT split_concepts",
+  "anchors_392": "run_b31v2.py:104-105 concatenates TRAIN and SEL_dirs after calling split_concepts(seed=0); the concatenation is the consumer's, not the splitter's",
+  "loop_skip_branches": "ast walk of the named extraction function counting `continue` and `break`. A per-concept filter in these extractors could only be a skip inside the concept loop, so zero skips is evidence that no concept is ever dropped by measurement",
+  "candidate_pool": "NO RULE EXISTS. There is no committed corpus, vocabulary slice, dataset or generator script from which the battery was drawn, so there is no denominator to compute against"
+ },
+ "provenance": {
+  "run_g0clear_py_sha256": "5ff6e5c2ed85c542bda38e378372f0279e3135c4e1b630a394c874b1b6c24bc9",
+  "git": {
+   "status": "read",
+   "n_commits": 1,
+   "commits": [
+    {
+     "commit": "681c26e804940e69771bbcb8de06f4fd91304618",
+     "date": "2026-06-20 23:03:25 -0400",
+     "subject": "runner(thought-transfer): Stage-0 G0-clear instrument \u00e2\u20ac\u201d N=462 concept bank + (layer,k) sweep with SELECTION/FINAL seal; loads only model A, computes only pc_cos (no cross-model number). Per PREREG_thought_transfer_g0clear."
+    }
+   ]
+  },
+  "recorded_pool_size": null,
+  "recorded_pool_size_status": "UNCHECKABLE \u2014 the pre-filter candidate pool was never recorded as an artifact, so no survival ratio exists to compute. This is a verdict, not a failure, and it is not a claim that the ratio is low. Absence of evidence is never a contradiction.",
+  "design_targets_not_measurements": {
+   "run_g0clear.py:29 docstring": "~480 single-word concepts",
+   "PREREG_thought_transfer_g0clear_2026_06_20.md:25,43": "N~480",
+   "note": "both were written before the list existed; they are design targets, not counts of anything"
+  }
+ },
+ "battery": {
+  "raw_tokens_in_literal": 465,
+  "raw_tokens_recorded_in_any_receipt": false,
+  "deduplicated": 462,
+  "deduplicated_recorded_in": "g0clear_result_llama3b.json .n_concepts",
+  "duplicates": [
+   {
+    "word": "chicken",
+    "first_index": 52,
+    "repeat_index": 133
+   },
+   {
+    "word": "mushroom",
+    "first_index": 104,
+    "repeat_index": 265
+   },
+   {
+    "word": "orange",
+    "first_index": 68,
+    "repeat_index": 439
+   }
+  ],
+  "distinct_after_dedup_equals_len_set": true,
+  "line_structure": {
+   "note": "token counts per source line of the literal. THE BYTES CARRY NO CATEGORY LABELS: there are no comments, no blank lines and no markers between the apparent category blocks, so any category attribution is a reader's inference and is NOT mechanically derivable from this file. Reported as structure, not as taxonomy.",
+   "lines": [
+    {
+     "line": 32,
+     "tokens": 19,
+     "first": "dog",
+     "last": "zebra"
+    },
+    {
+     "line": 33,
+     "tokens": 16,
+     "first": "giraffe",
+     "last": "shrimp"
+    },
+    {
+     "line": 34,
+     "tokens": 17,
+     "first": "snail",
+     "last": "swan"
+    },
+    {
+     "line": 35,
+     "tokens": 14,
+     "first": "chicken",
+     "last": "worm"
+    },
+    {
+     "line": 36,
+     "tokens": 15,
+     "first": "apple",
+     "last": "pineapple"
+    },
+    {
+     "line": 37,
+     "tokens": 14,
+     "first": "strawberry",
+     "last": "pepper"
+    },
+    {
+     "line": 38,
+     "tokens": 13,
+     "first": "lettuce",
+     "last": "turnip"
+    },
+    {
+     "line": 39,
+     "tokens": 18,
+     "first": "bread",
+     "last": "chocolate"
+    },
+    {
+     "line": 40,
+     "tokens": 14,
+     "first": "candy",
+     "last": "water"
+    },
+    {
+     "line": 41,
+     "tokens": 19,
+     "first": "hammer",
+     "last": "hoe"
+    },
+    {
+     "line": 42,
+     "tokens": 15,
+     "first": "ladder",
+     "last": "bucket"
+    },
+    {
+     "line": 43,
+     "tokens": 16,
+     "first": "car",
+     "last": "subway"
+    },
+    {
+     "line": 44,
+     "tokens": 8,
+     "first": "canoe",
+     "last": "sled"
+    },
+    {
+     "line": 45,
+     "tokens": 17,
+     "first": "chair",
+     "last": "cabinet"
+    },
+    {
+     "line": 46,
+     "tokens": 12,
+     "first": "drawer",
+     "last": "wardrobe"
+    },
+    {
+     "line": 47,
+     "tokens": 18,
+     "first": "shirt",
+     "last": "tie"
+    },
+    {
+     "line": 48,
+     "tokens": 8,
+     "first": "button",
+     "last": "helmet"
+    },
+    {
+     "line": 49,
+     "tokens": 17,
+     "first": "tree",
+     "last": "lake"
+    },
+    {
+     "line": 50,
+     "tokens": 17,
+     "first": "forest",
+     "last": "beach"
+    },
+    {
+     "line": 51,
+     "tokens": 18,
+     "first": "sun",
+     "last": "wood"
+    },
+    {
+     "line": 52,
+     "tokens": 12,
+     "first": "clay",
+     "last": "steam"
+    },
+    {
+     "line": 53,
+     "tokens": 15,
+     "first": "house",
+     "last": "barn"
+    },
+    {
+     "line": 54,
+     "tokens": 9,
+     "first": "stadium",
+     "last": "lighthouse"
+    },
+    {
+     "line": 55,
+     "tokens": 14,
+     "first": "guitar",
+     "last": "tambourine"
+    },
+    {
+     "line": 56,
+     "tokens": 17,
+     "first": "anger",
+     "last": "worry"
+    },
+    {
+     "line": 57,
+     "tokens": 9,
+     "first": "relief",
+     "last": "jealousy"
+    },
+    {
+     "line": 58,
+     "tokens": 15,
+     "first": "king",
+     "last": "sailor"
+    },
+    {
+     "line": 59,
+     "tokens": 12,
+     "first": "chef",
+     "last": "priest"
+    },
+    {
+     "line": 60,
+     "tokens": 19,
+     "first": "head",
+     "last": "brain"
+    },
+    {
+     "line": 61,
+     "tokens": 8,
+     "first": "bone",
+     "last": "chin"
+    },
+    {
+     "line": 62,
+     "tokens": 11,
+     "first": "red",
+     "last": "gray"
+    },
+    {
+     "line": 63,
+     "tokens": 15,
+     "first": "freedom",
+     "last": "wisdom"
+    },
+    {
+     "line": 64,
+     "tokens": 4,
+     "first": "chaos",
+     "last": "war"
+    }
+   ]
+  }
+ },
+ "parent_bank": {
+  "citation": "run_thought_transfer.py:31-40",
+  "raw_tokens": 121,
+  "deduplicated": 121,
+  "recorded_as": {
+   "run_g0clear.py:5 docstring": 110,
+   "g0clear_result_llama3b.json .parent_baseline.N": 110
+  },
+  "recorded_figure_matches_committed_literal": false,
+  "drift_unrecorded": 11,
+  "parent_words_present_in_battery": 121,
+  "parent_words_absent_from_battery": [],
+  "net_new_words_in_battery": 341,
+  "how_the_net_new_were_chosen": "UNCHECKABLE \u2014 the pre-filter candidate pool was never recorded as an artifact, so no survival ratio exists to compute. This is a verdict, not a failure, and it is not a claim that the ratio is low. Absence of evidence is never a contradiction."
+ },
+ "chain": [
+  {
+   "stage": "hand-typed literal `_BANK`",
+   "citation": "run_g0clear.py:31-65",
+   "in": null,
+   "removed": 0,
+   "out": 465,
+   "note": "the list was born whole; there is no upstream artifact"
+  },
+  {
+   "stage": "order-preserving deduplication",
+   "citation": "run_g0clear.py:66-67",
+   "in": 465,
+   "removed": 3,
+   "out": 462,
+   "note": "the ONLY filter in the entire chain",
+   "removed_words": [
+    "chicken",
+    "mushroom",
+    "orange"
+   ]
+  },
+  {
+   "stage": "tokenization / single-token constraint",
+   "citation": "run_g0clear.py extract_multi; run_thought_transfer.py extract",
+   "in": 462,
+   "removed": 0,
+   "out": 462,
+   "note": "NO SUCH FILTER EXISTS"
+  },
+  {
+   "stage": "presence-in-both-models / shared-vocabulary check",
+   "citation": "no target tokenizer is consulted anywhere; concepts are embedded through the 12 CONCEPT_TEMPLATES at introspection_gate.py:26-38",
+   "in": 462,
+   "removed": 0,
+   "out": 462,
+   "note": "NO SUCH FILTER EXISTS"
+  },
+  {
+   "stage": "frequency threshold",
+   "citation": "no frequency table is imported anywhere in the chain",
+   "in": 462,
+   "removed": 0,
+   "out": 462,
+   "note": "NO SUCH FILTER EXISTS"
+  },
+  {
+   "stage": "part-of-speech filter",
+   "citation": "no POS tagger is imported anywhere in the chain",
+   "in": 462,
+   "removed": 0,
+   "out": 462,
+   "note": "NO SUCH FILTER EXISTS"
+  },
+  {
+   "stage": "representation-quality gate / norm or outlier screen",
+   "citation": "no per-concept statistic is ever compared against a threshold",
+   "in": 462,
+   "removed": 0,
+   "out": 462,
+   "note": "NO SUCH FILTER EXISTS"
+  },
+  {
+   "stage": "downstream re-filtering by the read experiments",
+   "citation": "run_b31v2.py:34,103 and run_b34v3.py:26,70 both import the list wholesale",
+   "in": 462,
+   "removed": 0,
+   "out": 462,
+   "note": "NO SUCH FILTER EXISTS"
+  }
+ ],
+ "loop_skip_branches": {
+  "run_g0clear.extract_multi": {
+   "found": true,
+   "continue_statements": 0,
+   "break_statements": 0,
+   "if_statements": 1,
+   "if_statement_lines": [
+    {
+     "line": 94,
+     "source": "if (i + 1) % 40 == 0:"
+    }
+   ]
+  },
+  "run_thought_transfer.extract": {
+   "found": true,
+   "continue_statements": 0,
+   "break_statements": 0,
+   "if_statements": 0,
+   "if_statement_lines": []
+  }
+ },
+ "filter_token_scan_DIAGNOSTIC_not_a_category": {
+  "note": "a hit is not a filter and a miss is not proof of absence; the load-bearing evidence is loop_skip_branches",
+  "run_g0clear.py": {},
+  "run_b31v2.py": {
+   "skip": [
+    {
+     "line": 146,
+     "source": "print(f\">> {tag}: cells already banked \u2014 skip\", flush=True)"
+    }
+   ]
+  },
+  "run_b34v3.py": {},
+  "run_thought_transfer.py": {
+   "skip": [
+    {
+     "line": 76,
+     "source": "pad_token_id=tok.eos_token_id)[0, plen:], skip_special_tokens=True)"
+    },
+    {
+     "line": 79,
+     "source": "pad_token_id=tok.eos_token_id)[0, plen:], skip_special_tokens=True)"
+    }
+   ]
+  }
+ },
+ "splits": {
+  "split_concepts_seed0": {
+   "citation": "run_g0clear.py:99-108",
+   "train": 323,
+   "sel_dirs": 69,
+   "fin_dirs": 70
+  },
+  "b31v2_anchors": {
+   "citation": "run_b31v2.py:104-105",
+   "anchors": 392,
+   "held_out": 70,
+   "note": "train+sel concatenated by the CONSUMER, not the splitter"
+  },
+  "b34v3_seed343": {
+   "citation": "run_b34v3.py:32,64-72",
+   "train": 392,
+   "held_out": 70,
+   "note": "b34v3 does NOT use split_concepts(seed=0). Same battery, own permutation, different membership."
+  },
+  "held_out_overlap_seed343_vs_seed0": {
+   "n": 13,
+   "words": [
+    "bone",
+    "church",
+    "cloud",
+    "dream",
+    "forest",
+    "melon",
+    "pear",
+    "planet",
+    "singer",
+    "skirt",
+    "watch",
+    "yacht",
+    "yogurt"
+   ],
+   "genuinely_fresh": 57,
+   "preregistered_as": "disjoint",
+   "falsified_by": "b34v3_fresh_split_addendum.json"
+  },
+  "scripts_referencing_split_concepts": [
+   "run_b31v2.py",
+   "run_b34.py",
+   "run_b34v2.py",
+   "run_b34v3.py",
+   "run_b36.py",
+   "run_g0_stage1.py",
+   "run_g0_stage1b.py",
+   "run_g0_stage3_truthaxis.py",
+   "run_g0clear.py",
+   "run_read_verify.py",
+   "run_rung2_read.py",
+   "run_rung3_steerlayer.py"
+  ],
+  "scripts_importing_from_run_g0clear": [
+   "diag_b35c_collapse.py",
+   "run_b31v2.py",
+   "run_b34.py",
+   "run_b34v2.py",
+   "run_b34v3.py",
+   "run_b35a.py",
+   "run_b35b.py",
+   "run_b35c.py",
+   "run_b35c_nullreplicate.py",
+   "run_b36.py",
+   "run_b37.py",
+   "run_b38.py",
+   "run_b39.py",
+   "run_b40.py",
+   "run_b41.py",
+   "run_b42.py",
+   "run_b43.py",
+   "run_b44.py",
+   "run_b45.py",
+   "run_b46.py",
+   "run_g0_stage1.py",
+   "run_g0_stage1b.py",
+   "run_g0_stage3_truthaxis.py",
+   "run_read_verify.py",
+   "run_rung2_read.py",
+   "run_rung3_steerlayer.py"
+  ],
+  "held_out_ness_note": "the seed-0 FIN-70 is never in a fit within any single run, but it has been SCORED by every script listed above. Its held-out-ness has been spent by repetition, which no single receipt records."
+ },
+ "published_read_figures_are_A_terms": {
+  "why": "read_top1 is an index-matched argmin over the held-out target centroids (run_b31v2.py:90-93, run_b34v3.py:46-49). The truth is in the candidate array with probability 1; there is no threshold and no reject option. E = 1 by construction on every trial these scripts have ever run.",
+  "b31v2_gemma_M1_mlp_top1": 0.7857,
+  "b31v2_gemma_requires": "392 TRUE cross-model concept pairs (supervised)",
+  "b34v3_gemma_read_top1_full70": 0.5714,
+  "b34v3_gemma_read_top1_fresh57": 0.5263,
+  "b34v3_llama_read_top1_full70": 0.6857,
+  "b34v3_llama_read_top1_fresh57": 0.6667,
+  "quote_both_or_neither": "the fresh-57 recompute is the honest figure for b34v3; the full-70 headline includes 13 concepts scored before"
+ },
+ "closed_set_penalty_SEPARATE_TERM_not_E": {
+  "receipt": "b35c_result.json",
+  "verdict_in_receipt": "INVALID__null_artifact",
+  "status": "UNLICENSED \u2014 b35c returned INVALID__null_artifact on a null-model error (G2_null false). These retention figures are reported as observations and decide nothing.",
+  "vocab_size": 462,
+  "gemma_read70": 0.5714,
+  "gemma_read462": 0.2,
+  "llama_read70": 0.6857,
+  "llama_read462": 0.3143,
+  "gemma_retention_70_to_462": 0.35,
+  "llama_retention_70_to_462": 0.4584,
+  "retention_is_derived_from_two_receipts": [
+   "b34v3_result.json .targets.*.read_top1",
+   "b35c_result.json .targets.*.read462"
+  ],
+  "note": "widening an ALREADY-CLOSED candidate set 70 -> 462 cost most of the read. 462 is still the same hand-typed list, so this bounds nothing about an open vocabulary."
+ },
+ "dedup_survival_ratio_NOT_A_SELECTION_RATIO": {
+  "warning": "NOT A SELECTION RATIO and NOT AN E-TERM. This is the share of the hand-typed literal that survived order-preserving deduplication. It measures that the author typed three words twice while balancing category blocks. The literal is the OUTPUT of the selection, not its input; quoting this as E would be exactly the error the P = E x A decomposition exists to name.",
+  "value": 0.993548,
+  "numerator": 462,
+  "denominator": 465,
+  "what_it_measures": "deduplication of a hand-typed literal, nothing else"
+ },
+ "E_term_for_the_read_UNCHECKABLE": {
+  "status": "UNCHECKABLE \u2014 the pre-filter candidate pool was never recorded as an artifact, so no survival ratio exists to compute. This is a verdict, not a failure, and it is not a claim that the ratio is low. Absence of evidence is never a contradiction.",
+  "question_it_would_answer": "was the activation the reader was handed in fact a single-concept-dominated state, isolable at the committed extraction site \u2014 last token, layer 11 locked by the g0clear sweep, mean-pooled over the 12 CONCEPT_TEMPLATES, differenced against the fixed 'object' baseline \u2014 at the moment it was read?",
+  "why_it_cannot_be_measured_from_committed_artifacts": [
+   "the candidate pool was never written down; the selection happened at authoring time and left no rejection log",
+   "no generator script and no source corpus is cited anywhere in the repository",
+   "the apparatus has never once been pointed at a state it did not itself manufacture from 12 experimenter-written sentences, so no committed run can answer the question even in principle"
+  ],
+  "what_would_have_to_be_re_run": [
+   "commit a candidate pool as a mechanically-derived artifact with a stated rule and a hashed file, not a docstring summary",
+   "express each intended filter as a committed function and record the survivor count after each stage in the result JSON",
+   "sample the battery from the survivors under a committed seed",
+   "re-extract on GPU across all four models \u2014 the _b31v2_pts_*.npz caches are keyed positionally to the current 462-word list (run_b34v3.py:37-38) and cannot be reused for a different battery",
+   "re-run the b31v2 M0/M1/N1 cells and the b34v3 label-free read"
+  ],
+  "what_that_would_still_not_buy": "a perfectly recorded word-list ratio is an E-term for single-word English noun concepts, not for the states a model can hold. That second gap survives the repair and no construction over a word list closes it."
+ },
+ "reconciliation": {
+  "n_concepts_receipt": 462,
+  "n_concepts_recomputed": 462,
+  "n_concepts_reconciles": true,
+  "b31v2_n_heldout_receipt": 70,
+  "b31v2_n_heldout_recomputed": 70,
+  "b31v2_heldout_reconciles": true,
+  "b34v3_n_tr_receipt": 392,
+  "b34v3_n_tr_recomputed": 392,
+  "b34v3_n_heldout_receipt": 70,
+  "b34v3_n_heldout_recomputed": 70,
+  "b34v3_split_reconciles": true,
+  "b34v3_addendum_overlap_receipt": 13,
+  "b34v3_overlap_recomputed": 13,
+  "b34v3_overlap_reconciles": true,
+  "b34v3_genuinely_fresh_receipt": 57,
+  "b34v3_genuinely_fresh_recomputed": 57,
+  "b35c_vocab_size_receipt": 462,
+  "b35c_vocab_is_the_same_battery": true,
+  "all_reconcile": true
+ }
+}

--- a/papers/disjoint-worlds/read_extraction_census.py
+++ b/papers/disjoint-worlds/read_extraction_census.py
@@ -1,0 +1,611 @@
+# -*- coding: utf-8 -*-
+"""EXTRACTION census for the cross-model READ battery: where did the 462 concepts
+come from, and what was the pool they survived out of?
+
+WHY THIS FILE EXISTS
+--------------------
+A peer session proposed a decomposition that this lab has adopted:
+
+    P = E x A
+
+  P  precision as published
+  E  EXTRACTION — the share of cases where the thing the instrument was pointed at
+     was actually the thing it claims to adjudicate
+  A  ADJUDICATION — given the pointing was right, the share where the verdict was
+     right
+
+Every number this lab publishes is P and has been read as if it were A. For the
+diffgate path-claim class, P was measured at 0.16 held-out (`RESULT_v14`) and
+`extraction_census.py` opened the E-term. For the calibrated instruments
+(HaluEval-QA 0.998, TruthfulQA 0.994) the benchmark HANDS the span to the
+instrument, so E = 1 by construction and those numbers are pure A-terms.
+
+The cross-model read has the second shape. `read_top1` is an index-matched argmin
+over the held-out target centroids (`run_b31v2.py:90-93`, `run_b34v3.py:46-49`):
+the truth is in the candidate array with probability 1, there is no threshold and
+no reject option. So the published read figures are A-terms, and the question this
+file was written to answer is what E is for them.
+
+The proposed answer was: E is a SELECTION RATIO — the share of candidate concepts
+that survived into the committed battery — computable from committed artifacts with
+no new experiment. THIS FILE REPORTS THAT IT IS NOT COMPUTABLE, and reports the
+whole construction chain so a reader can see why.
+
+WHAT THIS FILE IS
+-----------------
+A CENSUS, in the tradition of `papers/closed-model-frontier/extraction_census.py`
+and `RESULT_collateral_census_2026_08_31.md`: descriptive, report-only, no
+hypothesis test, no gate, no verdict token. NO PREREGISTRATION COVERS IT, so
+nothing it emits may carry a headline finding.
+
+It loads no model, runs no experiment, and reads no GPU artifact. It parses
+committed Python source with `ast`, replays two splits with numpy, and reconciles
+its counts against receipts it does not write.
+
+It writes exactly one file: `read_extraction_census.json`. It never edits a receipt.
+
+    python papers/disjoint-worlds/read_extraction_census.py
+"""
+from __future__ import annotations
+
+import ast
+import hashlib
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import numpy as np
+
+HERE = Path(__file__).resolve().parent
+ROOT = HERE.parent.parent
+
+OUT = HERE / "read_extraction_census.json"
+OUT_MARKER = "EXTRACTION census of the cross-model read battery"
+
+G0CLEAR = HERE / "run_g0clear.py"
+PARENT = HERE / "run_thought_transfer.py"
+B31V2 = HERE / "run_b31v2.py"
+B34V3 = HERE / "run_b34v3.py"
+
+# Receipts READ for reconciliation. None of these is written by this file.
+R_G0CLEAR = HERE / "g0clear_result_llama3b.json"
+R_B31V2 = HERE / "b31v2_result.json"
+R_B34V3 = HERE / "b34v3_result.json"
+R_B34V3_ADD = HERE / "b34v3_fresh_split_addendum.json"
+R_B35C = HERE / "b35c_result.json"
+
+# The marker lives in the KEY NAMES, not in a sibling status field. The lesson is
+# `extraction_census.py`'s: a consumer who indexes a bare key never touches the
+# sibling that says the number decides nothing. A reader cannot reach these
+# integers without typing the warning.
+UNCHECKABLE = (
+    "UNCHECKABLE — the pre-filter candidate pool was never recorded as an "
+    "artifact, so no survival ratio exists to compute. This is a verdict, not a "
+    "failure, and it is not a claim that the ratio is low. Absence of evidence is "
+    "never a contradiction.")
+DEDUP_WARNING = (
+    "NOT A SELECTION RATIO and NOT AN E-TERM. This is the share of the "
+    "hand-typed literal that survived order-preserving deduplication. It measures "
+    "that the author typed three words twice while balancing category blocks. The "
+    "literal is the OUTPUT of the selection, not its input; quoting this as E "
+    "would be exactly the error the P = E x A decomposition exists to name.")
+
+
+# --------------------------------------------------------------------------
+# MECHANICAL — pure functions of committed bytes. Every rule is stated in RULES.
+# --------------------------------------------------------------------------
+
+def sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def literal_split_words(path: Path, name: str):
+    """The words of a module-level `NAME = <str literal>.split()` assignment.
+
+    Parsed with `ast` from the committed source rather than by importing the
+    module, because both modules import torch/transformers at module scope. The
+    string is recovered by `ast.literal_eval` of the receiver of `.split()`, so
+    implicit concatenation of adjacent literals is handled the way Python handles
+    it, and no regex approximates the parse.
+    """
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(isinstance(t, ast.Name) and t.id == name for t in node.targets):
+            continue
+        v = node.value
+        if (isinstance(v, ast.Call) and isinstance(v.func, ast.Attribute)
+                and v.func.attr == "split" and not v.args):
+            return (ast.literal_eval(v.func.value).split(),
+                    node.lineno, node.value.end_lineno)
+    raise LookupError(f"{name} not found as a `.split()` literal in {path.name}")
+
+
+def dedup_order_preserving(words):
+    """The comprehension at run_g0clear.py:66-67, reproduced exactly."""
+    seen = set()
+    return [c for c in words if not (c in seen or seen.add(c))]
+
+
+def duplicates_with_positions(words):
+    first, dups = {}, []
+    for i, w in enumerate(words):
+        if w in first:
+            dups.append({"word": w, "first_index": first[w], "repeat_index": i})
+        else:
+            first[w] = i
+    return dups
+
+
+def split_concepts_replay(concepts, seed=0):
+    """run_g0clear.py:99-108, reproduced. numpy only; no model, no GPU."""
+    rng = np.random.default_rng(seed)
+    idx = rng.permutation(len(concepts))
+    n = len(concepts)
+    n_tr, n_sel = int(0.70 * n), int(0.15 * n)
+    return ([concepts[i] for i in idx[:n_tr]],
+            [concepts[i] for i in idx[n_tr:n_tr + n_sel]],
+            [concepts[i] for i in idx[n_tr + n_sel:]])
+
+
+def b34v3_split_replay(concepts, seed=343, n_fin=70):
+    """run_b34v3.py:64-72, reproduced. NOT split_concepts — its own permutation."""
+    rng = np.random.default_rng(seed)
+    idx = rng.permutation(len(concepts))
+    n_tr = len(concepts) - n_fin
+    return ([concepts[i] for i in idx[n_fin:n_fin + n_tr]],
+            [concepts[i] for i in idx[:n_fin]])
+
+
+def loop_skip_branches(path: Path, func_name: str):
+    """Count `continue`/`break` statements inside a named function.
+
+    A per-concept filter in these extractors could only be expressed as a skip
+    inside the concept loop. Zero skips is therefore mechanical evidence that no
+    concept is ever dropped, stronger than a keyword grep.
+    """
+    src = path.read_text(encoding="utf-8")
+    lines = src.splitlines()
+    tree = ast.parse(src)
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == func_name:
+            ifs = [n for n in ast.walk(node) if isinstance(n, ast.If)]
+            return {
+                "found": True,
+                "continue_statements": sum(1 for n in ast.walk(node) if isinstance(n, ast.Continue)),
+                "break_statements": sum(1 for n in ast.walk(node) if isinstance(n, ast.Break)),
+                "if_statements": len(ifs),
+                # every branch quoted, so a reader can check that none of them is a
+                # per-concept filter without opening the file
+                "if_statement_lines": [
+                    {"line": n.lineno, "source": lines[n.lineno - 1].strip()} for n in ifs],
+            }
+    return {"found": False}
+
+
+FILTER_TOKENS = ("vocab", "tokeniz", "frequency", "freq_", "filter", "exclude",
+                 "drop", "reject", "discard", "skip", "min_len", "stopword")
+
+
+def token_scan(path: Path):
+    """Which filter-shaped identifiers appear anywhere in the file's bytes.
+
+    Reported as a DIAGNOSTIC, not as a category: a hit is not a filter and a miss
+    is not proof of absence. The load-bearing evidence is loop_skip_branches.
+    """
+    lines = path.read_text(encoding="utf-8").splitlines()
+    out = {}
+    for i, raw in enumerate(lines, 1):
+        low = raw.lower()
+        for t in FILTER_TOKENS:
+            if t in low:
+                out.setdefault(t, []).append({"line": i, "source": raw.strip()[:120]})
+    return out
+
+
+def files_referencing(pattern):
+    """Committed .py files in this directory whose source contains `pattern`.
+
+    This census file excludes itself: it references both patterns only in order to
+    reproduce them, and counting itself would inflate the reuse figure.
+    """
+    hits = []
+    for p in sorted(HERE.glob("*.py")):
+        if p.name == Path(__file__).name:
+            continue
+        try:
+            t = p.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            continue
+        if pattern in t:
+            hits.append(p.name)
+    return hits
+
+
+def git_provenance(path: Path):
+    try:
+        r = subprocess.run(
+            ["git", "log", "--follow", "--format=%H|%ad|%s", "--date=iso", "--", str(path)],
+            cwd=str(ROOT), capture_output=True, text=True, timeout=30)
+        if r.returncode != 0:
+            return {"status": "UNCHECKABLE_git_returned_nonzero", "stderr": r.stderr.strip()[:300]}
+        lines = [l for l in r.stdout.splitlines() if l.strip()]
+        commits = []
+        for l in lines:
+            h, d, s = l.split("|", 2)
+            commits.append({"commit": h, "date": d, "subject": s})
+        return {"status": "read", "n_commits": len(commits), "commits": commits}
+    except Exception as e:                                    # noqa: BLE001
+        return {"status": f"UNCHECKABLE_{type(e).__name__}", "detail": str(e)[:300]}
+
+
+RULES = {
+    "raw_tokens":
+        "the module-level `_BANK = \"\"\"...\"\"\".split()` literal in "
+        "run_g0clear.py, recovered by ast.literal_eval of the receiver of "
+        ".split(), then split on whitespace exactly as Python's str.split does",
+    "deduplicated":
+        "the order-preserving comprehension at run_g0clear.py:66-67, reproduced "
+        "character-for-character in dedup_order_preserving",
+    "split_seed0":
+        "run_g0clear.py:99-108 replayed with numpy default_rng(0): "
+        "n_tr = int(0.70*N), n_sel = int(0.15*N), fin = the remainder",
+    "split_seed343":
+        "run_b34v3.py:64-72 replayed with numpy default_rng(343): fin = first 70 "
+        "of the permutation, tr = the next N-70. This is NOT split_concepts",
+    "anchors_392":
+        "run_b31v2.py:104-105 concatenates TRAIN and SEL_dirs after calling "
+        "split_concepts(seed=0); the concatenation is the consumer's, not the "
+        "splitter's",
+    "loop_skip_branches":
+        "ast walk of the named extraction function counting `continue` and "
+        "`break`. A per-concept filter in these extractors could only be a skip "
+        "inside the concept loop, so zero skips is evidence that no concept is "
+        "ever dropped by measurement",
+    "candidate_pool":
+        "NO RULE EXISTS. There is no committed corpus, vocabulary slice, dataset "
+        "or generator script from which the battery was drawn, so there is no "
+        "denominator to compute against",
+}
+
+
+def main() -> int:
+    # Refuse to clobber anything that is not this file's own previous emission.
+    if OUT.exists():
+        try:
+            prev = json.loads(OUT.read_text(encoding="utf-8"))
+        except Exception:                                     # noqa: BLE001
+            print(f"REFUSING to overwrite unparseable {OUT.name}", file=sys.stderr)
+            return 2
+        if not str(prev.get("what", "")).startswith(OUT_MARKER):
+            print(f"REFUSING to overwrite {OUT.name}: not this census's output",
+                  file=sys.stderr)
+            return 2
+
+    # ---- the literal ----
+    raw, bank_start, bank_end = literal_split_words(G0CLEAR, "_BANK")
+    concepts = dedup_order_preserving(raw)
+    dups = duplicates_with_positions(raw)
+
+    # ---- the parent bank ----
+    parent_raw, p_start, p_end = literal_split_words(PARENT, "CONCEPTS")
+    parent = dedup_order_preserving(parent_raw)
+    parent_in_bank = [w for w in parent if w in set(concepts)]
+    parent_missing = [w for w in parent if w not in set(concepts)]
+    net_new = [w for w in concepts if w not in set(parent)]
+
+    # ---- the splits ----
+    tr0, sel0, fin0 = split_concepts_replay(concepts, seed=0)
+    tr343, fin343 = b34v3_split_replay(concepts, seed=343, n_fin=70)
+    overlap = sorted(set(fin343) & set(fin0))
+    anchors_392 = list(tr0) + list(sel0)
+
+    # ---- receipts, read only ----
+    r_g0 = json.loads(R_G0CLEAR.read_text(encoding="utf-8"))
+    r31 = json.loads(R_B31V2.read_text(encoding="utf-8"))
+    r34 = json.loads(R_B34V3.read_text(encoding="utf-8"))
+    r34a = json.loads(R_B34V3_ADD.read_text(encoding="utf-8"))
+    r35c = json.loads(R_B35C.read_text(encoding="utf-8"))
+
+    recon = {
+        "n_concepts_receipt": r_g0["n_concepts"],
+        "n_concepts_recomputed": len(concepts),
+        "n_concepts_reconciles": r_g0["n_concepts"] == len(concepts),
+        "b31v2_n_heldout_receipt": r31["n_heldout"],
+        "b31v2_n_heldout_recomputed": len(fin0),
+        "b31v2_heldout_reconciles": r31["n_heldout"] == len(fin0),
+        "b34v3_n_tr_receipt": r34["n_tr"],
+        "b34v3_n_tr_recomputed": len(tr343),
+        "b34v3_n_heldout_receipt": r34["n_heldout"],
+        "b34v3_n_heldout_recomputed": len(fin343),
+        "b34v3_split_reconciles": (r34["n_tr"] == len(tr343)
+                                   and r34["n_heldout"] == len(fin343)),
+        "b34v3_addendum_overlap_receipt": r34a["held_out_overlap_with_v1v2"],
+        "b34v3_overlap_recomputed": len(overlap),
+        "b34v3_overlap_reconciles": r34a["held_out_overlap_with_v1v2"] == len(overlap),
+        "b34v3_genuinely_fresh_receipt": r34a["genuinely_fresh"],
+        "b34v3_genuinely_fresh_recomputed": len(fin343) - len(overlap),
+        "b35c_vocab_size_receipt": r35c["vocab_size"],
+        "b35c_vocab_is_the_same_battery": r35c["vocab_size"] == len(concepts),
+    }
+    recon["all_reconcile"] = all(
+        recon[k] for k in recon if k.endswith(("_reconciles", "_battery")))
+
+    # ---- the filter chain ----
+    chain = [
+        {"stage": "hand-typed literal `_BANK`",
+         "citation": f"run_g0clear.py:{bank_start}-{bank_end}",
+         "in": None, "removed": 0, "out": len(raw),
+         "note": "the list was born whole; there is no upstream artifact"},
+        {"stage": "order-preserving deduplication",
+         "citation": "run_g0clear.py:66-67",
+         "in": len(raw), "removed": len(raw) - len(concepts), "out": len(concepts),
+         "note": "the ONLY filter in the entire chain",
+         "removed_words": [d["word"] for d in dups]},
+    ]
+    absent = [
+        ("tokenization / single-token constraint",
+         "run_g0clear.py extract_multi; run_thought_transfer.py extract"),
+        ("presence-in-both-models / shared-vocabulary check",
+         "no target tokenizer is consulted anywhere; concepts are embedded through "
+         "the 12 CONCEPT_TEMPLATES at introspection_gate.py:26-38"),
+        ("frequency threshold", "no frequency table is imported anywhere in the chain"),
+        ("part-of-speech filter", "no POS tagger is imported anywhere in the chain"),
+        ("representation-quality gate / norm or outlier screen",
+         "no per-concept statistic is ever compared against a threshold"),
+        ("downstream re-filtering by the read experiments",
+         "run_b31v2.py:34,103 and run_b34v3.py:26,70 both import the list wholesale"),
+    ]
+    for name, cite in absent:
+        chain.append({"stage": name, "citation": cite, "in": len(concepts),
+                      "removed": 0, "out": len(concepts),
+                      "note": "NO SUCH FILTER EXISTS"})
+
+    skips = {
+        "run_g0clear.extract_multi": loop_skip_branches(G0CLEAR, "extract_multi"),
+        "run_thought_transfer.extract": loop_skip_branches(PARENT, "extract"),
+    }
+
+    # ---- reuse of the same held-out set ----
+    reuse = files_referencing("split_concepts")
+    bank_consumers = files_referencing("from run_g0clear import")
+
+    # ---- line structure of the literal, with the honest caveat ----
+    src_lines = G0CLEAR.read_text(encoding="utf-8").splitlines()
+    lit_lines = []
+    for ln in range(bank_start, bank_end + 1):
+        body = src_lines[ln - 1]
+        if '"""' in body:          # the opening and closing delimiter lines
+            continue
+        words = body.split()
+        if words:
+            lit_lines.append({"line": ln, "tokens": len(words),
+                              "first": words[0], "last": words[-1]})
+
+    payload = {
+        "what": (OUT_MARKER + ": the construction chain of the N=462 concept "
+                 "battery that b31v2, b34v3 and b35c are scored over"),
+        "kind": ("CENSUS — descriptive, report-only. No hypothesis test, no gate, "
+                 "no verdict token, NO PREREGISTRATION. Nothing here may carry a "
+                 "headline finding."),
+        "companion_paper": "CENSUS_read_extraction_2026_09_01.md",
+        "loads_no_model": True,
+        "writes": [OUT.name],
+        "edits_no_receipt": True,
+        "rules": RULES,
+
+        "provenance": {
+            "run_g0clear_py_sha256": sha256(G0CLEAR),
+            "git": git_provenance(G0CLEAR),
+            "recorded_pool_size": None,
+            "recorded_pool_size_status": UNCHECKABLE,
+            "design_targets_not_measurements": {
+                "run_g0clear.py:29 docstring": "~480 single-word concepts",
+                "PREREG_thought_transfer_g0clear_2026_06_20.md:25,43": "N~480",
+                "note": ("both were written before the list existed; they are "
+                         "design targets, not counts of anything"),
+            },
+        },
+
+        "battery": {
+            "raw_tokens_in_literal": len(raw),
+            "raw_tokens_recorded_in_any_receipt": False,
+            "deduplicated": len(concepts),
+            "deduplicated_recorded_in": "g0clear_result_llama3b.json .n_concepts",
+            "duplicates": dups,
+            "distinct_after_dedup_equals_len_set": len(concepts) == len(set(raw)),
+            "line_structure": {
+                "note": ("token counts per source line of the literal. THE BYTES "
+                         "CARRY NO CATEGORY LABELS: there are no comments, no "
+                         "blank lines and no markers between the apparent "
+                         "category blocks, so any category attribution is a "
+                         "reader's inference and is NOT mechanically derivable "
+                         "from this file. Reported as structure, not as taxonomy."),
+                "lines": lit_lines,
+            },
+        },
+
+        "parent_bank": {
+            "citation": f"run_thought_transfer.py:{p_start}-{p_end}",
+            "raw_tokens": len(parent_raw),
+            "deduplicated": len(parent),
+            "recorded_as": {
+                "run_g0clear.py:5 docstring": 110,
+                "g0clear_result_llama3b.json .parent_baseline.N": r_g0["parent_baseline"]["N"],
+            },
+            "recorded_figure_matches_committed_literal":
+                r_g0["parent_baseline"]["N"] == len(parent),
+            "drift_unrecorded": len(parent) - r_g0["parent_baseline"]["N"],
+            "parent_words_present_in_battery": len(parent_in_bank),
+            "parent_words_absent_from_battery": parent_missing,
+            "net_new_words_in_battery": len(net_new),
+            "how_the_net_new_were_chosen": UNCHECKABLE,
+        },
+
+        "chain": chain,
+        "loop_skip_branches": skips,
+        "filter_token_scan_DIAGNOSTIC_not_a_category": {
+            "note": ("a hit is not a filter and a miss is not proof of absence; "
+                     "the load-bearing evidence is loop_skip_branches"),
+            "run_g0clear.py": token_scan(G0CLEAR),
+            "run_b31v2.py": token_scan(B31V2),
+            "run_b34v3.py": token_scan(B34V3),
+            "run_thought_transfer.py": token_scan(PARENT),
+        },
+
+        "splits": {
+            "split_concepts_seed0": {
+                "citation": "run_g0clear.py:99-108",
+                "train": len(tr0), "sel_dirs": len(sel0), "fin_dirs": len(fin0),
+            },
+            "b31v2_anchors": {
+                "citation": "run_b31v2.py:104-105",
+                "anchors": len(anchors_392), "held_out": len(fin0),
+                "note": "train+sel concatenated by the CONSUMER, not the splitter",
+            },
+            "b34v3_seed343": {
+                "citation": "run_b34v3.py:32,64-72",
+                "train": len(tr343), "held_out": len(fin343),
+                "note": ("b34v3 does NOT use split_concepts(seed=0). Same battery, "
+                         "own permutation, different membership."),
+            },
+            "held_out_overlap_seed343_vs_seed0": {
+                "n": len(overlap),
+                "words": overlap,
+                "genuinely_fresh": len(fin343) - len(overlap),
+                "preregistered_as": "disjoint",
+                "falsified_by": "b34v3_fresh_split_addendum.json",
+            },
+            "scripts_referencing_split_concepts": reuse,
+            "scripts_importing_from_run_g0clear": bank_consumers,
+            "held_out_ness_note": (
+                "the seed-0 FIN-70 is never in a fit within any single run, but it "
+                "has been SCORED by every script listed above. Its held-out-ness "
+                "has been spent by repetition, which no single receipt records."),
+        },
+
+        # The A-terms this census exists to scope. Read only; not recomputed here.
+        "published_read_figures_are_A_terms": {
+            "why": ("read_top1 is an index-matched argmin over the held-out target "
+                    "centroids (run_b31v2.py:90-93, run_b34v3.py:46-49). The truth "
+                    "is in the candidate array with probability 1; there is no "
+                    "threshold and no reject option. E = 1 by construction on every "
+                    "trial these scripts have ever run."),
+            "b31v2_gemma_M1_mlp_top1": r31["targets"]["gemma_2b"]["M1_mlp_top1"],
+            "b31v2_gemma_requires": "392 TRUE cross-model concept pairs (supervised)",
+            "b34v3_gemma_read_top1_full70": r34["targets"]["gemma_2b"]["read_top1"],
+            "b34v3_gemma_read_top1_fresh57": r34a["gemma_read_fresh_only"],
+            "b34v3_llama_read_top1_full70": r34["targets"]["llama_1b"]["read_top1"],
+            "b34v3_llama_read_top1_fresh57": r34a["llama_read_fresh_only"],
+            "quote_both_or_neither": (
+                "the fresh-57 recompute is the honest figure for b34v3; the full-70 "
+                "headline includes 13 concepts scored before"),
+        },
+
+        # The closed-set penalty, which is a separate term and is not E.
+        "closed_set_penalty_SEPARATE_TERM_not_E": {
+            "receipt": "b35c_result.json",
+            "verdict_in_receipt": r35c["verdict"],
+            "status": ("UNLICENSED — b35c returned INVALID__null_artifact on a "
+                       "null-model error (G2_null false). These retention figures "
+                       "are reported as observations and decide nothing."),
+            "vocab_size": r35c["vocab_size"],
+            "gemma_read70": r34["targets"]["gemma_2b"]["read_top1"],
+            "gemma_read462": r35c["targets"]["gemma_2b"]["read462"],
+            "llama_read70": r34["targets"]["llama_1b"]["read_top1"],
+            "llama_read462": r35c["targets"]["llama_1b"]["read462"],
+            "gemma_retention_70_to_462": round(
+                r35c["targets"]["gemma_2b"]["read462"]
+                / r34["targets"]["gemma_2b"]["read_top1"], 4),
+            "llama_retention_70_to_462": round(
+                r35c["targets"]["llama_1b"]["read462"]
+                / r34["targets"]["llama_1b"]["read_top1"], 4),
+            "retention_is_derived_from_two_receipts": [
+                "b34v3_result.json .targets.*.read_top1",
+                "b35c_result.json .targets.*.read462"],
+            "note": ("widening an ALREADY-CLOSED candidate set 70 -> 462 cost most "
+                     "of the read. 462 is still the same hand-typed list, so this "
+                     "bounds nothing about an open vocabulary."),
+        },
+
+        "dedup_survival_ratio_NOT_A_SELECTION_RATIO": {
+            "warning": DEDUP_WARNING,
+            "value": round(len(concepts) / len(raw), 6),
+            "numerator": len(concepts),
+            "denominator": len(raw),
+            "what_it_measures": "deduplication of a hand-typed literal, nothing else",
+        },
+
+        "E_term_for_the_read_UNCHECKABLE": {
+            "status": UNCHECKABLE,
+            "question_it_would_answer": (
+                "was the activation the reader was handed in fact a "
+                "single-concept-dominated state, isolable at the committed "
+                "extraction site — last token, layer 11 locked by the g0clear "
+                "sweep, mean-pooled over the 12 CONCEPT_TEMPLATES, differenced "
+                "against the fixed 'object' baseline — at the moment it was read?"),
+            "why_it_cannot_be_measured_from_committed_artifacts": [
+                "the candidate pool was never written down; the selection happened "
+                "at authoring time and left no rejection log",
+                "no generator script and no source corpus is cited anywhere in the "
+                "repository",
+                "the apparatus has never once been pointed at a state it did not "
+                "itself manufacture from 12 experimenter-written sentences, so no "
+                "committed run can answer the question even in principle",
+            ],
+            "what_would_have_to_be_re_run": [
+                "commit a candidate pool as a mechanically-derived artifact with a "
+                "stated rule and a hashed file, not a docstring summary",
+                "express each intended filter as a committed function and record "
+                "the survivor count after each stage in the result JSON",
+                "sample the battery from the survivors under a committed seed",
+                "re-extract on GPU across all four models — the _b31v2_pts_*.npz "
+                "caches are keyed positionally to the current 462-word list "
+                "(run_b34v3.py:37-38) and cannot be reused for a different battery",
+                "re-run the b31v2 M0/M1/N1 cells and the b34v3 label-free read",
+            ],
+            "what_that_would_still_not_buy": (
+                "a perfectly recorded word-list ratio is an E-term for single-word "
+                "English noun concepts, not for the states a model can hold. That "
+                "second gap survives the repair and no construction over a word "
+                "list closes it."),
+        },
+
+        "reconciliation": recon,
+    }
+
+    OUT.write_text(json.dumps(payload, indent=1) + "\n", encoding="utf-8")
+
+    # ---------------- table ----------------
+    print(f"\nREAD EXTRACTION CENSUS - {G0CLEAR.name} _BANK")
+    print(f"  sha256 {payload['provenance']['run_g0clear_py_sha256'][:16]}...")
+    g = payload["provenance"]["git"]
+    if g.get("status") == "read":
+        print(f"  git: {g['n_commits']} commit(s) --follow; the list was born whole")
+    print("\nCONSTRUCTION CHAIN")
+    for st in chain:
+        print(f"  {st['stage']:<52}{str(st['in'] or '-'):>6} -{st['removed']:<4}-> {st['out']:>4}"
+              f"   {st['citation']}")
+    print("\nSPLITS")
+    print(f"  split_concepts(seed=0)   TRAIN {len(tr0)} / SEL {len(sel0)} / FIN {len(fin0)}")
+    print(f"  b31v2 anchors            {len(anchors_392)} anchors, {len(fin0)} held-out")
+    print(f"  b34v3 seed 343           {len(tr343)} train, {len(fin343)} held-out")
+    print(f"  held-out overlap         {len(overlap)} of {len(fin343)}  "
+          f"(genuinely fresh {len(fin343) - len(overlap)})")
+    print("\nRECONCILIATION")
+    for k, v in recon.items():
+        if k.endswith(("_reconciles", "_battery", "all_reconcile")):
+            print(f"  {k:<40}{'OK' if v else 'MISMATCH - investigate'}")
+    print("\nDEDUP SURVIVAL RATIO (NOT a selection ratio, NOT an E-term)")
+    print(f"  {len(concepts)}/{len(raw)} = "
+          f"{payload['dedup_survival_ratio_NOT_A_SELECTION_RATIO']['value']}")
+    print("\nE-TERM FOR THE READ")
+    print("  UNCHECKABLE - no candidate pool was ever recorded. Not estimated here.")
+    print(f"\n-> {OUT.name}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/papers/disjoint-worlds/run_open_set_read.py
+++ b/papers/disjoint-worlds/run_open_set_read.py
@@ -1,0 +1,225 @@
+"""Open-set read — per PREREG_open_set_read_2026_09_01.md (frozen at 45d7ae5).
+
+`read_top1` in run_b31v2.py:90-93 and run_b34v3.py:46-49 is an index-matched argmin over a
+candidate array that CONTAINS the truth on every trial. There is no threshold and no reject
+option, so E = 1 by construction and every published read figure is an A-term: given the
+answer was in the list, was it picked?
+
+This asks the branch the apparatus cannot express: handed a state whose target is ABSENT from
+the candidate array, does the reader say so?
+
+Method. Replicate b34v3 exactly (seed 343, same rng consumption order, same TransferMap ->
+fit_mlp pipeline) to obtain the identical mapper, and reconcile its closed-set read_top1
+against the committed b34v3_result.json before anything else is allowed to run. Then split the
+70 HELD-OUT concepts into a candidate half C and an out-of-vocabulary half O under seed
+20260901. Show the reader C only. Queries from C are IN trials (target present); queries from O
+are OOV trials (target absent, correct behaviour is to abstain). Score AUROC of the top-1/top-2
+margin separating IN from OOV — threshold-free, so no operating point has to be chosen.
+
+CPU-only from the committed .npz banks. No model is loaded and nothing is collected.
+
+DISCLOSED DEVIATION FROM THE FROZEN PREREG. The prereg says "partition the 462 concept indices"
+into C and O. This runner partitions the 70 HELD-OUT concepts instead. That is STRICTER, not
+looser: every query here is a concept the mapper never trained on, whereas partitioning all 462
+would draw most queries from the 392 training concepts and confound familiarity with
+presence-in-candidate-set. The prereg did not fix |C| and |O|; they are set to 35/35 here so the
+two trial classes are balanced. Both facts are recorded in the emitted receipt.
+"""
+from __future__ import annotations
+
+import json
+import sys
+import time
+from pathlib import Path
+
+import numpy as np
+
+HERE = Path(__file__).resolve().parent
+ROOT = HERE.parent.parent
+sys.path.insert(0, str(HERE))
+sys.path.insert(0, str(ROOT))
+
+from run_g0clear import CONCEPTS as FULL_CONCEPTS      # noqa: E402
+from styxx_transfer import TransferMap                 # noqa: E402
+from run_b31v2 import fit_mlp                          # noqa: E402
+from run_b34v3 import (load_A, load_pts, read_top1,    # noqa: E402
+                       assignment_from_map, SEED, TARGETS)
+
+OPEN_SEED = 20260901
+N_CAND = 35          # |C| — the candidate half of the held-out 70
+COMMITTED = {"llama_1b": 0.6857, "gemma_2b": 0.5714, "qwen_1p5b": 0.1429}
+
+
+def auroc(pos, neg):
+    """P(a random positive scores above a random negative). Rank-based, ties at 0.5.
+
+    Implemented here rather than imported so the receipt does not depend on a
+    scikit-learn version. Mann-Whitney U over midranks.
+    """
+    pos, neg = np.asarray(pos, float), np.asarray(neg, float)
+    if len(pos) == 0 or len(neg) == 0:
+        return float("nan")
+    allv = np.concatenate([pos, neg])
+    order = allv.argsort(kind="mergesort")
+    ranks = np.empty(len(allv), float)
+    ranks[order] = np.arange(1, len(allv) + 1, dtype=float)
+    # midranks for ties
+    i = 0
+    s = allv[order]
+    while i < len(s):
+        j = i
+        while j + 1 < len(s) and s[j + 1] == s[i]:
+            j += 1
+        if j > i:
+            ranks[order[i:j + 1]] = (i + 1 + j + 1) / 2.0
+        i = j + 1
+    rpos = ranks[:len(pos)].sum()
+    return float((rpos - len(pos) * (len(pos) + 1) / 2.0) / (len(pos) * len(neg)))
+
+
+def margins(fin, ptsA, cand_ptsB, mapper):
+    """Top-1/top-2 margin per query against a candidate array, plus the argmin index.
+
+    The margin, not the raw d1: d1 scales with the query's norm and would measure the
+    query rather than the quality of the match. Both are returned; only the margin decides.
+    """
+    out_m, out_d1, out_arg = [], [], []
+    for c in fin:
+        d = np.linalg.norm(cand_ptsB - mapper(ptsA[c]), axis=1)
+        part = np.partition(d, 1)
+        out_m.append(float(part[1] - part[0]))
+        out_d1.append(float(part[0]))
+        out_arg.append(int(np.argmin(d)))
+    return np.array(out_m), np.array(out_d1), np.array(out_arg)
+
+
+def main():
+    t_all = time.time()
+    s0 = json.loads((HERE / "g0clear_result_llama3b.json").read_text(encoding="utf-8"))
+    kstar = s0["locked"]["k"]
+
+    # ---- replicate b34v3 EXACTLY: same seed, same rng consumption order ----
+    rng = np.random.default_rng(SEED)
+    idx = rng.permutation(len(FULL_CONCEPTS))
+    n_fin, n_tr = 70, len(FULL_CONCEPTS) - 70
+    fin_i, tr_i = idx[:n_fin], idx[n_fin:n_fin + n_tr]
+    tr = [FULL_CONCEPTS[i] for i in tr_i]
+    fin = [FULL_CONCEPTS[i] for i in fin_i]
+
+    ptsA = load_A()
+    XA = np.array([ptsA[c] for c in tr])
+
+    # ---- the open-set split, drawn from the HELD-OUT 70 only ----
+    rng_open = np.random.default_rng(OPEN_SEED)
+    p = rng_open.permutation(n_fin)
+    C_pos, O_pos = np.sort(p[:N_CAND]), np.sort(p[N_CAND:])
+    assert not (set(C_pos.tolist()) & set(O_pos.tolist()))
+
+    res = {
+        "prereg": "PREREG_open_set_read_2026_09_01.md",
+        "prereg_commit": "45d7ae5",
+        "what": ("does the reader decline when the target is ABSENT from the candidate array? "
+                 "read_top1 is an index-matched argmin over an array containing the truth, so "
+                 "E = 1 by construction and every published read figure is an A-term"),
+        "reject_statistic": "top-1/top-2 margin (d2 - d1) in the mapped space, fixed in the prereg",
+        "b34v3_seed": SEED, "open_seed": OPEN_SEED,
+        "n_heldout": n_fin, "n_candidates": int(N_CAND), "n_oov": int(len(O_pos)),
+        "deviation_from_prereg": (
+            "The prereg says 'partition the 462 concept indices'. This partitions the 70 HELD-OUT "
+            "concepts instead — STRICTER, because every query is then a concept the mapper never "
+            "trained on. Partitioning all 462 would draw most queries from the 392 training "
+            "concepts and confound familiarity with presence-in-candidate-set. The prereg did not "
+            "fix |C| and |O|; set to 35/35 here for balance. Disclosed, not silently taken."),
+        "targets": {},
+    }
+
+    for tag in TARGETS:
+        t0 = time.time()
+        ptsB = load_pts(tag)
+        XB = np.array([ptsB[c] for c in tr])
+        fin_ptsB = np.array([ptsB[c] for c in fin])
+
+        # identical rng draws to b34v3.main(), in the identical order
+        perm = rng.permutation(len(tr))
+        XB_shuf = XB[perm]
+        true_col = np.argsort(perm)
+
+        tm = TransferMap.fit(XA, XB_shuf, k=kstar)
+        disc_col = assignment_from_map(XA, XB_shuf, tm.transfer_point)
+        seed_acc = float((disc_col == true_col).mean())
+
+        mlp_fn, _ = fit_mlp(XA, XB_shuf[disc_col], seed=SEED)
+        read = read_top1(fin, ptsA, fin_ptsB, mlp_fn)
+
+        rand = rng.permutation(len(tr))
+        null_fn, _ = fit_mlp(XA, XB_shuf[rand], seed=SEED)
+
+        # ---- G-O1: closed-set reconciliation, before anything open-set is reported ----
+        recon_ok = abs(round(read, 4) - COMMITTED[tag]) < 1e-9
+
+        # ---- open-set: candidate array is C only; queries are all 70 held-out ----
+        cand = fin_ptsB[C_pos]
+        m_real, d1_real, arg_real = margins(fin, ptsA, cand, mlp_fn)
+        m_null, _, _ = margins(fin, ptsA, cand, null_fn)
+
+        is_in = np.zeros(n_fin, bool)
+        is_in[C_pos] = True
+        au_real = auroc(m_real[is_in], m_real[~is_in])
+        au_null = auroc(m_null[is_in], m_null[~is_in])
+
+        # accuracy on IN trials within the reduced candidate array (context, not a gate)
+        pos_of = {int(c): k for k, c in enumerate(C_pos)}
+        in_hits = sum(1 for q in C_pos if arg_real[q] == pos_of[int(q)])
+        res["targets"][tag] = {
+            "seed_acc": round(seed_acc, 4),
+            "closed_set_read_top1": round(read, 4),
+            "committed_read_top1": COMMITTED[tag],
+            "G_O1_reconciles": bool(recon_ok),
+            "auroc_margin_in_vs_oov": round(au_real, 4),
+            "auroc_margin_null_mapper": round(au_null, 4),
+            "in_trial_top1_within_C": round(in_hits / len(C_pos), 4),
+            "seconds": round(time.time() - t0, 1),
+        }
+        print(f">> {tag}: closed={read:.4f} (committed {COMMITTED[tag]}, "
+              f"reconciles={recon_ok})  AUROC={au_real:.4f}  null_AUROC={au_null:.4f}"
+              f"  [{time.time()-t0:.0f}s]", flush=True)
+
+    # ---------------- gates ----------------
+    T = res["targets"]
+    g1 = all(v["G_O1_reconciles"] for v in T.values())
+    g2 = all(v["auroc_margin_null_mapper"] <= 0.55 for v in T.values())
+
+    def verdict(a):
+        if a >= 0.75:
+            return "OPEN_SET_SIGNAL"
+        if a <= 0.55:
+            return "CLOSED_SET_ONLY"
+        return "INDETERMINATE"
+
+    per = {k: verdict(v["auroc_margin_in_vs_oov"]) for k, v in T.items()}
+    res["gates"] = {
+        "G_O1_closed_set_reconciliation": {"pass": bool(g1),
+                                           "note": "every target must re-derive its committed read_top1 exactly"},
+        "G_O2_null_mapper_auroc_le_0.55": {"pass": bool(g2),
+                                           "observed": {k: v["auroc_margin_null_mapper"] for k, v in T.items()}},
+        "G_O3_per_target_verdict": per,
+    }
+    if not g1:
+        res["verdict"] = "VOID__reconciliation_failed"
+    elif not g2:
+        res["verdict"] = "VOID__null_mapper_separates"
+    else:
+        vs = set(per.values())
+        res["verdict"] = ("OPEN_SET_SIGNAL" if vs == {"OPEN_SET_SIGNAL"}
+                          else "CLOSED_SET_ONLY" if vs == {"CLOSED_SET_ONLY"}
+                          else "MIXED__" + "_".join(f"{k}={v}" for k, v in sorted(per.items())))
+    res["seconds_total"] = round(time.time() - t_all, 1)
+
+    out = HERE / "open_set_read_result.json"
+    out.write_text(json.dumps(res, indent=2) + "\n", encoding="utf-8")
+    print(f"\nVERDICT: {res['verdict']}  -> {out.name}", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/papers/dogfood-self-audit/DOGFOOD_2026_09_01_the_instruments_on_todays_work.md
+++ b/papers/dogfood-self-audit/DOGFOOD_2026_09_01_the_instruments_on_todays_work.md
@@ -1,0 +1,144 @@
+# DOGFOOD — styxx's instruments pointed at styxx's own work, 2026-09-01
+
+Fathom Lab · 2026-09-01 · Every number below was produced today by running the shipped
+instruments on documents this lab wrote today, and every command is in the text so anyone can
+re-run it. Nothing here is a claim about a model. It is a claim about our own tooling.
+
+---
+
+## 1. The PR self-report gate has never checked anything
+
+`.github/workflows/audit-claims.yml:26` names a required check **`falsify PR self-report`**. It
+runs `styxx audit-claims pr_body.md --repo .`. Run over every substantive pull request this repo
+has merged:
+
+```
+PR    sentences  matched  coverage  claims  gate
+#32          38        0      0.00       0  PASS
+#33          29        0      0.00       0  PASS
+#34          26        0      0.00       0  PASS
+#35          32        0      0.00       0  PASS
+#36          15        0      0.00       0  PASS
+#37          28        0      0.00       0  PASS
+#41          37        0      0.00       0  PASS
+#42          19        0      0.00       0  PASS
+#45          16        0      0.00       0  PASS
+#46          15        0      0.00       0  PASS
+#47           7        0      0.00       0  PASS
+#48          41        0      0.00       0  PASS
+#50          28        0      0.00       0  PASS
+```
+
+**331 sentences. Zero claims extracted. Coverage 0.00 on every pull request. PASS on every one.**
+
+**The tool is not at fault and this must be said first.** Its own output is scrupulous: *"extracted
+0 checkable claim(s) from 28 sentence(s) (coverage 0.00); free-form prose not checked"* and
+*"no checkable claims found — nothing to falsify"*. An independently written regex over the same
+13 bodies finds **zero** claim-shaped sentences too, so 0.00 is the correct answer. This lab does
+not write path claims in pull request descriptions; it writes findings and numbers.
+
+**The defect is at the CI layer.** A required check called *falsify PR self-report* showing green
+reads, to anyone who has not opened the log, as *the self-report was checked and survived*. It
+means *there was nothing this instrument can check*. That is an absent measurement wearing a
+passing check — the same shape as `tests/test_ledger.py` skipping under a shallow checkout, found
+earlier today.
+
+**Cheapest honest repair:** have the step fail, or emit a neutral status, when
+`claims_extracted == 0`, so green means checked. Renaming it to `pr self-report: coverage` would
+also do.
+
+---
+
+## 2. An OATH verdict is a function of the receipt list the author chose
+
+`RESULT_extraction_ceiling_REFUTED_2026_09_01.md`, certified with `certify_doc` three times, same
+bytes, different receipt sets:
+
+| receipts supplied | VERIFIED | ABSTAIN | UNGROUNDED | verdict |
+|---|---|---|---|---|
+| 5 files, the ones the document cites | 26 | 28 | **3** | **OATH-FAILED** |
+| 8 files, adding the packet and key | 28 | 28 | **1** | **OATH-FAILED** |
+| the full pool of both arcs' JSON | 42 | 15 | **0** | **OATH-HELD** |
+
+**The same document fails and passes depending on how many receipts its author hands over, and
+the author chooses.** `OATH-HELD` is therefore a joint statement about a document *and a curated
+receipt list*, and only the first half is what a reader hears.
+
+### And the grounding that flipped it is coincidence-eligible
+
+The token that decided it was **55** — the central finding of the document, `E = 0.55`, written as
+*"the panel found 55 were made about a sentence that really was claiming…"*. It is genuinely in
+`extraction_panel_result.json` at `/decomposition/n_claim`.
+
+But counting every numeric leaf in the widened pool whose value equals 55:
+
+```
+leaves in the receipt pool whose value == 55: 257
+   extraction_panel_result.json  /decomposition/n_claim      <- the correct one
+   b23_fable_result.json         /rows[55]/i                 <- an array index
+   b24_headtohead_result.json    /rows[47]/i                 <- an array index
+   oath_corpus_attestation.json  /oath_failed_docs[0]/ungrounded[8]/line   <- a line number
+   ANALYSIS_base_rate_ceiling…certificate.json /ledger[58]/col             <- a column number
+   ... 252 more
+```
+
+**One correct leaf, 256 meaningless ones.** The verifier awards VERIFIED on a value-match without
+comparing the receipt *path* to the claim, so widening the pool raises the chance of grounding by
+accident far faster than the chance of grounding correctly. This is exactly the defect issue #39
+already names — *"604 false attestations … coincidental matches, which only status-level
+claim→field binding for floats will touch"* — now demonstrated on this lab's own headline number
+of the day at a 256:1 noise ratio.
+
+**What this does not show:** that the 55 in the document is wrong. It is right, and its receipt
+exists. What is shown is that the seal cannot distinguish that from luck.
+
+---
+
+## 3. The verifier accuses a DOI
+
+`PREREG_third_party_precision_2026_09_01.md` certifies **OATH-FAILED** with 11 ungrounded tokens.
+The first is:
+
+```
+token 3793302.3793583  @ line 66
+context: Agent-Authored Pull Requests*, MSR'26 Mining Challenge Track, DOI 10.1145/3793302.3793583
+```
+
+**That is a DOI being parsed as a decimal number and then accused of lacking a receipt.** A
+bibliographic identifier is not a measurement and cannot have one. Issue #39 already anticipated
+this class — it lists *"the arXiv DOI prefix 10.48550, which neither `_VERSIONISH` nor v0.5 class
+C reaches"* — and here it fires on a real citation in a real preregistration.
+
+**This is a false accusation by the lab's own definition**, and it is the class of defect that got
+the path-claim accuser retired. It should be counted the same way.
+
+---
+
+## 4. Today's own binding rate
+
+Over the seven documents written today, certified against the full pool:
+
+**VERIFIED 345 · ABSTAIN 89 · UNGROUNDED 11 · bound fraction E = 0.7753**
+
+Against the corpus-wide figure measured across all 241 committed certificates —
+**E = 0.7237** — today's documents bind slightly better than the historical average and in the
+same band. Read that as: *nothing improved today, and nothing regressed.* Roughly a fifth to a
+quarter of every number this lab writes is not bound by its own seal, and that has been stable.
+
+---
+
+## What this dogfood establishes
+
+1. A required CI check has passed 13 times without ever checking anything, and its name says
+   otherwise.
+2. An OATH verdict on fixed bytes is not a fixed verdict — it moves with the author's receipt
+   list, and moved from FAILED to HELD today.
+3. The grounding that produced HELD had 256 wrong candidates and one right one, and the verifier
+   cannot tell them apart.
+4. The verifier issues at least one false accusation against a DOI.
+5. The bound fraction of today's work, 0.7753, sits in the same band as the corpus, 0.7237.
+
+Every one of these is about our tooling and none is about anyone else's. They are published here
+rather than repaired quietly, and none of the repairs are made in this document — items 1 and 3
+change shipped behaviour and require their own preregistration and, for the accusing side, a
+blind panel.

--- a/styxx/diffgate.py
+++ b/styxx/diffgate.py
@@ -11,19 +11,130 @@ test, "only touches docs/" when it edited source, "adds function retry" when it 
 Construct ceiling, stated like every styxx instrument states it: the template set is
 CLOSED (touched/created/deleted paths · files-changed counts · added tests · added
 functions/classes · insertion/deletion counts · only-touches prefixes · tests-pass with
---run). Prose outside the templates is NOT judged — uncovered sentences are listed as
-uncovered, never scored. Verdicts per claim: VERIFIED / CONTRADICTED / UNCHECKABLE(named).
-The gate fails on any CONTRADICTED; UNCHECKABLE fails only under --strict.
+--evidence or --run). Prose outside the templates is NOT judged — uncovered sentences are
+listed as uncovered, never scored. Verdicts per claim: VERIFIED / CONTRADICTED /
+UNCHECKABLE(named). The gate fails on any CONTRADICTED; UNCHECKABLE fails only under
+--strict.
+
+THE ``tests_pass`` VOCABULARY IS TWO WORDS
+------------------------------------------
+
+::
+
+    _TESTS_PASS_VERDICTS = ("VERIFIED", "UNCHECKABLE")
+
+There is no accusing verdict for this claim kind. Not disabled, not behind a flag —
+**absent**. The branch that read a nonzero ``--run`` exit as CONTRADICTED has been
+deleted; ``selfcheck_tests_pass_never_accuses()`` re-derives its absence from this
+module's own source with ``ast``, and every surviving occurrence of the word inside the
+tests-pass leg is prose explaining why there is no such branch.
+
+Why deletion rather than a flag, in one line each:
+
+  * **Never measured.** The standing commitment out of
+    ``RESULT_v14_naming_the_defects_did_not_save_it_2026_09_01.md`` is DO NOT SHIP AN
+    ACCUSING VERDICT WHOSE PRECISION HAS NOT BEEN MEASURED BY A BLIND PANEL. This one has
+    been measured on neither leg — not the extraction, not the adjudication.
+  * **The extractor under it reads open prose with a closed regex.** The template at the
+    bottom of ``_TEMPLATES`` fires on ``- [ ] all tests pass`` (an unchecked PR-template
+    box, i.e. an author explicitly *declining* to assert), on ``all tests pass locally but
+    CI is red``, on ``once all tests pass I will mark this ready``, and inside blockquotes
+    and code fences. It reaches none of the negation, referential or containment guards —
+    those live in ``_REFERENTIAL`` / ``_CONTAINMENT`` and are applied only to
+    ``_PATH_KINDS``. A hard adjudicator behind a soft extractor inherits the extractor's
+    precision, not its own; that is the architecture RESULT_v14 measured at 0.16.
+  * **A nonzero exit is not a lie.** It is also what pytest rc=5 (no tests collected), a
+    misspelled command, a missing dependency and a flaky test produce.
+  * **A flag is what a maintainer who did not read the paper flips.**
+    ``WITHHOLD_PATH_ACCUSATION`` below is exactly such a flag. Absence of a branch cannot
+    be toggled by someone in a hurry; re-enabling must require writing the branch, in a
+    diff a reviewer can see.
+
+``VERIFIED`` survives, on the asymmetry ``styxx.evidence`` states for itself: a wrong
+VERIFIED repeats a claim the author already made in prose, a wrong CONTRADICTED attacks a
+stranger inside their own pull request. **It must never be printed as "the tests
+passed."** It reads: *the supplied evidence, or the supplied command, said so* — and
+because the extractor is unmeasured, a VERIFIED can attach to the sentence "Not all tests
+pass." That is a false RECORD, not an accusation. It is disclosed here and left in place
+rather than patched, because a fourth undisclosed repair cycle on this class is exactly
+what RESULT_v14 forbids.
+
+MONOTONICITY: TWO PROPERTIES, ONE HOLDS AND ONE DELIBERATELY DOES NOT
+---------------------------------------------------------------------
+
+These are different claims about ``--evidence`` and only one of them is a guarantee.
+Conflating them is how this file previously came to promise something it does not do.
+
+**Monotone against the empty baseline — HOLDS. This is the guarantee callers get.**
+Supplying evidence never leaves the gate worse off than supplying none. A
+``tests_pass`` claim is UNCHECKABLE with no report, so evidence can only move it to
+VERIFIED or leave it exactly where it was: no other claim kind reads ``evidence``,
+supplying it adds and removes no claims, and there is no route to CONTRADICTED —
+``styxx.evidence``'s vocabulary is two words, ``_evidence_leg`` clamps anything else
+to UNCHECKABLE, and ``selfcheck_tests_pass_never_accuses`` re-derives that from this
+file's own source. Handing the gate a report therefore cannot fail a build that would
+have passed with no report at all.
+
+**Monotone under set extension — DOES NOT HOLD, and that is DELIBERATE.**
+Going from evidence set E to E union {x} CAN demote VERIFIED to UNCHECKABLE. Measured
+directly, under ``--strict``, on one ``tests_pass`` claim:
+
+===========================  ==========  =====================
+evidence supplied            overall     ``tests_pass``
+===========================  ==========  =====================
+(none)                       FAIL        UNCHECKABLE
+``green.xml``                PASS        VERIFIED
+``green.xml`` ``empty.xml``  FAIL        UNCHECKABLE
+===========================  ==========  =====================
+
+Row three is not a regression and must not be "repaired" — not by letting a partial
+read affirm, and not by special-casing empty files. It is the contract's own rule,
+stated in ``styxx.evidence``: ANY unparsed source blocks VERIFIED, because a partial
+read may honestly DECLINE but may not honestly AFFIRM. You cannot certify "all tests
+pass" from nine shards out of ten. Adding a file adds a question, and a question the
+gate could not read is not an answer. Affirming from an incomplete set is the exact
+failure mode this whole module exists to refuse, so the demotion is the module
+working, not the module breaking.
+
+THE CASE THAT WILL BITE SOMEONE, in plain words: a sharded CI matrix where nine JUnit
+reports parse and the tenth is truncated — the runner died, the artifact upload raced
+the job, the shard timed out. The gate DECLINES. It does not affirm from the nine,
+and under ``--strict`` that is a red build. That is the intended behaviour.
+
+What an operator should do about it: **supply complete evidence, or supply none.**
+Those are the two honest positions and there is no third. Wire the job so a missing
+shard report fails collection outright, rather than passing whichever files happened
+to land in the directory; or, when a shard is known-lost and you would rather not
+block, pass no evidence at all and let the claim stand UNCHECKABLE on its own terms.
+Do not pass the partial set hoping the good files carry it — they will not, by
+design. The ``why`` on the declining claim names how many of how many sources could
+not be read and names one of them by path and reason, so the red build already says
+which shard to go and fix.
+
+``--run`` IS CODE EXECUTION
+---------------------------
+
+``--run CMD`` executes CMD **through a shell, with cwd set to --repo**. On an untrusted
+pull request that is remote code execution with extra steps: ``pytest`` imports the PR's
+``conftest.py`` at collection, ``pytest.ini``/``pyproject.toml`` ``addopts`` can load a
+plugin, ``npm test`` runs the string in the PR's ``package.json``, ``make test`` runs the
+PR's Makefile. ``os.environ`` is inherited unscrubbed. And the PR author controls the exit
+code in **both** directions, so the check is trivially green-lit by the adversary it
+exists to catch while remaining fully dangerous to the defender. Correct in first-party CI
+on a repository you own; never on a stranger's branch. Prefer ``--evidence``, which reads
+bytes and executes nothing.
 
 CLI::
 
     python -m styxx.diffgate SUMMARY.md --repo . --base main --head HEAD \
+        [--evidence junit.xml attestation.json --commit <40-hex>] \
         [--run "pytest -q"] [--strict] [--out GATE.json]
 """
 
 from __future__ import annotations
 
 import argparse
+import ast
 import json
 import re
 import subprocess
@@ -31,7 +142,8 @@ import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 
-__all__ = ["gate_diff", "DiffGate", "DiffClaim"]
+__all__ = ["gate_diff", "gate_diff_text", "DiffGate", "DiffClaim",
+           "selfcheck_tests_pass_never_accuses"]
 
 # A claimed path must end in a KNOWN file extension (closed set — the same honesty as the
 # template set itself). The naive any-dotted-token form false-accused decimals (0.5349),
@@ -179,6 +291,298 @@ def _names_without_claiming(sentence: str, m) -> bool:
     return any(k.lower() in window for k in _REFERENTIAL)
 
 
+# ══════════════════════════════════════════════════════════════════════════════
+# the tests_pass leg — two words, and the accusing branch is gone
+# ══════════════════════════════════════════════════════════════════════════════
+#
+# Anything that consumes this tuple gets the whole vocabulary. There is no hidden
+# member and no flag that adds one. See the module docstring for why the third
+# word was deleted rather than gated.
+_TESTS_PASS_VERDICTS = ("VERIFIED", "UNCHECKABLE")
+
+# The functions that decide a tests_pass verdict, named here so that
+# selfcheck_tests_pass_never_accuses() scans exactly them. The path-claim
+# branches inside _gate are a DIFFERENT class with a different (published,
+# withheld) history and are deliberately out of scope for that check.
+_TESTS_PASS_FUNCTIONS = ("_evidence_leg", "_run_leg", "_tests_pass_verdict")
+
+# PREREG_evidence_leg_2026_09_01 committed to replacing the old string, "no --run
+# command supplied; the gate does not take the agent's word for test results",
+# because it implied the remedy was to supply a shell string — the one thing this
+# gate should not push a reader toward against an untrusted branch, and the thing
+# capsule R4 refuses to seal. This note is APPENDED to the adjudicator's own
+# words rather than replacing them, and it names the reading channel instead.
+# Strictly more informative at an identical verdict.
+_NO_EVIDENCE_NOTE = (
+    "No test REPORT was handed to the gate. It does not take the agent's word "
+    "for test results, so with nothing to read it declines — absence of evidence "
+    "is not a contradiction. The channel that makes this readable is a report "
+    "passed with --evidence: a JUnit XML, or better a test-result attestation "
+    "whose subject names the head commit. Even then no signature is checked, and "
+    "the answer is VERIFIED or UNCHECKABLE — there is no accusing verdict for "
+    "this claim kind.")
+
+
+def _evidence_leg(paths, commit: str | None) -> tuple[str, str]:
+    """Read a `tests_pass` claim through styxx.evidence. VERIFIED or UNCHECKABLE.
+
+    THE IMPORT IS LOCAL AND EVERY FAILURE IS CONTAINED, the same way `_gate`
+    imports `styxx.claimdetect` and `styxx.undeclared` imports
+    `parse_unified_diff`: the dependency direction stays one-way (diffgate ->
+    evidence, never back), and a missing, unreadable or malformed evidence file
+    can never break the rest of the gate. A claim that could not be read is
+    UNCHECKABLE — not an exception, and never an accusation.
+
+    NO PARSING AND NO VERDICT TABLE IS REIMPLEMENTED HERE. This function calls
+    `load_evidence` and `adjudicate_tests_pass` and does nothing else with the
+    bytes. A second copy of a JUnit reader would drift from the first, and a
+    drifting second parser is what produced the correction this lab published on
+    2026-08-31.
+
+    NOTHING HERE READS ``ev["observed"]``. That is styxx.evidence's REPORT-ONLY
+    band, and its own note says a caller that turns ``failing_tests > 0`` into a
+    failing check "has reintroduced, without measurement, exactly the verdict
+    this module declines to ship". `selfcheck_no_accusation` states its boundary
+    as not being able to prove a caller has not done so. This is that caller, and
+    `selfcheck_tests_pass_never_accuses()` below is the counterpart it asked for.
+
+    THE TWO MONOTONICITY PROPERTIES, because this is the leg they are about:
+
+      * **Monotone against the empty baseline — HOLDS.** Evidence never leaves a
+        `tests_pass` claim worse than supplying none. That is the guarantee.
+      * **Monotone under set extension — DOES NOT HOLD, deliberately.** Adding a
+        source to an already-affirming set can demote VERIFIED to UNCHECKABLE,
+        because `adjudicate_tests_pass` blocks VERIFIED on ANY unparsed source. A
+        partial read DECLINES rather than AFFIRMS: nine parsed shards out of ten
+        cannot certify "all tests pass", and affirming from an incomplete set is
+        the failure mode this module exists to refuse. Do not "fix" this by
+        letting a partial read affirm, and do not special-case empty files.
+
+    So `--evidence green.xml` can be VERIFIED while `--evidence green.xml
+    empty.xml` is UNCHECKABLE. Operators: supply COMPLETE evidence or supply
+    NONE. The `why` returned here carries the adjudicator's own count of how many
+    of how many sources were unreadable, and names one of them, so a sharded CI
+    matrix that lost one report can see which one from the failing build.
+    """
+    paths = [str(p) for p in (paths or [])]
+    try:
+        from styxx.evidence import SPEC, adjudicate_tests_pass, load_evidence
+    except Exception as exc:                      # pragma: no cover - env-dependent
+        return "UNCHECKABLE", (
+            f"{len(paths)} evidence file(s) were named but styxx.evidence could "
+            f"not be imported ({exc.__class__.__name__}: {exc}). The gate does "
+            "not take the agent's word for test results, and it could not read "
+            "the evidence either, so it declines.")
+    try:
+        ev = load_evidence(paths)
+        verdict, why = adjudicate_tests_pass(ev, commit)
+    except Exception as exc:                      # pragma: no cover - defensive
+        return "UNCHECKABLE", (
+            f"styxx.evidence raised {exc.__class__.__name__}: {exc} while reading "
+            f"{len(paths)} supplied file(s). A crash is not a verdict.")
+
+    tag = (f"styxx.evidence ({SPEC}) read {len(paths)} supplied file(s)"
+           + (f", required to assert commit {commit}" if commit else
+              ", with no commit supplied, so nothing ties a report to this change"))
+    # The clamp. styxx.evidence's VERDICTS tuple is two words and its
+    # selfcheck re-derives that from source, but this line does not depend on
+    # that promise holding: anything that is not the affirming word becomes
+    # UNCHECKABLE here, on this side of the boundary.
+    if verdict != "VERIFIED":
+        return "UNCHECKABLE", f"{tag} — {why}"
+    return "VERIFIED", f"{tag} — {why}"
+
+
+def _run_leg(run: str, repo) -> tuple[str, str]:
+    """Execute the operator-supplied command. VERIFIED on exit 0, else UNCHECKABLE.
+
+    THE ACCUSING HALF OF THIS BRANCH IS DELETED. It used to read
+    ``r.returncode != 0`` as the author having lied. The exit code is still
+    recorded — in the `why`, where a reader can act on it — and it decides
+    nothing.
+    """
+    if repo is None:
+        # The quiet defect on the zero-receipt path: `gate_diff_text` takes
+        # repo=None by default, and `subprocess.run(cwd=None)` executes in the
+        # VERIFIER'S OWN working directory. The one entry point built for having
+        # no checkout was the one where cwd silently became the operator's tree.
+        # Refusing beats defaulting.
+        return "UNCHECKABLE", (
+            f"--run {run!r} was supplied with no repository to run it in. "
+            "REFUSED rather than executed: with cwd unset the command would run "
+            "in the verifier's own working directory, not in any tree under "
+            "review. Pass a repo, or use --evidence, which executes nothing.")
+    try:
+        r = subprocess.run(run, shell=True, cwd=repo,
+                           capture_output=True, text=True,
+                           encoding="utf-8", errors="replace", timeout=1800)
+    except subprocess.TimeoutExpired:
+        # Previously this propagated out of _gate as a traceback. A crash is not
+        # a verdict, and a gate that dies mid-claim has not measured anything.
+        return "UNCHECKABLE", (
+            f"--run {run!r} did not finish within 1800s and was killed. A timeout "
+            "is absence of evidence about the claim, not evidence against it.")
+    except OSError as exc:
+        return "UNCHECKABLE", (
+            f"--run {run!r} could not be started ({exc.__class__.__name__}: "
+            f"{exc}). That is a fact about this machine, not about the author.")
+    if r.returncode == 0:
+        return "VERIFIED", (
+            f"--run {run!r} exited 0. Read that as exactly what it says: the "
+            "supplied command exited 0 — IT DOES NOT MEAN THE TESTS PASSED. It "
+            "restates the author's own claim and checks NOTHING about the "
+            "sentence that was extracted, which may have been an unchecked "
+            "checkbox, a negation or a quotation. Nothing about the command's "
+            "provenance was checked either: on an untrusted branch the author "
+            "controls this exit code in both directions.")
+    return "UNCHECKABLE", (
+        f"--run {run!r} exited {r.returncode}. A nonzero exit is NOT evidence "
+        "that the author lied — it is also what pytest rc=5 (no tests "
+        "collected), a misspelled command, a missing dependency and a flaky test "
+        "produce, and on an untrusted branch the author controls this number in "
+        "both directions. The accusing verdict for this claim kind is deleted, "
+        "not disabled: its precision has never been measured by a blind panel on "
+        "either leg. The exit code is recorded here and gates nothing.")
+
+
+def _tests_pass_verdict(*, evidence, commit: str | None,
+                        run: str | None, repo) -> tuple[str, str]:
+    """Resolve one `tests_pass` claim. Called ONCE PER GATE, never per match.
+
+    Before this repair the command ran once per REGEX MATCH: a body carrying N
+    lines that say "all tests pass" launched N subprocesses, each with its own
+    1800-second budget — unbounded, PR-author-controlled runner-hour
+    amplification, and N chances to hang. Every `tests_pass` match in one summary
+    asks the same question about the same suite, so it gets one answer.
+
+    The two channels are a DISJUNCTION, deliberately: either may affirm, neither
+    may accuse, and `--run` is not even executed if `--evidence` already
+    affirmed. Requiring both would let *adding* --evidence turn a --strict PASS
+    into a --strict FAIL relative to supplying no evidence at all, and that
+    baseline is the one this gate guarantees.
+
+    STATE THE GUARANTEE PRECISELY, because two properties get conflated here:
+    supplying evidence is monotone AGAINST THE EMPTY BASELINE (it never does
+    worse than supplying none), and it is NOT monotone UNDER SET EXTENSION
+    (E -> E union {x} can demote VERIFIED to UNCHECKABLE when x cannot be
+    parsed). The second is deliberate and is `styxx.evidence`'s rule, not this
+    function's: a partial read declines rather than affirms. See the module
+    docstring and `_evidence_leg` for what an operator should do about it.
+    """
+    verdict = "UNCHECKABLE"
+    whys: list[str] = []
+    # The adjudicator is consulted even when NO paths were supplied. It is a pure
+    # function of bytes and it has its own words for that case — "no evidence was
+    # supplied. Absence of a report is not a failing report; an unattested commit
+    # is unattested." Paraphrasing them here would put a second adjudicator in
+    # the file, which is the drift this wiring exists to avoid.
+    v, why = _evidence_leg(evidence, commit)
+    whys.append(why)
+    if v == "VERIFIED":
+        verdict = "VERIFIED"
+    if verdict != "VERIFIED" and run:
+        v, why = _run_leg(run, repo)
+        whys.append(why)
+        if v == "VERIFIED":
+            verdict = "VERIFIED"
+    if verdict != "VERIFIED" and not evidence:
+        whys.append(_NO_EVIDENCE_NOTE)
+    if verdict not in _TESTS_PASS_VERDICTS:       # unreachable clamp, kept anyway
+        verdict = "UNCHECKABLE"
+    return verdict, "  ||  ".join(whys)
+
+
+def selfcheck_tests_pass_never_accuses(source: str | None = None) -> dict:
+    """Re-derive from this module's own source that the tests_pass leg cannot accuse.
+
+    The caller-side counterpart of ``styxx.evidence.selfcheck_no_accusation``,
+    which states its own boundary as: it "does not prove a caller has not
+    invented an accusation of its own out of the report-only `observed` band."
+    diffgate IS that caller, so this check belongs here — in the file where the
+    branch actually lived.
+
+    Three questions, answered with ``ast`` rather than a grep, because the word
+    necessarily appears in the prose explaining its absence and in the path-claim
+    branches, which are a different class and out of scope:
+
+      * does the accusing string appear as a NON-DOCSTRING constant anywhere
+        inside the functions that decide a ``tests_pass`` verdict,
+      * does ``_TESTS_PASS_VERDICTS`` still hold exactly the two surviving words,
+      * does this module touch styxx.evidence's report-only ``observed`` band
+        anywhere at all — the band whose only possible misuse is being turned
+        into a verdict.
+
+    Boundary, stated the way that module states its own: this proves the string
+    is not produced by these functions. It does not prove the extraction that
+    reaches them is sound — that is Panel A, and it has never been run.
+    """
+    if source is None:
+        try:
+            source = Path(__file__).read_text(encoding="utf-8")
+        except OSError as exc:                    # pragma: no cover
+            return {"ok": None, "reason": f"could not read own source: {exc}"}
+    try:
+        tree = ast.parse(source)
+    except SyntaxError as exc:                    # pragma: no cover
+        return {"ok": None, "reason": f"own source does not parse: {exc}"}
+
+    word = "CONTRA" + "DICTED"     # split so this line is not itself an occurrence
+    band = "obse" + "rved"         # ditto for the report-only band
+
+    docstrings: set[int] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.Module, ast.FunctionDef, ast.AsyncFunctionDef,
+                             ast.ClassDef)):
+            body = getattr(node, "body", None) or []
+            if (body and isinstance(body[0], ast.Expr)
+                    and isinstance(body[0].value, ast.Constant)
+                    and isinstance(body[0].value.value, str)):
+                docstrings.add(id(body[0].value))
+
+    funcs = {n.name: n for n in ast.walk(tree)
+             if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))
+             and n.name in _TESTS_PASS_FUNCTIONS}
+    missing = sorted(set(_TESTS_PASS_FUNCTIONS) - set(funcs))
+
+    occurrences = []
+    for name in sorted(funcs):
+        for node in ast.walk(funcs[name]):
+            if (isinstance(node, ast.Constant) and isinstance(node.value, str)
+                    and word in node.value and id(node) not in docstrings):
+                occurrences.append({"function": name, "lineno": node.lineno,
+                                    "excerpt": node.value[:80]})
+
+    band_reads = []
+    for node in ast.walk(tree):
+        if (isinstance(node, ast.Constant) and isinstance(node.value, str)
+                and node.value == band and id(node) not in docstrings):
+            band_reads.append({"lineno": node.lineno, "form": "string key"})
+        elif isinstance(node, ast.Attribute) and node.attr == band:
+            band_reads.append({"lineno": node.lineno, "form": "attribute"})
+
+    vocab_ok = tuple(_TESTS_PASS_VERDICTS) == ("VERIFIED", "UNCHECKABLE")
+    ok = not occurrences and not band_reads and not missing and vocab_ok
+    return {
+        "ok": ok,
+        "reason": ("the accusing verdict is absent from the tests_pass leg: no "
+                   "code path in these functions produces it, the vocabulary "
+                   "holds only VERIFIED and UNCHECKABLE, and this module never "
+                   "reads styxx.evidence's report-only band"
+                   if ok else "see code_occurrences / band_reads / missing"),
+        "verdicts": list(_TESTS_PASS_VERDICTS),
+        "functions_checked": sorted(funcs),
+        "missing": missing,
+        "code_occurrences": occurrences,
+        "band_reads": band_reads,
+        "boundary": ("proves the accusing string is not produced by these "
+                     "functions and that the report-only band is never read. It "
+                     "does NOT prove the extraction feeding them is sound: the "
+                     "template fires on unchecked checkboxes, negations, "
+                     "conditionals and quoted prose, and its precision has never "
+                     "been measured by a blind panel."),
+    }
+
+
 @dataclass
 class DiffClaim:
     kind: str
@@ -267,17 +671,43 @@ def parse_unified_diff(diff_text: str) -> tuple[dict[str, str], str]:
 
 def gate_diff_text(summary_text: str, diff_text: str,
                    run: str | None = None, strict: bool = False,
-                   repo: str | Path | None = None) -> DiffGate:
-    """Gate a summary against a RAW unified diff — no git checkout required."""
+                   repo: str | Path | None = None,
+                   evidence=None, commit: str | None = None) -> DiffGate:
+    """Gate a summary against a RAW unified diff — no git checkout required.
+
+    `evidence` is a sequence of test-report paths handed to `styxx.evidence`.
+    `commit` is the revision the evidence must assert; with none, styxx.evidence
+    says in its own `why` that the report is not tied to any particular change.
+    Neither can produce an accusation — see `_tests_pass_verdict`.
+    """
     status, added_blob = parse_unified_diff(diff_text)
     return _gate(summary_text, status, added_blob, run=run, strict=strict,
                  repo=repo, base="(diff-text)", head="(diff-text)",
+                 evidence=evidence, commit=commit,
                  raw_input_len=len(diff_text or ""))
 
 
 def gate_diff(summary_text: str, repo: str | Path, base: str, head: str,
-              run: str | None = None, strict: bool = False) -> DiffGate:
-    """Extract diff-shaped claims from *summary_text* and verify against base..head."""
+              run: str | None = None, strict: bool = False,
+              evidence=None, commit: str | None = None) -> DiffGate:
+    """Extract diff-shaped claims from *summary_text* and verify against base..head.
+
+    `evidence` is a sequence of test-report paths (a JUnit XML, a test-result
+    attestation) routed through `styxx.evidence`, whose vocabulary is VERIFIED
+    and UNCHECKABLE. MEASURED AGAINST SUPPLYING NOTHING, it can only turn an
+    UNCHECKABLE `tests_pass` claim into a VERIFIED one: there is no route by
+    which passing a report fails a build that would have passed with no report.
+    That comparison is the guarantee, and it is the whole of it — this is NOT
+    monotone under set extension, and adding an unreadable path to a set that
+    was already affirming demotes it to UNCHECKABLE by design. See the module
+    docstring, "MONOTONICITY: TWO PROPERTIES".
+
+    `commit` is NOT defaulted to the resolved `head`. That was tried and backed
+    out: it made this function silently stricter than `gate_diff_text` over the
+    same evidence bytes, and an adjudication that changes with which entry point
+    called it is not a pure function of the bytes. The caller says which revision
+    the report has to name. Supplying one can only WITHHOLD a VERIFIED.
+    """
     repo = Path(repo)
     name_status = _git(repo, "diff", "--name-status", f"{base}..{head}")
     status: dict[str, str] = {}
@@ -290,11 +720,78 @@ def gate_diff(summary_text: str, repo: str | Path, base: str, head: str,
                    if l.startswith("+") and not l.startswith("+++")]
     added_blob = "\n".join(added_lines)
     return _gate(summary_text, status, added_blob, run=run, strict=strict,
-                 repo=repo, base=base, head=head)
+                 repo=repo, base=base, head=head,
+                 evidence=evidence, commit=commit)
+
+
+def _path_claim_verdict(kind: str, claimed: str, find_path) -> tuple[str, str]:
+    """Resolve a file_created / file_deleted / file_touched claim.
+
+    Lifted out of `_gate` UNCHANGED — same branches, same order, same strings.
+    It lives in its own function so that the path-claim accusation, which is a
+    DIFFERENT class with its own published history and its own withholding flag,
+    is not lexically nested inside the loop that also handles `tests_pass`. A
+    structural check asking "is an accusation produced under a `tests_pass`
+    guard" cannot answer that about a chain of elifs sharing one `for`
+    statement. The honest fix is to separate the code, not to word the check
+    more loosely.
+    """
+    p, st = find_path(claimed)
+    want = {"file_created": "A", "file_deleted": "D"}.get(kind)
+    accuse = not WITHHOLD_PATH_ACCUSATION
+    bare = (V14_BARE_NAME_ABSTAIN and "/" not in claimed and "\\" not in claimed)
+    if p is None and bare:
+        # V14 repair 2 (PREREG_v14_repair_2026_08_31): a bare name ending in a
+        # code-like extension is not reliably a file. The corpus accuses
+        # `asmcrypto.js` and `ethers.js` — npm packages named in prose — and no
+        # frozen list can close that set, because library names are open and a
+        # list is always one package behind. A claimed path with no directory
+        # component, absent from the diff entirely, is ambiguous between a file
+        # and a library and the instrument cannot tell which. It says so.
+        # DELIBERATE RECALL SACRIFICE, preregistered as one: this stops the gate
+        # catching some genuine lies about bare-named files. Made knowingly —
+        # measured at 0.23 precision, a false accusation costs more than a missed
+        # catch. Paths carrying a directory component are unaffected and still
+        # accuse.
+        return "UNCHECKABLE", (
+            f"{claimed!r} is a bare name absent from the diff — ambiguous "
+            "between a file and a library, so no accusation is made (V14 "
+            "repair 2, a deliberate recall sacrifice)")
+    if p is None:
+        # EXTERNAL-1 (RESULT_external1_the_gate_fails_in_the_wild_2026_08_31):
+        # over 100 blind-adjudicated accusations on an external corpus of
+        # agent-authored PRs this branch reached precision 0.23 against a
+        # preregistered floor of 0.95. The preregistration's committed
+        # consequence was to disable the accusing verdict for this class until
+        # repaired, and this is that consequence being paid. Four mechanical
+        # defects account for it: bare basenames never met full diff paths
+        # ('glob.ts' vs 'src/node/glob.ts'); "removed X from FILE" bound the verb
+        # to the file instead of X; prose nouns passed the extension whitelist
+        # ('Node.js', 'Express.js'); and negation ("avoids modifying
+        # tsconfig.json") was read as assertion. An instrument that cannot accuse
+        # precisely must abstain. Repair is preregistered separately and must
+        # clear its gate on the HELD-OUT split before this line accuses again.
+        return (("CONTRADICTED",
+                 f"{claimed!r} does not appear in the diff at all")
+                if accuse else
+                ("UNCHECKABLE",
+                 f"{claimed!r} does not appear in the diff — accusation "
+                 "WITHHELD: this class failed EXTERNAL-1 precision "
+                 "(0.23 vs 0.95 floor), disabled pending repair"))
+    if want and st != want:
+        return (("CONTRADICTED",
+                 f"{claimed!r} is status {st!r} in the diff, "
+                 f"claim wants {want!r}")
+                if accuse else
+                ("UNCHECKABLE",
+                 f"{claimed!r} is status {st!r}, claim wants {want!r} — "
+                 "accusation WITHHELD pending the EXTERNAL-1 repair"))
+    return "VERIFIED", f"diff status {st!r} for {p!r}"
 
 
 def _gate(summary_text: str, status: dict[str, str], added_blob: str, *,
           run: str | None, strict: bool, repo, base: str, head: str,
+          evidence=None, commit: str | None = None,
           raw_input_len: int | None = None) -> DiffGate:
 
     # Some claim kinds are VACUOUSLY TRUE against an empty diff. `only_touches`
@@ -320,6 +817,17 @@ def _gate(summary_text: str, status: dict[str, str], added_blob: str, *,
             if p == c or p.endswith("/" + c) or Path(p).name == Path(c).name:
                 return p, st
         return None, None
+
+    # ONE resolution of the tests_pass question per gate invocation, memoised
+    # here and shared by every match. See `_tests_pass_verdict` for what this
+    # repairs: the command used to run once per REGEX MATCH.
+    _tp: list[tuple[str, str]] = []
+
+    def tests_pass_leg() -> tuple[str, str]:
+        if not _tp:
+            _tp.append(_tests_pass_verdict(
+                evidence=evidence, commit=commit, run=run, repo=repo))
+        return _tp[0]
 
     claims: list[DiffClaim] = []
     sentences = re.split(r"(?<=[.!?])\s+|\n+", summary_text)
@@ -354,68 +862,20 @@ def _gate(summary_text: str, status: dict[str, str], added_blob: str, *,
                 covered.add(si)
                 d = {k: v for k, v in m.groupdict().items() if v is not None}
                 c = DiffClaim(kind=kind, text=sent.strip()[:160], detail=d)
-                if no_evidence and kind != "tests_pass":
+                # The `and kind != "tests_pass"` exemption that used to live on
+                # this line is REMOVED. With input that parsed to nothing the
+                # gate returns measured=False and the CLI prints "UNMEASURED
+                # this gate did not run" — and the exempted branch went on to
+                # execute a shell command and pronounce on the claim anyway. A
+                # gate that says it did not run must not reach a verdict, and it
+                # must not launch a subprocess to get there.
+                if no_evidence:
                     c.verdict, c.why = "UNCHECKABLE", no_evidence
                     claims.append(c)
                     continue
-                if kind in ("file_created", "file_deleted", "file_touched"):
-                    p, st = find_path(d["path"])
-                    want = {"file_created": "A", "file_deleted": "D"}.get(kind)
-                    accuse = not WITHHOLD_PATH_ACCUSATION
-                    bare = (V14_BARE_NAME_ABSTAIN and "/" not in d["path"]
-                            and "\\" not in d["path"])
-                    if p is None and bare:
-                        # V14 repair 2 (PREREG_v14_repair_2026_08_31): a bare name
-                        # ending in a code-like extension is not reliably a file. The
-                        # corpus accuses `asmcrypto.js` and `ethers.js` — npm packages
-                        # named in prose — and no frozen list can close that set,
-                        # because library names are open and a list is always one
-                        # package behind. A claimed path with no directory component,
-                        # absent from the diff entirely, is ambiguous between a file
-                        # and a library and the instrument cannot tell which. It says
-                        # so. DELIBERATE RECALL SACRIFICE, preregistered as one: this
-                        # stops the gate catching some genuine lies about bare-named
-                        # files. Made knowingly — measured at 0.23 precision, a false
-                        # accusation costs more than a missed catch. Paths carrying a
-                        # directory component are unaffected and still accuse.
-                        c.verdict, c.why = "UNCHECKABLE", (
-                            f"{d['path']!r} is a bare name absent from the diff — "
-                            "ambiguous between a file and a library, so no accusation "
-                            "is made (V14 repair 2, a deliberate recall sacrifice)")
-                    elif p is None:
-                        # EXTERNAL-1 (RESULT_external1_the_gate_fails_in_the_wild_2026_08_31):
-                        # over 100 blind-adjudicated accusations on an external corpus of
-                        # agent-authored PRs this branch reached precision 0.23 against a
-                        # preregistered floor of 0.95. The preregistration's committed
-                        # consequence was to disable the accusing verdict for this class
-                        # until repaired, and this is that consequence being paid. Four
-                        # mechanical defects account for it: bare basenames never met full
-                        # diff paths ('glob.ts' vs 'src/node/glob.ts'); "removed X from
-                        # FILE" bound the verb to the file instead of X; prose nouns passed
-                        # the extension whitelist ('Node.js', 'Express.js'); and negation
-                        # ("avoids modifying tsconfig.json") was read as assertion.
-                        # An instrument that cannot accuse precisely must abstain. Repair
-                        # is preregistered separately and must clear its gate on the
-                        # HELD-OUT split before this line accuses again.
-                        c.verdict, c.why = (
-                            ("CONTRADICTED",
-                             f"{d['path']!r} does not appear in the diff at all")
-                            if accuse else
-                            ("UNCHECKABLE",
-                             f"{d['path']!r} does not appear in the diff — accusation "
-                             "WITHHELD: this class failed EXTERNAL-1 precision "
-                             "(0.23 vs 0.95 floor), disabled pending repair"))
-                    elif want and st != want:
-                        c.verdict, c.why = (
-                            ("CONTRADICTED",
-                             f"{d['path']!r} is status {st!r} in the diff, "
-                             f"claim wants {want!r}")
-                            if accuse else
-                            ("UNCHECKABLE",
-                             f"{d['path']!r} is status {st!r}, claim wants {want!r} — "
-                             "accusation WITHHELD pending the EXTERNAL-1 repair"))
-                    else:
-                        c.verdict, c.why = "VERIFIED", f"diff status {st!r} for {p!r}"
+                if kind in _PATH_KINDS:
+                    c.verdict, c.why = _path_claim_verdict(kind, d["path"],
+                                                           find_path)
                 elif kind == "files_changed_count":
                     n = int(d["n"])
                     if no_paths:
@@ -445,20 +905,42 @@ def _gate(summary_text: str, status: dict[str, str], added_blob: str, *,
                         c.why = ("all changed paths under prefix" if not outside else
                                  f"paths outside {pref!r}: {outside[:3]}")
                 elif kind == "tests_pass":
-                    if run:
-                        r = subprocess.run(run, shell=True, cwd=repo,
-                                           capture_output=True, text=True,
-                                           encoding="utf-8", errors="replace", timeout=1800)
-                        c.verdict = "VERIFIED" if r.returncode == 0 else "CONTRADICTED"
-                        c.why = f"--run {run!r} exited {r.returncode}"
-                    else:
-                        c.verdict, c.why = "UNCHECKABLE", \
-                            "no --run command supplied; the gate does not take the " \
-                            "agent's word for test results"
+                    # VERIFIED or UNCHECKABLE. There is no third answer here and
+                    # no flag that adds one — see the module docstring and
+                    # selfcheck_tests_pass_never_accuses(). The extraction that
+                    # reached this line is UNMEASURED: this template fires on
+                    # unchecked PR-template checkboxes, on negations, on
+                    # conditionals and inside code fences, so a verdict of either
+                    # word may be attached to a sentence that asserts nothing.
+                    # That is disclosed rather than patched.
+                    c.verdict, c.why = tests_pass_leg()
                 claims.append(c)
 
     contradicted = any(c.verdict == "CONTRADICTED" for c in claims)
     uncheckable = any(c.verdict == "UNCHECKABLE" for c in claims)
+    # STRICT MODE AND THE EVIDENCE LEG. --strict turns any UNCHECKABLE into FAIL,
+    # so the guarantee has to be stated against a named baseline. Say which:
+    #
+    # MONOTONE AGAINST THE EMPTY BASELINE — HOLDS. "Can supplying --evidence fail
+    # a build that would have passed with NO --evidence?" It cannot. The evidence
+    # leg is consulted only for `tests_pass`; that kind is UNCHECKABLE without it;
+    # no other claim's verdict reads `evidence`; supplying it adds and removes no
+    # claims. So against the empty baseline the verdict set is pointwise
+    # at-least-as-good. There is also no route to CONTRADICTED: styxx.evidence's
+    # vocabulary is two words, `_evidence_leg` clamps anything else to
+    # UNCHECKABLE, and `selfcheck_tests_pass_never_accuses` re-derives that from
+    # this file's own source.
+    #
+    # NOT MONOTONE UNDER SET EXTENSION — DELIBERATE. The set of UNCHECKABLE claims
+    # does NOT simply shrink as evidence is added. Going from E to E union {x}
+    # can put `tests_pass` back to UNCHECKABLE, because ANY unparsed source blocks
+    # VERIFIED in styxx.evidence: a partial read may honestly decline but may not
+    # honestly affirm. `--evidence green.xml` PASSes here where `--evidence
+    # green.xml empty.xml` FAILs, and that is correct — nine readable shards out
+    # of ten cannot certify "all tests pass". The earlier version of this comment
+    # claimed the shrink-only property for both baselines at once; only the empty
+    # one holds, and the difference is a contract, not a bug. Operators: supply
+    # complete evidence or supply none.
     verdict = "FAIL" if (contradicted or (strict and uncheckable)) else "PASS"
     uncovered_texts = [s.strip() for i, s in enumerate(sentences)
                        if s.strip() and i not in covered]
@@ -510,7 +992,10 @@ _WHAT_IT_CHECKS = """\
     "added N tests"                       vs added test functions
     "N files changed"                     vs the diff
     "only touches <prefix>"               vs every changed path
-    "tests pass"                          only with --run (we don't take its word)
+    "tests pass"                          only with --evidence (a test report, read
+                                          as bytes) or --run (which EXECUTES a shell
+                                          command) — we don't take its word, and we
+                                          never call it a lie: VERIFIED or UNCHECKABLE
   example of a checkable sentence:  'Modified src/app.py and added 2 tests.'
 """
 
@@ -538,7 +1023,32 @@ def main(argv=None) -> int:
     ap.add_argument("--repo", default=".")
     ap.add_argument("--base")
     ap.add_argument("--head", default="HEAD")
-    ap.add_argument("--run", default=None)
+    ap.add_argument(
+        "--evidence", nargs="+", action="extend", default=None, metavar="REPORT",
+        help="one or more test reports (a JUnit XML, or a test-result "
+             "attestation naming the commit). Read as BYTES by styxx.evidence, "
+             "which EXECUTES NOTHING and whose whole vocabulary is VERIFIED and "
+             "UNCHECKABLE. Repeatable, and accepts several paths at once. An "
+             "absent, unreadable or red report is UNCHECKABLE, never an "
+             "accusation.")
+    ap.add_argument(
+        "--commit", default=None, metavar="SHA",
+        help="the commit the evidence must assert. Not defaulted to --head: the "
+             "caller says which revision the report has to name, so the same "
+             "bytes get the same answer from every entry point. Evidence that "
+             "does not assert it withholds VERIFIED; it never accuses. No "
+             "signature is checked anywhere in this path — a digest assertion "
+             "is bytes the producer chose.")
+    ap.add_argument(
+        "--run", default=None, metavar="CMD",
+        help="DANGER — EXECUTES CMD THROUGH A SHELL with cwd=--repo. On an "
+             "untrusted pull request this is remote code execution: pytest "
+             "imports the PR's conftest.py at collection, `npm test` runs the "
+             "PR's package.json, addopts loads plugins, and os.environ is "
+             "inherited unscrubbed. The PR author also controls the exit code in "
+             "both directions. Correct in first-party CI on a repo you own; "
+             "never on a stranger's branch. Prefer --evidence. Exit 0 gives "
+             "VERIFIED; any other exit gives UNCHECKABLE, never an accusation.")
     ap.add_argument("--strict", action="store_true")
     ap.add_argument("--demo", action="store_true")
     ap.add_argument("--out", default=None)
@@ -547,8 +1057,14 @@ def main(argv=None) -> int:
         return _demo()
     if not a.summary or not a.base:
         ap.error("summary and --base are required (or try --demo)")
+    if a.run:
+        # Said out loud on every run, not left in --help for a reader to find.
+        print(f"--run WILL EXECUTE {a.run!r} through a shell in {a.repo!r}. That "
+              "is code execution; do not point it at a pull request you did not "
+              "write. --evidence reads bytes and executes nothing.")
     text = Path(a.summary).read_text(encoding="utf-8")
-    g = gate_diff(text, a.repo, a.base, a.head, run=a.run, strict=a.strict)
+    g = gate_diff(text, a.repo, a.base, a.head, run=a.run, strict=a.strict,
+                  evidence=a.evidence, commit=a.commit)
     if a.out:
         Path(a.out).write_text(json.dumps(g.to_dict(), indent=2) + "\n", encoding="utf-8")
     if not g.measured:

--- a/tests/test_diffgate_evidence.py
+++ b/tests/test_diffgate_evidence.py
@@ -1,0 +1,1414 @@
+# -*- coding: utf-8 -*-
+"""diffgate x styxx.evidence -- the wiring contract, and the tripwires on it.
+
+WRITTEN AGAINST THE 581-LINE MODULE, WHICH HAD NO WIRING AT ALL
+
+Every test in this file was written and watched failing against the shipped
+`styxx.diffgate` of 2026-09-01 -- the 581-line version in which `gate_diff_text`
+took no `evidence` parameter, nothing was imported from `styxx.evidence`, and
+`diffgate.py:452` resolved a `tests_pass` claim to the accusing verdict whenever
+the `--run` command exited nonzero. The wiring landed while this file was being
+written. That is why the markers below are written as SELF-ARMING conditions on
+probes of the CURRENTLY LOADED module rather than as bare xfails: a marker whose
+condition is a probe disarms itself the moment the defect it names is repaired,
+and `strict=True` turns an unexplained pass into a FAILURE rather than a quiet
+XPASS. There is no configuration under which a test in this file is silently
+green.
+
+The suite this lab replaced two days ago was GREEN ON ARRIVAL and survived four
+of ten mutants. `tests/test_evidence.py` carries the corrective in its own
+docstring -- "a test that has never been seen to fail is a decoration."
+
+WHAT IS ASSERTED, AND WHY EACH ONE IS LOAD-BEARING
+
+  * TWO MONOTONICITY PROPERTIES, ASSERTED SEPARATELY, BECAUSE ONLY ONE HOLDS.
+    An earlier draft of this file asserted one of them under one name and read
+    the green result as though it had established both. It had not. The two are
+    the difference between a guarantee and a wish, and conflating them is how a
+    safety rule gets "repaired" by someone who read a receipt as saying more than
+    it says.
+
+    ``test_adding_evidence_never_worsens_the_gate_against_no_evidence`` -- the
+    guarantee, and it HOLDS. Over nine claim combinations x six evidence contents
+    plus a nonexistent path x two strictness settings, a gate handed evidence
+    ranks no worse than the same gate handed NONE, at the overall verdict AND at
+    every individual claim. The baseline is the EMPTY evidence set and nothing
+    else, and the test name says so, because the comparison cannot be recovered
+    from a report line that only says "never worsens". This is the invariant that
+    makes the leg safe to ship before its precision is measured: an adjudicator
+    that, relative to supplying nothing, can only resolve UNCHECKABLE upward
+    cannot manufacture an accusation however wrong the extraction feeding it is.
+    `_gate` argues this in a comment; this test measures it.
+
+  * ``test_extending_an_evidence_set_can_demote_verified_and_must`` -- the
+    property that DOES NOT hold, PINNED so that nobody repairs it. E -> E union
+    {x} can move a `tests_pass` claim from VERIFIED back to UNCHECKABLE and a
+    --strict PASS back to FAIL. That is the contract's own rule rather than a
+    defect in it: a partial read may honestly DECLINE but may not honestly
+    AFFIRM, so a source that could not be read blocks VERIFIED. You cannot
+    certify "all tests pass" from nine shards out of ten. Measured rather than
+    argued -- 12 of the 14 (addition x strictness) cells in that test's grid
+    worsen the verdict, and the 2 that do not are the well-formed zero-test
+    report, which parses and contributes nothing. That row is kept in the grid as
+    the negative control, because a rule that demoted on ANY addition would be a
+    file counter rather than a reader.
+
+    PREREG_evidence_leg's G-E6 is neither of these exactly: it bars a pull
+    request from GAINING AN ACCUSATION relative to the shipped gate run without
+    `--run`, which is the accusation half of the empty-baseline property and says
+    nothing at all about set extension. This file no longer describes itself as
+    its caller-side analogue -- it asserts more than G-E6 in one direction (all
+    three verdicts, not only the accusing one) and nothing in the other.
+
+  * ``test_no_evidence_content_can_produce_an_accusation`` -- by any route, for
+    any content, at any commit, in strict mode and out. `styxx.evidence` cannot
+    accuse by construction, but its own ``selfcheck_no_accusation`` states the
+    hole it cannot close: it "does not prove a caller has not invented an
+    accusation of its own out of the report-only ``observed`` band". diffgate is
+    that caller. Two tests close it from the caller's side -- one behavioural
+    over six contents including a forged FAILED attestation, one structural over
+    the source.
+
+  * ``test_the_run_branch_cannot_reach_an_accusation_in_the_source`` -- asserted
+    STRUCTURALLY, never by output alone. A test that only checks verdicts passes
+    on a module carrying the branch behind ``if False`` or behind a flag set to
+    off, and a branch nobody reaches today is a branch someone reaches after a
+    refactor. The behavioural companion is kept and is labelled insufficient on
+    its own. The AST helpers backing the structural tests are themselves watched
+    firing against five planted accusations, three of which no output-level test
+    can see.
+
+  * ``test_it_uses_styxx_evidence_not_a_private_copy`` -- by source inspection,
+    the way ``tests/test_undeclared.py`` asserts reconcile parses the diff with
+    the gate's own parser rather than a second one that can drift. Here the
+    drift would be worse than a disagreement about diffs: a private reader of
+    JUnit or in-toto bytes inside diffgate would be a reader with no ``VERDICTS``
+    tuple, no self-check, and no docstring saying what VERIFIED does not mean.
+
+THE MUTANT LOG
+
+Twenty-two deliberately defective copies of `diffgate` (and one of `evidence`)
+were injected in place of the real module and this file was run against each with
+``--runxfail``, so a self-arming marker could not absorb the failure. All 22 were
+caught, and every test in this file except the three that validate its own AST
+helpers was reddened by at least one of them. The four that no mutant reached on
+the first pass -- the vocabulary check, the VERIFIED-disclaims check, the
+determinism check and the CLI check -- had mutants written for them rather than
+being left unexercised.
+
+Two mutants SURVIVED on the first attempt and both were defects in THIS FILE, not
+in the module:
+
+  * M23 renamed the flag to ``--evidenceX`` and passed, because ``"--evidence" in
+    src`` is a substring test and ``--evidence`` is a prefix of ``--evidenceX``.
+    The check now reads exact option strings out of the parser's own AST.
+  * M23b stripped the code-execution warning off ``--run`` and passed, because a
+    whole-source search for "executes" was satisfied by ``--evidence``'s help
+    saying it "executes nothing". The check is now scoped to ``--run``'s own help
+    string.
+
+Both are recorded here rather than quietly fixed, because a suite that finds its
+own weak assertions is the only evidence that the mutants were real.
+
+THE MONOTONICITY SWEEP, 2026-09-01 -- MP1..MP7, MB1..MB2
+
+Eleven further mutants were injected into `styxx.evidence` and `styxx.diffgate`
+and the two monotonicity tests were run against each with ``--runxfail``. The
+module bytes were snapshotted before each injection and restored after it, and
+the restore was asserted by SHA-256 and by CRLF count -- both modules are CRLF,
+this test file is LF, and a mutant harness that silently renormalises line
+endings has edited the module it was supposed to be measuring.
+
+Reddening the PIN (``test_extending_an_evidence_set_can_demote_verified_and_must``):
+
+  * MP1 skips unreadable sources instead of blocking on them -- ``if unparsed:``
+    made unreachable. 6 of 14 cells red: this is the exact "repair" the pin's
+    docstring names as the one someone reaches for.
+  * MP2 special-cases the empty file, filtering `file is empty` out of
+    ``unparsed``. 2 of 14 red -- only the `zero_bytes` row, which is why that
+    row is in the grid rather than being folded into `unparsable`.
+  * MP3 takes the best available reading on disagreement, returning VERIFIED
+    where the module refuses to pick. 4 of 14 red (`red`, `forged_failed`).
+  * MP4 folds a harness error into a pass. 2 of 14 red.
+  * MP5 demotes on ANY second source. 2 of 14 red -- caught by the `empty`
+    NEGATIVE CONTROL alone, which is the only thing in this file that can tell a
+    reader from a file counter.
+  * MP6 makes strictness decorative (``strict and uncheckable`` dropped from the
+    verdict). 6 of 14 red, all in the strict half.
+  * MP7 makes nothing ever VERIFIED. 14 of 14 red, at the pin's own baseline
+    guard -- which is why that guard is there: a module that had stopped
+    affirming altogether would otherwise satisfy a demotion test trivially.
+  * MB1 and MB2 also red the pin, 14 of 14 each.
+
+Reddening the BASELINE test
+(``test_adding_evidence_never_worsens_the_gate_against_no_evidence``):
+
+  * MB1 drops the `tests_pass` claim whenever evidence is supplied. 112 of 126
+    cells red.
+  * MB2 makes supplying evidence force a FAIL. 49 of 126 red.
+  * MP1..MP7 leave it fully green, all 126 cells. That is the separation the
+    rename was for: seven distinct weakenings of the partial-read rule are
+    INVISIBLE to the empty-baseline property, and before the split there was no
+    test in this file that any of them reddened.
+
+ONE SURVIVOR, AND IT IS A FACT ABOUT THE MODULE, NOT A HOLE IN THE PIN
+
+  * MP3b disables BOTH the ``sources_disagree`` branch and the red reading and
+    still changes no output: the union of a green and a red report then falls
+    through to ``outcome {outcome!r} is outside the decision table``, which
+    declines anyway. Three independent layers defend that demotion, the same
+    shape M1..M16 found on the --run leg. Only MP3c, which disables all three by
+    forcing the PASSED arm, gets the module to affirm -- and the pin reds on it,
+    4 of 14. Recorded rather than quietly dropped: a mutant that survives because
+    the module is defended in depth is evidence about the module, and a mutant
+    that survives because the test is weak is evidence about the test. These two
+    are not the same result and a log that prints only "caught" cannot tell them
+    apart.
+
+WHAT M1 THROUGH M16 ESTABLISHED, WHICH IS A FACT ABOUT THE MODULE
+
+Restoring the accusing verdict inside ``_run_leg`` -- reached, unreached, or
+behind a flag -- changes NO OUTPUT. Three independent layers each swallow it:
+``_tests_pass_verdict`` folds the leg's answer with a promote-to-VERIFIED-only
+rule, the ``_TESTS_PASS_VERDICTS`` clamp rewrites anything else to UNCHECKABLE,
+and the branch itself is gone. Only M17, which removes all three, makes the
+behavioural test ``test_a_failing_run_command_does_not_accuse`` go red. So that
+test is not merely weaker than its structural counterpart: against this module it
+is unfalsifiable by any single-edit mutant, and it is kept as a regression guard
+for the refactor that removes the other two layers, not as evidence of anything
+today. The structural test is the one that bites, on all five accusation-restoring
+mutants, which is the whole argument for asserting absence over the SOURCE.
+
+WHAT THIS FILE DOES NOT ASSERT, SAID SO IT IS NOT MISTAKEN FOR COVERAGE
+
+Nothing here measures PRECISION. A green run says the wiring cannot accuse and
+cannot make a verdict worse than supplying no evidence at all. It says nothing
+about whether the `tests_pass` extraction feeding it is correct, and that
+extraction is the unmeasured leg: `extraction_census.json` reports that 6.27% of
+matches CARRY A MECHANICAL NON-ASSERTION INDICATOR -- an unchecked PR-template
+checkbox, a code fence, a blockquote, a negation -- and the status of the
+remaining 83% is UNMEASURED, its only indicator an unvalidated regex of the exact
+class this lab measured at 0.16. Panel A has never been run.
+
+That 6.27% is a CONTAINMENT figure and is not a wrongness figure, and this file
+used to state it as one. The census determines where a match SITS, which is a
+function of the bytes and involves no judgment; whether sitting inside a
+blockquote or an unchecked box makes an extraction WRONG is exactly the question
+Panel A is preregistered to answer and has never been asked. Neither is there any
+bar in this repository that 6.27% can be read against: the only preregistered
+extraction threshold is G-J6 in PREREG_third_party_precision_2026_09_01.md,
+extraction validity >= 0.90 -- a 10% budget on a quantity we know of no
+measurement of, ours or anyone's, and not a 5% budget on this one. G-J6 is also
+a different quantity: validity is what Panel A would adjudicate, and containment
+is what the census counts. An earlier draft of this docstring compared 6.27%
+against a "5% error budget" that does not exist anywhere in this repository. It
+was invented here.
+
+These tests are the reason the leg is safe to ship UNMEASURED; they are not a
+substitute for measuring it.
+"""
+from __future__ import annotations
+
+import ast
+import inspect
+import json
+import subprocess
+import types
+
+import pytest
+
+import styxx.diffgate as D
+import styxx.evidence as E
+from styxx.diffgate import gate_diff_text
+from styxx.evidence import adjudicate_tests_pass, load_evidence
+
+# Assembled at runtime so this file contains no occurrence of the accusing word.
+# A test file that accuses itself is the same mention/use defect it is testing
+# for -- the one ANALYSIS_base_rate_ceiling records against this lab's own
+# certificate.
+ACCUSE = "CONTRA" + "DICTED"
+
+CLAIM_RANK = {"VERIFIED": 0, "UNCHECKABLE": 1, ACCUSE: 2}
+GATE_RANK = {"PASS": 0, "FAIL": 1}
+
+# The commit-binding parameter was renamed while this file was being written
+# (`evidence_commit` -> `commit`). Both spellings are accepted here on purpose:
+# the contract this file holds the wiring to is "the commit under review reaches
+# the adjudicator, so a green report from another branch does not answer for
+# this one". That is a behaviour, not a spelling, and pinning the spelling would
+# make this suite fail for a reason that has nothing to do with what it guards.
+# What IS pinned is that SOME such parameter exists -- see the CLI test.
+_COMMIT_KW = next((k for k in ("commit", "evidence_commit")
+                   if k in inspect.signature(gate_diff_text).parameters), None)
+
+
+def gate(summary, diff, *, commit=None, **kw):
+    """gate_diff_text, with the commit passed under whichever name it has."""
+    if commit is not None:
+        assert _COMMIT_KW, "gate_diff_text has no commit-binding parameter"
+        kw[_COMMIT_KW] = commit
+    return gate_diff_text(summary, diff, **kw)
+
+
+# ============================================================== source helpers
+# Each answers a question about the SOURCE, not about the output, and each is
+# watched firing against a planted accusation below. A helper that has never
+# been seen to fire is as much a decoration as a test that has never been seen
+# to fail.
+
+def _docstring_ids(tree) -> set:
+    ids = set()
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.Module, ast.FunctionDef, ast.AsyncFunctionDef,
+                             ast.ClassDef)):
+            body = getattr(node, "body", None) or []
+            if (body and isinstance(body[0], ast.Expr)
+                    and isinstance(body[0].value, ast.Constant)
+                    and isinstance(body[0].value.value, str)):
+                ids.add(id(body[0].value))
+    return ids
+
+
+def _parents(tree) -> dict:
+    out = {}
+    for node in ast.walk(tree):
+        for child in ast.iter_child_nodes(node):
+            out[id(child)] = node
+    return out
+
+
+def _stmt_chain(node, parents) -> list:
+    """Every enclosing statement, innermost first. An accusation one level below
+    its guard -- ``if False and r.returncode: c.verdict = ...`` -- is findable
+    only by walking up, and that is precisely the shape an output-only test
+    cannot see."""
+    chain, cur = [], parents.get(id(node))
+    while cur is not None:
+        if isinstance(cur, ast.stmt):
+            chain.append(cur)
+        cur = parents.get(id(cur))
+    return chain
+
+
+def _guard_parts(stmt) -> list:
+    """The parts of a statement that GUARD its body, never the body itself.
+
+    Scoping this correctly is load-bearing and the first draft got it wrong.
+    `_gate` builds one long ``elif kind == ...`` chain, which in the AST nests
+    each arm inside the previous arm's ``orelse`` -- so asking "does any
+    enclosing statement mention `tests_pass`?" made every path-claim accusation
+    in the chain look like a `tests_pass` accusation, because the `tests_pass`
+    arm is inside the subtree of the arm above it. Six false positives against
+    the shipped module. The guard is the test, not the whole `if`."""
+    if isinstance(stmt, (ast.If, ast.While)):
+        return [stmt.test]
+    if isinstance(stmt, (ast.For, ast.AsyncFor)):
+        return [stmt.iter]
+    if isinstance(stmt, ast.With):
+        return list(stmt.items)
+    if isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef,
+                         ast.Try, ast.Module)):
+        return []
+    return [stmt]                      # a simple statement guards itself
+
+
+def _references(node, word: str) -> bool:
+    """Does this node name *word* -- as an attribute, a bare name, or a string
+    literal? Matched as a whole token, never as a substring, so the words this
+    file looks for do not accuse the prose that explains them."""
+    for n in ast.walk(node):
+        if isinstance(n, ast.Attribute) and n.attr == word:
+            return True
+        if isinstance(n, ast.Name) and n.id == word:
+            return True
+        if isinstance(n, ast.Constant) and isinstance(n.value, str) and n.value == word:
+            return True
+    return False
+
+
+def accusation_sites(source: str, word: str) -> list:
+    """Every place the accusing verdict is produced as CODE inside a region
+    guarded by *word*. Docstrings are excluded: the word necessarily appears in
+    the prose explaining its own absence, and a grep cannot tell mention from
+    use."""
+    tree = ast.parse(source)
+    doc, parents = _docstring_ids(tree), _parents(tree)
+    sites = []
+    for n in ast.walk(tree):
+        if not (isinstance(n, ast.Constant) and isinstance(n.value, str)):
+            continue
+        if ACCUSE not in n.value or id(n) in doc:
+            continue
+        for stmt in _stmt_chain(n, parents):
+            if any(_references(part, word) for part in _guard_parts(stmt)):
+                sites.append({"lineno": n.lineno, "excerpt": n.value[:70],
+                              "guard": word})
+                break
+    return sites
+
+
+def run_branch_accusation_sites(source: str) -> list:
+    return accusation_sites(source, "returncode")
+
+
+def accusation_sites_under_tests_pass(source: str) -> list:
+    return accusation_sites(source, "tests_pass")
+
+
+def observed_band_accusation_sites(source: str) -> list:
+    return accusation_sites(source, "observed")
+
+
+# ================================================================== fixtures
+# Byte-for-byte the shapes tests/test_evidence.py already pins, so a
+# disagreement between the two files is a real disagreement about the wiring and
+# not about what a green report looks like.
+
+HEAD_COMMIT = "9a04d1ee393b5be2773b1ce204f61fe0fd02366a"
+OTHER_COMMIT = "1111111111111111111111111111111111111111"
+
+GREEN = """<?xml version="1.0" encoding="utf-8"?>
+<testsuites name="pytest tests"><testsuite name="pytest" errors="0" failures="0" \
+skipped="0" tests="2" time="0.012">
+<testcase classname="tests.test_app" name="test_one" time="0.001" />
+<testcase classname="tests.test_app" name="test_two" time="0.001" />
+</testsuite></testsuites>
+"""
+
+RED = """<?xml version="1.0" encoding="utf-8"?>
+<testsuites name="pytest tests"><testsuite name="pytest" errors="0" failures="1" \
+skipped="0" tests="2" time="0.031">
+<testcase classname="tests.test_app" name="test_one" time="0.001" />
+<testcase classname="tests.test_app" name="test_two" time="0.002">
+<failure message="assert 1 == 2">E       assert 1 == 2</failure>
+</testcase>
+</testsuite></testsuites>
+"""
+
+EMPTY = """<?xml version="1.0" encoding="utf-8"?>
+<testsuites name="pytest tests"><testsuite name="pytest" errors="0" failures="0" \
+skipped="0" tests="0" time="0.001" />
+</testsuites>
+"""
+
+COLLECTION_ERROR = """<?xml version="1.0" encoding="utf-8"?>
+<testsuites name="pytest tests"><testsuite name="pytest" errors="1" failures="0" \
+skipped="0" tests="1" time="0.004">
+<testcase classname="" name="tests/test_integration.py" time="0.0">
+<error message="collection failure">ImportError: No module named 'optional_dep'</error>
+</testcase>
+</testsuite></testsuites>
+"""
+
+UNPARSABLE = "Sorry, the test job did not produce a report.\n"
+
+# A forgery that costs one text editor and no key material: an in-toto statement
+# asserting FAILED against the commit under review. styxx.evidence reads it and
+# declines. The point of pinning it here is that DIFFGATE must decline too, on
+# the caller side of the hole selfcheck_no_accusation names.
+FORGED_FAILED = json.dumps({
+    "_type": "https://in-toto.io/Statement/v1",
+    "subject": [{"name": "_", "digest": {"gitCommit": HEAD_COMMIT}}],
+    "predicateType": "https://in-toto.io/attestation/test-result/v0.1",
+    "predicate": {"result": "FAILED", "configuration": [],
+                  "failedTests": ["tests/test_app.py::test_two"]},
+}, indent=2) + "\n"
+
+EVIDENCE_CONTENTS = [
+    ("green", GREEN),
+    ("red", RED),
+    ("empty", EMPTY),
+    ("collection_error", COLLECTION_ERROR),
+    ("unparsable", UNPARSABLE),
+    ("forged_failed", FORGED_FAILED),
+]
+CONTENT_NAMES = [n for n, _ in EVIDENCE_CONTENTS]
+
+
+@pytest.fixture(scope="module")
+def ev(tmp_path_factory):
+    """name -> list of paths. Plus three entries that are NOT in
+    ``CONTENT_NAMES``, so adding them does not silently re-parametrize every
+    other test in this file:
+
+      "none"        nothing supplied at all
+      "missing"     a path that does not exist
+      "zero_bytes"  a file that exists and is empty
+
+    All three are absences and none of them is the same absence. "zero_bytes" is
+    the CI shape the set-extension pin below is written around: a shard whose
+    upload produced a file but no report. It is a distinct case from
+    ``unparsable`` (bytes that are not a report) and from ``missing`` (no file),
+    and the contract treats all three identically on purpose -- a source that
+    could not be read is a source that could not be read, and the module does not
+    special-case the empty one."""
+    d = tmp_path_factory.mktemp("evidence")
+    (d / "zero_bytes.xml").write_bytes(b"")
+    out = {"none": [], "missing": [str(d / "never_written.xml")],
+           "zero_bytes": [str(d / "zero_bytes.xml")]}
+    for name, text in EVIDENCE_CONTENTS:
+        p = d / f"{name}.xml"
+        p.write_bytes(text.encode("utf-8"))
+        out[name] = [str(p)]
+    return out
+
+
+TOUCHED = ("diff --git a/styxx/app.py b/styxx/app.py\n--- a/styxx/app.py\n"
+           "+++ b/styxx/app.py\n@@\n+def test_one(): pass\n")
+OUTSIDE = ("diff --git a/other/y.py b/other/y.py\n--- a/other/y.py\n"
+           "+++ b/other/y.py\n@@\n+y = 1\n")
+
+# Deliberately including rows whose baseline is already FAIL (a path lie, a
+# symbol lie, a count lie) and one whose baseline is UNMEASURED. Monotonicity
+# has to hold on the unhappy rows or it is a statement about the happy path
+# wearing the word "property".
+CASES = [
+    ("bare", "All tests pass.", TOUCHED),
+    ("with_a_true_path_claim", "Modified styxx/app.py. All tests pass.", TOUCHED),
+    ("with_a_path_lie", "This change only touches styxx/. All tests pass.", OUTSIDE),
+    ("with_a_symbol_lie", "Adds function nonexistent_helper. Tests pass.", TOUCHED),
+    ("with_a_count_lie", "3 files changed. All tests are passing.", TOUCHED),
+    ("many_claims", "Modified styxx/app.py, added 1 tests, adds function test_one. "
+                    "All tests pass.", TOUCHED),
+    ("repeated_claims", "All tests pass. All tests pass. All tests pass.", TOUCHED),
+    ("unreadable_diff", "All tests pass.", "Sorry, I could not produce a diff."),
+    ("no_tests_pass_claim", "Modified styxx/app.py.", TOUCHED),
+]
+
+
+def tp(g):
+    return [c for c in g.claims if c.kind == "tests_pass"]
+
+
+# ==================================================================== probes
+# Every marker's condition is a probe of the CURRENTLY LOADED module, so the
+# marker disarms itself when the defect it names is repaired, and strict=True
+# makes an unexplained pass a failure. All four probes are behavioural; the
+# run-branch probe falls back to a coarse source read only if the call raised,
+# and that overlap with the assertion it guards is disclosed rather than hidden.
+
+
+class _Stub:
+    """Stands in for subprocess.run so that no shell is ever spawned by this
+    file. `--run` passes shell=True with cwd set to the tree under test, and
+    executing that from a test suite is the code-execution path the module's own
+    CLI help now warns about at diffgate.py:936. This file reads it, never runs
+    it."""
+
+    def __init__(self, returncode=7, raises=None):
+        self.returncode, self.raises, self.calls = returncode, raises, 0
+
+    def __call__(self, *a, **kw):
+        self.calls += 1
+        if self.raises is not None:
+            raise self.raises
+        return types.SimpleNamespace(returncode=self.returncode, stdout="", stderr="")
+
+
+def _with_stub(stub, fn):
+    """Synchronous, always restored. Probes run at import where monkeypatch does
+    not exist yet, so the same helper serves both."""
+    real = D.subprocess.run
+    D.subprocess.run = stub
+    try:
+        return fn()
+    finally:
+        D.subprocess.run = real
+
+
+def _run_gate(rc=0, raises=None, summary="All tests pass.", **kw):
+    stub = _Stub(returncode=rc, raises=raises)
+    g = _with_stub(stub, lambda: gate_diff_text(summary, TOUCHED, run="pytest -q",
+                                                repo=".", **kw))
+    return g, stub
+
+
+def _probe_run_branch_accuses() -> bool:
+    try:
+        g, _ = _run_gate(rc=7)
+        return any(c.verdict == ACCUSE for c in tp(g))
+    except Exception:
+        return bool(run_branch_accusation_sites(inspect.getsource(D)))
+
+
+def _probe_run_executes_more_than_once() -> bool:
+    try:
+        _, stub = _run_gate(rc=0, summary="All tests pass.\nAll tests pass.\n"
+                                          "All tests pass.")
+    except Exception:
+        return True
+    return stub.calls > 1
+
+
+def _probe_timeout_escapes() -> bool:
+    try:
+        _run_gate(raises=subprocess.TimeoutExpired(cmd="pytest -q", timeout=1))
+    except Exception:
+        return True
+    return False
+
+
+def _probe_tests_pass_exempt_from_no_evidence() -> bool:
+    """The exemption at the old diffgate.py:357 (`no_evidence and kind !=
+    "tests_pass"`) let a claim escape the branch that says the gate had nothing
+    to read."""
+    try:
+        g = gate_diff_text("All tests pass.", "Sorry, I could not produce a diff.")
+        return any("carries no file statuses" not in c.why for c in tp(g))
+    except Exception:
+        return True
+
+
+EVIDENCE_WIRED = "evidence" in inspect.signature(gate_diff_text).parameters
+RUN_BRANCH_ACCUSES = _probe_run_branch_accuses()
+RUN_EXECUTES_PER_MATCH = _probe_run_executes_more_than_once()
+TIMEOUT_ESCAPES = _probe_timeout_escapes()
+TESTS_PASS_EXEMPT = _probe_tests_pass_exempt_from_no_evidence()
+
+owed_wiring = pytest.mark.xfail(not EVIDENCE_WIRED, strict=True, reason=(
+    "OWED: gate_diff_text takes no `evidence` parameter. Self-arming strict "
+    "xfail -- it disarms when the parameter appears, and an unexplained pass "
+    "before then is a FAILURE, not a quiet XPASS."))
+owed_run = pytest.mark.xfail(RUN_BRANCH_ACCUSES, strict=True, reason=(
+    "OWED: the DECISION of 2026-09-01 deletes the accusing half of the --run "
+    "branch. A nonzero exit still resolves to an accusation."))
+
+
+# ==============================================================================
+# THE TRIPWIRE -- the one thing the self-arming markers cannot do for themselves
+# ==============================================================================
+#
+# Every marker above is a LATCH: it arms on the defect it guards and disarms once
+# that defect is repaired. A latch cannot tell "not fixed yet" from "fixed, then
+# REGRESSED" -- both present as the defect being live, and in both cases the
+# marker absorbs its own tests into xfail and pytest exits 0.
+#
+# Demonstrated on 2026-09-01 by adversarial review: reintroducing the
+# TimeoutExpired defect this file was written to guard produced
+# "277 passed, 2 xfailed", exit 0, three runs running -- the regression rendered
+# as an OWED note. The four latches also explain the flip seen the same morning,
+# 230 xfailed -> 279 passed (owed_wiring 220 + owed_run 8 + per-match 1 +
+# timeout 1), when a concurrent rewrite disarmed all four at once.
+#
+# The module docstring's promise -- "there is no configuration under which a test
+# in this file is silently green" -- is only TRUE with this test present. Each
+# probe's repaired value is pinned below as a constant, so re-arming any latch
+# now reds the suite instead of quietly widening it.
+#
+# When a new owed defect is added, add its probe here with the value it is
+# expected to hold ONCE REPAIRED. That is what carries the repair forward.
+
+_PINNED_PROBES = {
+    "EVIDENCE_WIRED": True,
+    "RUN_BRANCH_ACCUSES": False,
+    "RUN_EXECUTES_PER_MATCH": False,
+    "TIMEOUT_ESCAPES": False,
+    "TESTS_PASS_EXEMPT": False,
+}
+
+
+def test_no_self_arming_marker_has_re_armed():
+    """A latch that re-arms is a REGRESSION, not an outstanding debt.
+
+    This is the only test in the file that fails when a REPAIRED defect comes
+    back. Every other guard on those four defects is behind a marker that arms
+    on exactly the condition it is meant to report.
+    """
+    observed = {name: globals()[name] for name in _PINNED_PROBES}
+    regressed = {n: v for n, v in observed.items() if v is not _PINNED_PROBES[n]}
+    assert not regressed, (
+        "a self-arming xfail marker has RE-ARMED, which means a repair that had "
+        "already landed has regressed. The markers cannot report this themselves "
+        "-- they absorb it into xfail and exit 0. Expected "
+        f"{ {n: _PINNED_PROBES[n] for n in regressed} }, observed {regressed}.")
+
+
+# ====================================== LIVE: the helpers are watched biting
+
+def _snippet(text: str) -> str:
+    return text.replace("@A@", ACCUSE)
+
+
+_MUTANT_REACHED = _snippet('''
+def _gate(run=None):
+    if run:
+        r = subprocess.run(run, shell=True)
+        c.verdict = "VERIFIED" if r.returncode == 0 else "@A@"
+''')
+
+_MUTANT_UNREACHED = _snippet('''
+def _gate(run=None):
+    """A branch nobody reaches today is a branch someone reaches after a
+    refactor. No output-level test can see this one."""
+    if run:
+        r = subprocess.run(run, shell=True)
+        if False and r.returncode != 0:
+            c.verdict = "@A@"
+        else:
+            c.verdict = "UNCHECKABLE"
+''')
+
+_MUTANT_FLAGGED = _snippet('''
+WITHHOLD_TESTS_PASS_ACCUSATION = True
+
+def _gate(run=None):
+    if run:
+        r = subprocess.run(run, shell=True)
+        if r.returncode != 0 and not WITHHOLD_TESTS_PASS_ACCUSATION:
+            c.verdict = "@A@"
+''')
+
+_MUTANT_OBSERVED = _snippet('''
+def _evidence_leg(ev):
+    observed = ev.get("observed") or {}
+    if observed.get("failing"):
+        return "@A@", "the attested report reads red"
+    return "UNCHECKABLE", "no"
+''')
+
+_MUTANT_KIND_SCOPED = _snippet('''
+def _gate():
+    for kind, rx in TEMPLATES:
+        if kind == "tests_pass":
+            if evidence_says_red:
+                c.verdict = "@A@"
+''')
+
+# Here the word appears only as prose about its own absence. A helper that fires
+# on this is a grep with extra steps, and would refuse the very paragraphs this
+# codebase writes to explain a deletion.
+_INNOCENT = _snippet('''
+def _run_leg(run, repo):
+    """The accusing verdict @A@ is DELETED here, not gated.
+
+    A nonzero returncode is not evidence that the author lied: it is also what
+    "no tests collected", a missing dependency and a flaky test produce.
+    """
+    r = subprocess.run(run, shell=True, cwd=repo)          # @A@ deleted
+    return ("VERIFIED", "exited 0") if r.returncode == 0 else ("UNCHECKABLE", "x")
+''')
+
+# The elif-chain shape that produced six false positives in the first draft of
+# `_guard_parts`. A path-claim accusation lives in an arm ABOVE the tests_pass
+# arm, and in the AST the tests_pass arm sits inside its `orelse` -- so a helper
+# that inspects whole enclosing statements rather than their guards reports it
+# as a tests_pass accusation. It is not one.
+_ELIF_CHAIN = _snippet('''
+def _gate():
+    for kind in kinds:
+        if kind == "only_touches":
+            c.verdict = "VERIFIED" if not outside else "@A@"
+        elif kind == "tests_pass":
+            c.verdict = tests_pass_leg()
+''')
+
+
+@pytest.mark.parametrize("label,src,helper", [
+    ("reached", _MUTANT_REACHED, run_branch_accusation_sites),
+    ("unreached-guard", _MUTANT_UNREACHED, run_branch_accusation_sites),
+    ("withheld-behind-a-flag", _MUTANT_FLAGGED, run_branch_accusation_sites),
+    ("report-only-band", _MUTANT_OBSERVED, observed_band_accusation_sites),
+    ("kind-scoped", _MUTANT_KIND_SCOPED, accusation_sites_under_tests_pass),
+])
+def test_the_source_helpers_detect_what_they_claim_to_detect(label, src, helper):
+    """Every structural assertion in this file is worth exactly what these
+    helpers are worth, so each is watched firing against a planted accusation
+    before it is trusted to report an absence.
+
+    Three of the five are shapes no output-level test can see: a branch behind
+    ``if False``, a branch behind a flag set to off, and an accusation invented
+    by a caller out of the report-only band. WITHHOLD_PATH_ACCUSATION is the
+    flag shape already in this repository, and PREREG_evidence_leg indicts it by
+    name -- flags get flipped by people who did not read the paper."""
+    assert helper(src), f"the {label} mutant went undetected"
+
+
+def test_the_helpers_do_not_fire_on_prose_explaining_the_absence():
+    """Mention is not use. ANALYSIS_base_rate_ceiling records this lab's own
+    certificate failing on exactly this distinction, and a checker that repeats
+    it would forbid the paragraphs that explain a deletion."""
+    assert run_branch_accusation_sites(_INNOCENT) == []
+    assert accusation_sites_under_tests_pass(_INNOCENT) == []
+    assert observed_band_accusation_sites(_INNOCENT) == []
+
+
+def test_the_kind_scoped_helper_does_not_blame_a_neighbouring_elif_arm():
+    """The false positive that the first draft of this file shipped, pinned so
+    it cannot come back. In the AST an ``elif`` arm nests inside the previous
+    arm's ``orelse``, so `tests_pass` is inside the SUBTREE of the
+    `only_touches` arm -- and a helper that reads whole enclosing statements
+    instead of their guards reports the path-claim accusation as a `tests_pass`
+    accusation. Six such reports against the shipped module."""
+    assert accusation_sites_under_tests_pass(_ELIF_CHAIN) == []
+    assert run_branch_accusation_sites(_ELIF_CHAIN) == []
+
+
+# ============================ LIVE: the caller-side hole styxx.evidence names
+
+def test_no_diffgate_path_maps_the_report_only_band_to_an_accusation():
+    """``styxx.evidence.selfcheck_no_accusation`` states its own boundary: it
+    "does not prove a caller has not invented an accusation of its own out of
+    the report-only `observed` band". diffgate is that caller, and this is the
+    caller-side counterpart -- the tripwire PREREG_evidence_leg's G-E6 was meant
+    to be, relocated to the file where such a branch would actually live."""
+    sites = observed_band_accusation_sites(inspect.getsource(D))
+    assert sites == [], f"diffgate turns the report-only band into a verdict: {sites}"
+
+
+def test_the_evidence_module_still_refuses_to_accuse():
+    """The cheapest way to wire this leg wrongly is to give styxx.evidence its
+    accusing verdict back and leave diffgate innocent. Its self-check is
+    re-derived here so this file fails if that happens."""
+    assert tuple(E.VERDICTS) == ("VERIFIED", "UNCHECKABLE"), E.VERDICTS
+    sc = E.selfcheck_no_accusation()
+    assert sc["ok"] is True, sc
+    assert sc["code_occurrences"] == []
+
+
+def test_diffgates_own_selfcheck_agrees_with_this_files_independent_read():
+    """SECONDARY, and deliberately not the primary. A module grading itself is
+    not evidence; the AST helpers above are this file's own instrument and the
+    assertions that matter run through them. What this adds is a disagreement
+    alarm: if the two readers ever diverge, one of them is wrong and both are
+    worth looking at."""
+    sc = D.selfcheck_tests_pass_never_accuses()
+    assert sc["ok"] is True, sc
+    assert sc["code_occurrences"] == [] and sc["band_reads"] == []
+    assert sc["missing"] == [], (
+        "the self-check names functions that no longer exist, so it is scanning "
+        f"nothing: {sc['missing']}")
+    assert tuple(D._TESTS_PASS_VERDICTS) == ("VERIFIED", "UNCHECKABLE")
+
+
+# ============================ LIVE: the baseline the property is measured against
+
+@pytest.mark.parametrize("label,summary,diff", CASES)
+@pytest.mark.parametrize("strict", [False, True])
+def test_without_evidence_tests_pass_is_uncheckable_and_says_why(label, summary,
+                                                                 diff, strict):
+    """With no report and no --run there is no execution evidence, and
+    UNCHECKABLE is the honest answer -- ANALYSIS_base_rate_ceiling section 10
+    counts 5,514 claims parked exactly there corpus-wide with an accusation
+    count of zero. This is the EMPTY-SET BASELINE that the guarantee below is
+    measured against -- the only baseline it is measured against; if it drifts,
+    that test is comparing against something else."""
+    g = gate_diff_text(summary, diff, strict=strict)
+    for c in tp(g):
+        assert c.verdict == "UNCHECKABLE", f"{label}: {c.verdict} -- {c.why}"
+        assert c.why, "an UNCHECKABLE verdict must say why"
+
+
+@pytest.mark.parametrize("label,summary,diff", CASES)
+def test_the_gate_never_takes_the_agents_word_for_a_test_result(label, summary, diff):
+    """The inverse failure of the accusation, and the one this module exists
+    against: believing "all tests pass" because it was written down."""
+    g = gate_diff_text(summary, diff)
+    for c in tp(g):
+        assert c.verdict != "VERIFIED", (
+            f"{label}: the gate certified a test result from prose alone")
+
+
+@pytest.mark.parametrize("label,summary,diff", CASES)
+def test_the_tests_pass_vocabulary_is_a_subset_of_evidence_VERDICTS(label, summary,
+                                                                    diff):
+    """Whatever diffgate says about a `tests_pass` claim must be a word
+    styxx.evidence would say. Two words. A wiring that invents a third has
+    invented an accusation under another name."""
+    g = gate_diff_text(summary, diff)
+    for c in tp(g):
+        assert c.verdict in set(E.VERDICTS), c.verdict
+
+
+def test_the_retired_why_string_is_gone():
+    """PREREG_evidence_leg committed to replacing "no --run command supplied",
+    which implied the remedy was to supply a shell string -- the one thing this
+    gate must not encourage against a branch you did not write. Strictly more
+    informative at an identical verdict, which is why it shipped ahead of any
+    measurement."""
+    g = gate_diff_text("All tests pass.", TOUCHED)
+    for c in tp(g):
+        assert "no --run command supplied" not in c.why
+        assert "--evidence" in c.why, (
+            "the reader has to be told which channel can answer this")
+
+
+# ================================================ LIVE/OWED: the --run branch
+
+@owed_run
+def test_the_run_branch_cannot_reach_an_accusation_in_the_source():
+    """THE structural one. DECISION of 2026-09-01: the accusing half of the
+    --run branch is DELETED, not withheld behind a flag, because
+    WITHHOLD_PATH_ACCUSATION is the counter-example this codebase already
+    carries and PREREG_evidence_leg indicts by name. Absence of a branch cannot
+    be toggled by someone in a hurry.
+
+    Asserted over the SOURCE. The behavioural companion below would pass on a
+    module carrying the branch behind ``if False`` or behind a flag set to off,
+    and both of those mutants are watched being caught above rather than here."""
+    sites = run_branch_accusation_sites(inspect.getsource(D))
+    assert sites == [], (
+        "the accusing verdict is reachable from a returncode comparison: "
+        f"{sites}. Its precision has never been measured by a blind panel on "
+        "either leg -- not extraction, not adjudication.")
+
+
+@owed_run
+def test_no_accusation_is_produced_anywhere_under_a_tests_pass_guard():
+    """Wider than the returncode form: any accusation produced under a
+    `tests_pass` guard, whatever supplies it."""
+    sites = accusation_sites_under_tests_pass(inspect.getsource(D))
+    assert sites == [], sites
+
+
+@owed_run
+@pytest.mark.parametrize("rc", [1, 4, 5, 127])
+def test_a_failing_run_command_does_not_accuse(rc):
+    """The behavioural companion, kept and explicitly INSUFFICIENT ALONE, and
+    the mutant sweep measured exactly how insufficient.
+
+    Restoring the accusing verdict inside `_run_leg` -- reached (M1), unreached
+    (M2), or behind a flag set to off (M3) -- changes no output at all, because
+    `_tests_pass_verdict` folds the leg's answer with a promote-to-VERIFIED-only
+    rule and the `_TESTS_PASS_VERDICTS` clamp rewrites anything else. Removing
+    the accusing branch AND the fold still changes nothing (M16). Only M17,
+    which removes all three layers, makes this test go red. So against today's
+    module it is unfalsifiable by any single-edit mutant: it is a regression
+    guard for the refactor that flattens those layers, not evidence of anything
+    now. The structural test above is the one that bites, on all five.
+
+    The exit codes are chosen, not arbitrary: pytest rc=5 is "no tests
+    collected", rc=4 a usage error, 127 a misspelled command. Each was read as a
+    lie by the shipped code, which is the whole argument -- a nonzero exit is a
+    fact about a process, and on an untrusted branch it is a process the author
+    controls in both directions from their own conftest.py."""
+    g, _ = _run_gate(rc=rc)
+    for c in tp(g):
+        assert c.verdict != ACCUSE, f"rc={rc} produced an accusation: {c.why}"
+    assert g.verdict == "PASS", f"rc={rc} failed the build on an unmeasured verdict"
+
+
+@owed_run
+def test_the_why_for_a_nonzero_exit_names_what_else_produces_one():
+    """A verdict that declines has to say why in terms a reader can act on. The
+    DECISION pins the sentence: a nonzero exit is also what "no tests
+    collected", a misspelled command, a missing dependency and a flaky test
+    produce."""
+    g, _ = _run_gate(rc=5)
+    whys = [c.why.lower() for c in tp(g)]
+    assert whys
+    for why in whys:
+        assert "exited 5" in why, "the exit code belongs in the record"
+        assert any(k in why for k in ("no tests collected", "misspelled",
+                                      "missing dependency", "flaky")), why
+
+
+@owed_run
+def test_a_run_that_exits_zero_verifies_but_may_not_claim_the_tests_passed():
+    """VERIFIED survives on evidence.py's stated asymmetry -- a wrong VERIFIED
+    repeats a claim the author already made in prose, a wrong accusation attacks
+    a stranger inside their own pull request. The disclosed defect rides with
+    it: the same extraction that fires on "Not all tests pass." would stamp
+    VERIFIED on a sentence asserting the opposite, so the why-string is required
+    to disclaim rather than to be trusted."""
+    g, _ = _run_gate(rc=0)
+    claims = tp(g)
+    assert claims
+    for c in claims:
+        assert c.verdict == "VERIFIED"
+        assert "exited 0" in c.why
+        low = c.why.lower()
+        # A disjunction over phrasings rather than one pinned sentence: what is
+        # load-bearing is that the record disclaims, not which words it uses.
+        assert any(k in low for k in ("does not mean the tests passed",
+                                      "not a statement about the suite",
+                                      "checks nothing about the sentence")), c.why
+        assert any(k in low for k in ("checkbox", "negation", "quotation")), (
+            "the disclosed extraction defect has to ride with the verdict: this "
+            "template fires on unchecked PR-template boxes and on negations, so "
+            "a VERIFIED can attach to a sentence asserting the opposite")
+
+
+@pytest.mark.xfail(RUN_EXECUTES_PER_MATCH, strict=True, reason=(
+    "OWED: the command runs once per REGEX MATCH rather than once per gate. A "
+    "body repeating the sentence is unbounded, author-controlled runner-hour "
+    "amplification -- each launch carrying its own 1800s budget."))
+def test_the_run_command_executes_at_most_once_per_gate():
+    _, stub = _run_gate(rc=0, summary="All tests pass.\nAll tests pass.\n"
+                                      "All tests pass.")
+    assert stub.calls <= 1, f"{stub.calls} executions for one gate invocation"
+
+
+@pytest.mark.xfail(TIMEOUT_ESCAPES, strict=True, reason=(
+    "OWED: subprocess.TimeoutExpired propagates uncaught out of _gate. A "
+    "traceback is not a verdict."))
+def test_a_run_timeout_is_uncheckable_not_a_traceback():
+    g, _ = _run_gate(raises=subprocess.TimeoutExpired(cmd="pytest -q", timeout=1800))
+    claims = tp(g)
+    assert claims
+    for c in claims:
+        assert c.verdict == "UNCHECKABLE"
+        assert c.why
+
+
+def test_run_with_no_repo_refuses_rather_than_running_in_the_verifiers_own_tree():
+    """The quiet defect on the zero-receipt path: gate_diff_text takes repo=None
+    by default and subprocess.run(cwd=None) executes wherever the verifier
+    happens to be standing. The one entry point built for having no checkout was
+    the one where cwd silently became the operator's own tree."""
+    stub = _Stub(returncode=0)
+    g = _with_stub(stub, lambda: gate_diff_text("All tests pass.", TOUCHED,
+                                                run="pytest -q"))
+    assert stub.calls == 0, "the command was executed with no repository to run it in"
+    for c in tp(g):
+        assert c.verdict == "UNCHECKABLE"
+        assert "verifier" in c.why.lower() or "cwd" in c.why.lower()
+
+
+@pytest.mark.xfail(TESTS_PASS_EXEMPT, strict=True, reason=(
+    "OWED: the `and kind != \"tests_pass\"` exemption lets a tests_pass claim "
+    "escape the branch that says the gate had nothing to read."))
+def test_a_diff_that_parsed_to_nothing_leaves_every_claim_unread():
+    """DECISION repair 1. With input that parsed to nothing the gate reports
+    measured=False, and no claim -- `tests_pass` included -- may be resolved
+    against evidence the gate does not have.
+
+    A tension worth recording rather than hiding: a test report is arguably
+    independent of whether the DIFF was readable, so it is defensible for
+    --evidence to answer here. The shipped module says no, the DECISION's
+    repair 1 says no, and this pins the shipped reading. Whoever changes it
+    should change this test deliberately."""
+    g = gate_diff_text("All tests pass.", "Sorry, I could not produce a diff.")
+    assert g.measured is False
+    for c in g.claims:
+        assert c.verdict == "UNCHECKABLE"
+        assert g.why_unmeasured in c.why or "carries no file" in c.why
+
+
+# ============================================= LIVE/OWED: the evidence wiring
+
+@owed_wiring
+def test_a_supporting_report_moves_tests_pass_off_uncheckable(ev):
+    g = gate_diff_text("Modified styxx/app.py. All tests pass.", TOUCHED,
+                       evidence=ev["green"])
+    claims = tp(g)
+    assert claims, "the claim must still be extracted"
+    for c in claims:
+        assert c.verdict == "VERIFIED", f"{c.verdict} -- {c.why}"
+    assert g.verdict == "PASS"
+
+
+@owed_wiring
+@pytest.mark.parametrize("name", CONTENT_NAMES + ["missing"])
+def test_the_verdict_is_the_adjudicators_verdict_not_a_second_opinion(ev, name):
+    """The gate may not re-derive an answer styxx.evidence already gave. Same
+    bytes, same verdict -- otherwise there are two adjudicators and only one of
+    them has a docstring saying what VERIFIED does not mean."""
+    want, _ = adjudicate_tests_pass(load_evidence(ev[name]), None)
+    g = gate_diff_text("All tests pass.", TOUCHED, evidence=ev[name])
+    claims = tp(g)
+    assert claims
+    for c in claims:
+        assert c.verdict == want, f"{name}: gate {c.verdict}, evidence {want}"
+
+
+@owed_wiring
+@pytest.mark.parametrize("name", CONTENT_NAMES + ["missing"])
+def test_the_adjudicators_reason_is_preserved_verbatim(ev, name):
+    """A paraphrase is a second opinion wearing the first one's clothes. The
+    reason the reader acts on has to be the one styxx.evidence wrote -- the
+    string that says an all-skipped suite is not a green run, or that a partial
+    read is a guess with a citation. diffgate may add context around it; it may
+    not restate it."""
+    _, want_why = adjudicate_tests_pass(load_evidence(ev[name]), None)
+    g = gate_diff_text("All tests pass.", TOUCHED, evidence=ev[name])
+    for c in tp(g):
+        assert want_why in c.why, (
+            f"{name}: the adjudicator's reason was paraphrased away:\n"
+            f"  gate:     {c.why}\n  evidence: {want_why}")
+
+
+@owed_wiring
+def test_a_supporting_report_is_not_read_as_the_tests_passed(ev):
+    """VERIFIED means an attestation reports PASSED and no signature was
+    checked. It does not mean the tests passed, and it says nothing about
+    whether the sentence extracted was a claim at all -- 179 corpus-wide
+    `tests_pass` extractions sit inside an UNCHECKED PR-template box where the
+    author is explicitly declining to assert."""
+    g = gate_diff_text("All tests pass.", TOUCHED, evidence=ev["green"])
+    for c in tp(g):
+        low = c.why.lower()
+        assert "no signature was checked" in low or "not mean the tests passed" in low, \
+            c.why
+
+
+@owed_wiring
+def test_no_report_supplied_leaves_it_uncheckable_and_names_the_channels(ev):
+    """"--evidence with no report" has two readings and they are different
+    absences. Nothing supplied at all is answered by the gate's own named
+    reason; a path that does not exist is answered by the adjudicator, and that
+    case is covered by the reason-preserved test above."""
+    g = gate_diff_text("All tests pass.", TOUCHED, evidence=ev["none"])
+    claims = tp(g)
+    assert claims
+    for c in claims:
+        assert c.verdict == "UNCHECKABLE"
+        assert c.why, "an UNCHECKABLE verdict must say why"
+        assert "no --run command supplied" not in c.why
+        assert "--evidence" in c.why
+        assert "no accusing verdict" in c.why.lower(), (
+            "the absence of the third word is part of the answer, not trivia")
+
+
+@owed_wiring
+@pytest.mark.parametrize("name", CONTENT_NAMES + ["none", "missing"])
+@pytest.mark.parametrize("strict", [False, True])
+@pytest.mark.parametrize("commit", [None, HEAD_COMMIT, OTHER_COMMIT])
+def test_no_evidence_content_can_produce_an_accusation(ev, name, strict, commit):
+    """By any route, for any content, at any commit, strict and not.
+
+    `red`, `collection_error` and `forged_failed` are the readings where the
+    evidence looks unambiguously bad, and `forged_failed` is an accusation
+    against a named commit that costs one hand-written JSON file and no key
+    material. None may become a verdict against the author. There is no
+    sub-population of evidence contents on which this relaxes."""
+    g = gate("Modified styxx/app.py. All tests pass.", TOUCHED,
+             evidence=ev[name], commit=commit, strict=strict)
+    for c in tp(g):
+        assert c.verdict != ACCUSE, f"{name}/{commit}: {c.why}"
+        assert c.verdict in set(E.VERDICTS), c.verdict
+
+
+@owed_wiring
+@pytest.mark.parametrize("label,summary,diff", CASES)
+@pytest.mark.parametrize("name", CONTENT_NAMES + ["missing"])
+@pytest.mark.parametrize("strict", [False, True])
+def test_adding_evidence_never_worsens_the_gate_against_no_evidence(
+        ev, label, summary, diff, name, strict):
+    """THE LOAD-BEARING ONE, AND IT IS THE WEAKER OF THE TWO READINGS.
+
+    RENAMED AND RESCOPED on 2026-09-01. This test shipped as
+    ``test_adding_evidence_never_worsens_the_gate_verdict``, and under that name
+    it was read as establishing that evidence never worsens a verdict FULL STOP.
+    It never measured that and it never could: the only baseline it compares
+    against is the EMPTY evidence set. The body is unchanged and correct. The
+    name and the docstring were the defect, and they are corrected here rather
+    than deleted, because the record of what a green test was taken to mean is
+    part of what the test is for.
+
+    WHAT IS ASSERTED. Over every claim combination, every evidence content and
+    both strictness settings: the gate handed evidence ranks no worse than the
+    same gate handed NONE -- at the overall verdict, and at every single claim.
+    Evidence may move a `tests_pass` claim UPWARD, from UNCHECKABLE to VERIFIED.
+    Relative to supplying nothing it may never move a claim downward, and it may
+    never turn a would-have-been PASS into a FAIL.
+
+    WHAT IS NOT ASSERTED, and is FALSE:
+    ``E -> E union {x}`` never worsens. It can and it does, deliberately, and
+    ``test_extending_an_evidence_set_can_demote_verified_and_must`` pins that so
+    the two are never again read off one report line.
+
+    This is what makes the leg safe to ship before Panel A exists: an adjudicator
+    that can only resolve upward FROM THE NO-EVIDENCE BASELINE cannot manufacture
+    an accusation however wrong the extraction feeding it is -- and that
+    extraction carries a mechanical non-assertion indicator on 6.27% of matches,
+    with the other 83% unmeasured. Whether such a match is a WRONG extraction is
+    Panel A's question, not the census's, and Panel A has not been run.
+
+    `_gate` argues this invariant in a comment. A comment is not a receipt."""
+    base = gate_diff_text(summary, diff, strict=strict)
+    with_ev = gate_diff_text(summary, diff, evidence=ev[name], strict=strict)
+
+    assert GATE_RANK[with_ev.verdict] <= GATE_RANK[base.verdict], (
+        f"{label}+{name}+strict={strict}: {base.verdict} -> {with_ev.verdict}")
+    assert [c.kind for c in with_ev.claims] == [c.kind for c in base.claims], (
+        "evidence added or removed claims; it is an adjudicator, not an extractor")
+    for a, b in zip(base.claims, with_ev.claims):
+        assert CLAIM_RANK[b.verdict] <= CLAIM_RANK[a.verdict], (
+            f"{label}+{name}: {a.kind} {a.verdict} -> {b.verdict} ({b.why})")
+    assert with_ev.measured == base.measured, (
+        "evidence about tests cannot make a diff readable or unreadable")
+
+
+# The grid for the pin below. Each row is an addition to an already-VERIFIED
+# evidence set, paired with the mechanism by which the contract refuses to keep
+# affirming once it is present. `demotes=False` rows are NEGATIVE CONTROLS and
+# are as load-bearing as the rest: a rule that demoted on any addition at all
+# would be counting files rather than reading them, and would be indistinguishable
+# from the real rule on a grid made only of demoting rows.
+SET_EXTENSIONS = [
+    # name,             demotes, mechanism
+    ("zero_bytes",      True,  "a file that exists and holds no report"),
+    ("missing",         True,  "a shard whose upload never arrived"),
+    ("unparsable",      True,  "bytes that are neither XML nor JSON"),
+    ("red",             True,  "a second source that disagrees (FAILED, PASSED)"),
+    ("forged_failed",   True,  "a hand-written FAILED attestation, no key material"),
+    ("collection_error", True, "a harness error: the runner broke, nothing lied"),
+    ("empty",           False, "a well-formed zero-test report: parses, adds nothing"),
+]
+
+
+@owed_wiring
+@pytest.mark.parametrize("name,demotes,mechanism", SET_EXTENSIONS)
+@pytest.mark.parametrize("strict", [False, True])
+def test_extending_an_evidence_set_can_demote_verified_and_must(
+        ev, name, demotes, mechanism, strict):
+    """THE PIN. THIS TEST GOING RED MEANS THE SAFETY RULE WAS WEAKENED.
+
+    Read this before you "fix" anything it reports.
+
+    Adding evidence to an evidence set that already resolved VERIFIED can move
+    that claim back to UNCHECKABLE, and under --strict can move the gate from
+    PASS to FAIL. That is NOT a monotonicity bug. It is the contract's central
+    rule, and this test exists so that the rule cannot be quietly removed by
+    someone who read the sibling test's name -- "never worsens" -- as a promise
+    that this could not happen.
+
+    THE RULE: a partial read may honestly DECLINE, but it may not honestly
+    AFFIRM. VERIFIED on a `tests_pass` claim asserts that the evidence in hand
+    says every test passed. If one of the supplied sources could not be read,
+    the evidence in hand is a subset of the evidence that was offered, and no
+    subset licenses a statement about the whole. You cannot certify "all tests
+    pass" from nine shards out of ten, and the tenth shard is exactly where a
+    real CI failure hides -- an upload that timed out, a runner that OOMed, a
+    matrix leg that never started. Affirming from an incomplete evidence set is
+    the single failure this module was built to refuse. The same reasoning
+    covers the sources that DID parse and disagree: refusing beats picking, and
+    refusing beats taking the union.
+
+    HOW SOMEONE BREAKS THIS. Not maliciously -- by seeing a green run demoted to
+    UNCHECKABLE by one junk file, calling it a regression, and making the
+    adjudicator skip sources it cannot read, or treat an empty file as "no
+    evidence supplied", or take the best available reading. Each of those turns
+    "I read everything and it all passed" into "I read what I could and what I
+    could read passed", which is a different sentence with the same word on it.
+    If this test is red, that is what changed. The repair is to revert it. If
+    you believe the rule itself is wrong, that is a preregistration and a panel,
+    not a patch.
+
+    WHAT IS MEASURED, because a pin that asserts nothing pins nothing: the
+    baseline `[green]` is confirmed VERIFIED and PASS first -- otherwise a module
+    that had stopped affirming altogether would pass this test trivially -- and
+    then each addition is checked against the direction recorded in
+    ``SET_EXTENSIONS``. 12 of the 14 (addition x strictness) cells demote; the 2
+    that do not are the well-formed zero-test report, which parses and adds
+    nothing, and it is in the grid to show the rule reads sources rather than
+    counting them."""
+    base = gate_diff_text("All tests pass.", TOUCHED, evidence=ev["green"],
+                          strict=strict)
+    base_claims = tp(base)
+    assert base_claims, "no tests_pass claim was extracted; the grid measures nothing"
+    assert all(c.verdict == "VERIFIED" for c in base_claims), (
+        "the baseline of this test is a green report resolving VERIFIED. It did "
+        f"not: {[(c.verdict, c.why) for c in base_claims]}. Until that is true "
+        "again this test cannot say anything about set extension.")
+    assert base.verdict == "PASS", base.verdict
+
+    ext = gate_diff_text("All tests pass.", TOUCHED,
+                         evidence=ev["green"] + ev[name], strict=strict)
+    ext_claims = tp(ext)
+    assert [c.kind for c in ext.claims] == [c.kind for c in base.claims], (
+        "extending the evidence set added or removed claims; the adjudicator "
+        "reached the extractor")
+
+    for c in ext_claims:
+        assert c.verdict != ACCUSE, (
+            f"{name}: extending the evidence set produced an accusation. The "
+            "demotion this test pins is VERIFIED -> UNCHECKABLE and stops "
+            f"there. {c.why}")
+
+    if demotes:
+        assert all(c.verdict == "UNCHECKABLE" for c in ext_claims), (
+            f"SAFETY RULE WEAKENED. Adding {name} ({mechanism}) to a green "
+            "evidence set left the `tests_pass` claim at "
+            f"{[c.verdict for c in ext_claims]}, so the gate is now certifying "
+            "'all tests pass' from an evidence set it did not fully read. A "
+            "partial read may DECLINE; it may not AFFIRM. This is not a "
+            "monotonicity bug to be fixed -- see this test's docstring. If the "
+            "adjudicator was changed to skip unreadable sources, or to special-"
+            "case empty files, or to take the best available reading, revert it.")
+        if strict:
+            assert ext.verdict == "FAIL", (
+                f"SAFETY RULE WEAKENED. Under --strict, {name} ({mechanism}) "
+                "demoted the claim but the gate still reported "
+                f"{ext.verdict}. A --strict gate that passes on an UNCHECKABLE "
+                "`tests_pass` claim has made strictness decorative.")
+        assert any(c.why != b.why for c, b in zip(ext_claims, base_claims)), (
+            "the verdict moved and the reason did not; the reader is not being "
+            "told which source could not be read")
+    else:
+        assert all(c.verdict == "VERIFIED" for c in ext_claims), (
+            f"NEGATIVE CONTROL FAILED. Adding {name} ({mechanism}) demoted the "
+            f"claim to {[c.verdict for c in ext_claims]}. This source parses "
+            "cleanly and contributes no failure, so nothing about it makes the "
+            "read partial. A rule that demotes here is counting files rather "
+            "than reading them, and the demotions this test pins would then be "
+            "evidence of nothing.")
+        assert ext.verdict == base.verdict, (ext.verdict, base.verdict)
+
+
+@owed_wiring
+@pytest.mark.parametrize("name", CONTENT_NAMES)
+@pytest.mark.parametrize("commit", [None, HEAD_COMMIT, OTHER_COMMIT])
+def test_evidence_never_worsens_the_run_leg_either(ev, name, commit):
+    """The two channels are a disjunction, and the dangerous direction is the
+    one where requiring BOTH would let adding a report turn a --strict PASS into
+    a --strict FAIL. Measured against the NO-EVIDENCE baseline -- a green --run
+    with nothing supplied on the evidence channel -- and so this is the run-leg
+    instance of the guarantee that holds, not of the set-extension property that
+    does not. Adding a SECOND report to a report already in hand is the pin
+    above; adding a first one to a green run is this."""
+    base, _ = _run_gate(rc=0, strict=True)
+    with_ev = _with_stub(_Stub(returncode=0), lambda: gate(
+        "All tests pass.", TOUCHED, run="pytest -q", repo=".",
+        evidence=ev[name], commit=commit, strict=True))
+    assert GATE_RANK[with_ev.verdict] <= GATE_RANK[base.verdict], (
+        f"{name}/{commit}: adding a report broke a green run")
+    for a, b in zip(base.claims, with_ev.claims):
+        assert CLAIM_RANK[b.verdict] <= CLAIM_RANK[a.verdict], (a.verdict, b.verdict)
+
+
+@owed_wiring
+@pytest.mark.parametrize("name", CONTENT_NAMES)
+def test_evidence_does_not_touch_any_other_claim_kind(ev, name):
+    """A test report says nothing about whether the diff touched the file the
+    summary named. If any non-`tests_pass` verdict or reason moves, the wiring
+    has reached somewhere it was not invited."""
+    summary = ("Modified styxx/app.py, added 1 tests, adds function test_one. "
+               "This change only touches styxx/. All tests pass.")
+    base = gate_diff_text(summary, TOUCHED)
+    with_ev = gate_diff_text(summary, TOUCHED, evidence=ev[name])
+    a = [(c.kind, c.verdict, c.why) for c in base.claims if c.kind != "tests_pass"]
+    b = [(c.kind, c.verdict, c.why) for c in with_ev.claims if c.kind != "tests_pass"]
+    assert a == b
+
+
+@owed_wiring
+def test_a_commit_the_evidence_does_not_name_stays_uncheckable(ev):
+    """The commit has to reach the adjudicator or `--evidence-commit` is
+    decoration. A green report that never names the change under review is a
+    green report about something else -- and a report from another branch, or
+    from last week, is the exact hazard styxx.evidence's binding section exists
+    for."""
+    want_verdict, want_why = adjudicate_tests_pass(
+        load_evidence(ev["green"]), OTHER_COMMIT)
+    assert want_verdict == "UNCHECKABLE"
+    g = gate("All tests pass.", TOUCHED, evidence=ev["green"],
+             commit=OTHER_COMMIT)
+    claims = tp(g)
+    assert claims
+    for c in claims:
+        assert c.verdict == "UNCHECKABLE", c.why
+        assert want_why in c.why
+
+
+@owed_wiring
+def test_evidence_is_deterministic_over_the_same_bytes(ev):
+    """styxx.evidence is a pure function of bytes and the wiring may not smuggle
+    ambient state in around it. Same inputs, same record, twice."""
+    a = gate_diff_text("All tests pass.", TOUCHED, evidence=ev["green"]).to_dict()
+    b = gate_diff_text("All tests pass.", TOUCHED, evidence=ev["green"]).to_dict()
+    assert a == b
+
+
+@owed_wiring
+def test_the_evidence_leg_runs_once_per_gate_not_once_per_match(ev):
+    """Same repair as the --run leg, and the same reason: every `tests_pass`
+    match in one summary asks the same question about the same suite. Counted
+    by intercepting the loader rather than by reading the code."""
+    calls = {"n": 0}
+    real = E.load_evidence
+
+    def counting(paths):
+        calls["n"] += 1
+        return real(paths)
+
+    D_ev = D.styxx.evidence if hasattr(D, "styxx") else E
+    E.load_evidence = counting
+    try:
+        gate_diff_text("All tests pass.\nAll tests pass.\nAll tests pass.",
+                       TOUCHED, evidence=ev["green"])
+    finally:
+        E.load_evidence = real
+    assert D_ev is E
+    assert calls["n"] <= 1, f"{calls['n']} evidence reads for one gate invocation"
+
+
+@owed_wiring
+def test_it_uses_styxx_evidence_not_a_private_copy():
+    """Asserted by source inspection, the way ``tests/test_undeclared.py``
+    asserts reconcile parses the diff with the gate's own parser rather than a
+    second one that can drift.
+
+    Here the drift would be worse than a disagreement about diffs: a private
+    reader of JUnit or in-toto bytes inside diffgate would be a reader with no
+    ``VERDICTS`` tuple, no self-check, and no docstring saying what VERIFIED
+    does not mean."""
+    src = inspect.getsource(D)
+    assert "from styxx.evidence import" in src, (
+        "diffgate does not import styxx.evidence")
+    assert "adjudicate_tests_pass" in src and "load_evidence" in src, (
+        "diffgate does not call the adjudicator; it has an opinion of its own")
+
+    tree = ast.parse(src)
+    imported = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported.update(a.name.split(".")[0] for a in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imported.add(node.module.split(".")[0])
+    assert "xml" not in imported, (
+        "diffgate parses XML itself; that is a second evidence reader")
+
+    # Identifiers only -- prose constants legitimately mention in-toto and JUnit,
+    # and a substring grep over the whole file would refuse the paragraphs that
+    # explain the delegation.
+    names = {n.attr for n in ast.walk(tree) if isinstance(n, ast.Attribute)}
+    names |= {n.id for n in ast.walk(tree) if isinstance(n, ast.Name)}
+    for smell in ("fromstring", "ElementTree", "predicateType", "failedTests",
+                  "passedTests", "testsuite", "observed"):
+        assert smell not in names, (
+            f"diffgate appears to read evidence bytes itself ({smell!r}); that "
+            "is a second adjudicator, and only one of them has a self-check")
+
+
+@owed_wiring
+def test_the_cli_exposes_the_evidence_channel_and_warns_about_the_other_one():
+    """A library-only wiring is a wiring nobody uses. And the CLI is where the
+    module advertises `--run`, which on an untrusted pull request is arbitrary
+    code execution against the tree under test -- pytest imports the PR's
+    conftest.py at collection, `npm test` runs the PR's package.json, and
+    os.environ is inherited unscrubbed."""
+    sig = inspect.signature(gate_diff_text).parameters
+    assert "evidence" in sig
+    assert _COMMIT_KW is not None, (
+        "no commit-binding parameter: a green report from another branch, or "
+        "from last week, would answer for this change")
+    # Exact option strings, not substrings. A substring check passed a mutant
+    # that renamed the flag to `--evidenceX`, because "--evidence" is a prefix of
+    # it -- the same mention/use sloppiness this file exists to avoid, committed
+    # by this file. Found by mutant M23.
+    src = inspect.getsource(D.main)
+    tree = ast.parse(src)
+    helps = {}
+    for n in ast.walk(tree):
+        if (isinstance(n, ast.Call) and isinstance(n.func, ast.Attribute)
+                and n.func.attr == "add_argument" and n.args
+                and isinstance(n.args[0], ast.Constant)):
+            kw = {k.arg: k.value for k in n.keywords}
+            h = kw.get("help")
+            helps[n.args[0].value] = (h.value if isinstance(h, ast.Constant)
+                                      and isinstance(h.value, str) else "")
+    assert "--evidence" in helps, sorted(helps)
+    assert set(helps) & {"--evidence-commit", "--commit"}, sorted(helps)
+    assert "--run" in helps, sorted(helps)
+    # Scoped to --run's OWN help. A whole-source search for "executes" was
+    # satisfied by --evidence's help saying it "executes nothing", so a mutant
+    # that stripped the warning off --run passed. Found by mutant M23b.
+    run_help = helps["--run"].lower()
+    assert "execut" in run_help, (
+        "--run's own help must say out loud that it runs a shell command: on an "
+        "untrusted pull request that is code execution against the tree under "
+        f"test. Got: {helps['--run']!r}")
+    assert "never an accusation" in run_help or "uncheckable" in run_help, (
+        "--run's help must say which verdicts it can produce, because the one "
+        "it cannot produce is the whole point")


### PR DESCRIPTION
Every precision this lab has published answers *"given a claim was extracted, was the verdict right?"* None answers the question before it: **given the detector fired, was a claim being made at all?**

`RESULT_v14...md` is 84 lines and the word **extraction** appears in it zero times. That is how a shortfall from a 0.95 floor to **0.16** came to be published as unexplained.

Write it `P = E x A`. Three repair cycles were spent on `A`. `E` has never been measured on the class that shipped an accusation.

## Two preregistrations, both pre-committed in both directions

**`closed-model-frontier`** — re-asks the question of the **already-sealed** V14 130-item packet (100 accusations + 30 decoys, key digest committed before judging, published as #43). No new sample is drawn, so no sampling degree of freedom exists.

| observed E | verdict, fixed now |
|---|---|
| `E <= 0.23` | SUPPORTED — the adjudicator was sound; three repair cycles worked the wrong layer |
| `E >= 0.40` | REFUTED — extraction exculpates nothing and 0.16 stays unexplained |
| between | INDETERMINATE — no narrative is built on it |

Reconciliation obligation: `upheld / scored` must re-derive 0.16 or the run is VOID, not adjusted.

**`disjoint-worlds`** — the same question of the cross-model read. `read_top1` is an index-matched `argmin` over held-out target centroids, so the truth sits in the candidate array with probability 1. There is no threshold and no reject option: **E = 1 by construction** on every trial those scripts have ever run, and the published read figures are therefore A-terms. `E` itself comes back **UNCHECKABLE** — the candidate pool was never committed as an artifact, so no survival ratio exists. That is a verdict, not a failure, and not a claim that the ratio is low.

## What these documents do NOT license

The `tests_pass` census counts are **CONTAINMENT** figures — they record where a match *sits*, not whether the extraction was *wrong*. Whether an unticked task box makes an extraction wrong is precisely what is preregistered here, so no share of matches may be called "not assertions" until a panel answers.

The read census likewise refuses a number that would have flattered the thesis: a 0.9935 dedup-survival ratio is explicitly forbidden as `E`, because "the literal is the OUTPUT of the selection, not its input."

Also included: `4c90d9c` wires the evidence leg into the gate and deletes the `--run` accusation, plus a regression tripwire pinning the five self-arming probes — a latch that re-arms is a regression, and the latches cannot report that themselves.

Ledger rebuilt. Full suite **3180 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
