### PR TITLE
negative result: the core's summaries do not diverge from its spans

### DIFF
--- a/papers/sworn/NOTE_summary_faithfulness_negative_2026_09_06.md
+++ b/papers/sworn/NOTE_summary_faithfulness_negative_2026_09_06.md
@@ -1,0 +1,67 @@
+# NOTE — the core's summaries do not diverge from its spans (negative result)
+
+*2026-09-06. Records a hypothesis that was tested and failed. Nothing here is a defect report.*
+
+## The hypothesis
+
+Several findings in the sidecar-battery leg looked like one shape: **a summary field and a detail
+field that can disagree, with nothing checking the summary is faithful to its details.** If that
+shape were general, the verdict core would be the place to find more of it — it carries five
+summaries over its span table (`counts`, `sworn_total`, `unresolved`, `document_verdict`, `rungs`),
+and every reader acts on those rather than on the spans underneath.
+
+Stated as a check: for each summary field, recompute it from `core["spans"]` alone and compare.
+
+## What was run
+
+The differential harness's seeded grammar, seed `20260906`, indices 0–3999. Each generated document
+was verified; documents the verifier refuses have no summaries and were skipped. Every summary field
+of every resulting core was recomputed from its spans and compared.
+
+    documents checked: 4000 of 4000 generated
+    every summary field follows from its spans, on all 4000.
+
+## The result
+
+**Negative. No divergence in any field, in any of 4000 cases.** The hypothesis is wrong in the form
+it was stated: the class of defect it predicted does not exist inside the verdict core.
+
+## What that corrects
+
+The generalisation was too broad, and the corrected reading is narrower. Re-examined, the leg's
+actual findings were not summaries diverging from details:
+
+| finding | what it actually was |
+| --- | --- |
+| rounding: `receipt=0.4211`, `receipt_rounded=0`, verdict HELD | the verdict is *faithful* to its comparison — `detail` honestly records that it compared against 0. The question is whether that comparison should be made, which is a semantics decision, still operator-gated. |
+| `check` printing VERIFIED on a SWORN-FAILED document | CLI presentation. The receipt re-derives; the document did not hold. Two different questions, one word. |
+| the `load_sidecar` / `render` gap | across two artifacts — one validated, a different one consumed. |
+
+The shape those share is **artifact A validated, artifact B consumed**, not a broken summary
+function. That is a narrower and more useful description, and it is the one to carry forward.
+
+## What was kept
+
+`tests/test_sworn_core_is_faithful_to_its_spans.py`, which pins the property as a standing check
+over 1500 generated documents. It is kept because nothing else states the property, **not** because
+it caught anything — it has never caught a real defect and may never.
+
+Its claim is deliberately modest, and the test says so in its own docstring: it checks that the
+summaries agree with the span table shipped in the same core. It does not independently verify the
+adjudication rules — `_recompute` restates the rules in `verify`, so if both are wrong in the same
+way it passes.
+
+Watched to fail before it was kept, against two mutations of `styxx/sworn.py`:
+
+| mutation | result |
+| --- | --- |
+| `"spans": verdicts[1:]` — summaries tallied from a list the reader is not given | 5 of 5 fields fail |
+| ladder drops `counts["MALFORMED"] == 0`, so a malformed span no longer fails the document | `document_verdict` alone fails; the other 4 pass |
+
+The second is the more useful demonstration: the guard fires on exactly the field that broke, so it
+localises the defect rather than only reporting that something moved.
+
+## Standing
+
+Negative results are cheap to omit and expensive to lose — the omission is what makes a corpus look
+like it only ever confirms its author. This one is recorded at the same prominence as a finding.

--- a/tests/test_sworn_core_is_faithful_to_its_spans.py
+++ b/tests/test_sworn_core_is_faithful_to_its_spans.py
@@ -1,0 +1,136 @@
+"""Every summary in the verdict core agrees with the span table shipped in that same core.
+
+WHY THIS EXISTS. The core carries five summaries over its spans — `counts`, `sworn_total`,
+`unresolved`, `document_verdict` and `rungs` — and every reader acts on those, not on the span table
+underneath. Inside `verify` they are tallied from the internal `verdicts` list, and `spans` is set
+from that same list; nothing states that they must stay the same list. A refactor that filtered,
+re-ordered or re-adjudicated one of the two would produce a core whose headline described a span
+table it no longer shipped, and every existing test would still pass.
+
+WHAT THIS CHECKS, EXACTLY. That `core[field]` equals the same field recomputed from `core["spans"]`.
+That is a narrower claim than it may look:
+
+  - It DOES catch the summaries and the emitted spans being derived from different lists, a span
+    dropped or added between tally and emission, and an edit to one derivation rule and not the
+    other.
+  - It does NOT independently verify the adjudication rules. `_recompute` below restates the rules
+    in `verify`; if both are wrong in the same way, this passes. It is a change-detector over the
+    summary logic and an agreement check between the two halves of the core — not a proof that
+    either half is right.
+  - It says nothing about whether any individual span's verdict is correct. A verifier that
+    adjudicated every span wrongly and summarised those wrong spans faithfully would pass.
+
+It runs over the differential harness's seeded grammar rather than hand-written documents, so the
+inputs are ones nobody chose — the corpus that found two real defects in the JavaScript verifier.
+
+PROVENANCE. Written after a hypothesis failed. Several findings in the sidecar-battery leg looked
+like "a summary overselling its details", so the shape was tested as a property over 4000 generated
+documents. Not one diverged: the hypothesis was wrong, and the class of defect it predicted does not
+exist inside the core. The property is kept because nothing else pins it, not because it caught
+anything.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from styxx import sworn  # noqa: E402
+from styxx.sworn import VERDICTS  # noqa: E402
+
+try:
+    import conformance.sworn.differential as D
+except Exception as exc:                                        # noqa: BLE001
+    D = None
+    _WHY = str(exc)
+
+SEED = 20260906
+CASES = 1500          # the probe that produced the negative result ran 4000; this is the standing size
+
+
+def _recompute(core: dict) -> dict:
+    """Each summary, derived from `core["spans"]` alone, restating the rules in `verify`."""
+    spans = core["spans"]
+    counts = {v: 0 for v in VERDICTS}
+    for s in spans:
+        counts[s["verdict"]] += 1
+    sworn_total = sum(counts.values())
+
+    if core["document_malformed"]:
+        verdict = "SWORN-FAILED"
+    elif sworn_total == 0:
+        verdict = "UNSWORN"
+    elif counts["FAILED"] == 0 and counts["MALFORMED"] == 0:
+        verdict = "SWORN-HELD"
+    else:
+        verdict = "SWORN-FAILED"
+
+    rungs: dict = {}
+    for s in spans:
+        prov = s.get("provenance") or {}
+        if prov.get("form") == "rn":
+            key = prov.get("rung")
+        elif prov.get("form") in ("path", "prereg"):
+            key = "committed"
+        else:
+            key = "unresolved"
+        rungs[key] = rungs.get(key, 0) + 1
+
+    return {"counts": counts, "sworn_total": sworn_total, "unresolved": counts["UNRESOLVED"],
+            "document_verdict": verdict, "rungs": rungs}
+
+
+def _cores():
+    """Verified cores over the seeded grammar. Cases the generator makes unverifiable are skipped —
+    a document the verifier refuses has no summaries to check."""
+    if D is None:
+        pytest.skip("the differential generator is not importable here: %s" % _WHY)
+    made = 0
+    for i in range(CASES):
+        c = D.case(SEED, i)
+        try:
+            man = sworn.Manifest.from_dict(c["manifest"]) if c["manifest"] is not None else None
+        except BaseException:                                   # noqa: BLE001
+            continue
+        try:
+            core = sworn.verify(c["document"], name=c["name"], manifest=man, commit=c["commit"])
+        except BaseException:                                   # noqa: BLE001
+            continue
+        made += 1
+        yield i, core
+    if made == 0:
+        pytest.fail("no document verified at all — this test would pass vacuously")
+
+
+@pytest.mark.parametrize("field", ["counts", "sworn_total", "unresolved", "document_verdict",
+                                   "rungs"])
+def test_the_summary_agrees_with_the_spans_it_ships_with(field):
+    checked = 0
+    for i, core in _cores():
+        checked += 1
+        want = _recompute(core)[field]
+        got = core.get(field)
+        assert got == want, (
+            "case %d: core[%r] is %r but the span table shipped in the same core implies %r — the "
+            "headline describes spans the reader is not given" % (i, field, got, want))
+    assert checked > CASES // 2, (
+        "only %d of %d generated documents verified; the corpus this pins has shrunk" % (checked,
+                                                                                          CASES))
+
+
+def test_the_check_is_not_vacuous():
+    """The grammar must reach more than one document verdict and a non-empty rungs table, or the
+    parametrised tests above are pinning a single shape."""
+    verdicts, rung_keys, any_spans = set(), set(), 0
+    for _i, core in _cores():
+        verdicts.add(core["document_verdict"])
+        rung_keys |= set(core.get("rungs") or {})
+        any_spans += len(core["spans"])
+    assert len(verdicts) >= 2, "only reached %r" % (verdicts,)
+    assert rung_keys, "no span carried provenance, so the rungs summary was never exercised"
+    assert any_spans > 0


### PR DESCRIPTION
## What this is

A hypothesis, tested, that **failed**. Recorded at the same prominence a finding would get.

Several findings in the sidecar-battery leg looked like one shape: *a summary field and a detail field that can disagree, with nothing checking the summary is faithful to its details.* If that shape were general, the verdict core is where more of it would live — it carries five summaries over its span table (`counts`, `sworn_total`, `unresolved`, `document_verdict`, `rungs`), and readers act on those, not on the spans.

Stated as a check: recompute each summary from `core["spans"]` alone and compare.

```
documents checked: 4000 of 4000 generated
every summary field follows from its spans, on all 4000.
```

**No divergence, in any field, in any case.** The hypothesis is wrong in the form it was stated.

## What it corrects

The generalisation was too broad. Re-examined, the leg's findings were not summaries diverging from details — the rounding verdict is *faithful* to its comparison (`detail` honestly records that it compared against 0); `check` printing VERIFIED is CLI presentation; the `load_sidecar`/`render` gap is across two artifacts. The shape they actually share is **artifact A validated, artifact B consumed**. Narrower, and the one worth carrying forward. `NOTE_summary_faithfulness_negative_2026_09_06.md` says so in the corpus rather than only in a commit message.

## What is kept, and how modestly

`tests/test_sworn_core_is_faithful_to_its_spans.py` pins the property over 1500 generated documents. Kept because nothing else states it — **not** because it caught anything. It never has.

Its docstring states what it does *not* check: `_recompute` restates the rules in `verify`, so it is an agreement check between the two halves of the core (were the summaries and the emitted spans derived from the same list?), not an independent derivation of the adjudication rules. If both halves are wrong the same way, it passes.

## Watched to fail first

| mutation of `styxx/sworn.py` | result |
| --- | --- |
| `"spans": verdicts[1:]` — summaries tallied from a list the reader is not given | 5 of 5 fields fail |
| ladder drops `counts["MALFORMED"] == 0`, so a malformed span no longer fails the document | `document_verdict` alone fails; other 4 pass |

The second matters more: the guard fires on exactly the field that broke, so it localises rather than only reporting that something moved.

## Checks

- Full suite: **4442 passed, 13 skipped, 4 xfailed**. `tests/test_anthropic_hack.py` deselected locally — it memory-maps transformers weights and this machine's disk is at 486 MB free, which crashes the loader. Machine state, unrelated to this change; CI on Linux runs it.
- No receipt regenerated, no conformance vector moved: this adds a test and a note, and touches no verifier code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)