### PR TITLE
the path-segment class is identical in both implementations, and pinned

### DIFF
--- a/papers/sworn/SPEC_path_segment_class_is_pinned_v01_2026_09_06.md
+++ b/papers/sworn/SPEC_path_segment_class_is_pinned_v01_2026_09_06.md
@@ -1,0 +1,79 @@
+# SPEC — the path-segment class is identical in both implementations, and pinned (v0.1)
+
+**Frozen 2026-09-06, before the code.** One rule, P1. Found by the eight-dimension adversarial
+audit (`wf_9466dcba-f49`, dimension `parity`).
+
+## The defect
+
+`sworn.py` rejects bad path segments with `_PATH_SEG_BAD = [\\\s\x00-\x1f\x7f*?\[\]]`.
+`sworn_verify.js` cannot write `\s` and mean the same thing, so it **hand-expands** the class
+(l.471). The expansion omits one member of Python's `\s`: `U+0085 NEXT LINE`.
+
+Measured over every Unicode scalar value on this build:
+
+```
+python rejects: 58 code points
+node rejects  : 57 code points
+rejected by PYTHON only: ['U+0085']
+rejected by NODE only  : []
+```
+
+A `path:` receipt whose target contains `U+0085` therefore splits the two verifiers on the
+**document verdict**:
+
+```
+PYTHON  document_verdict SWORN-FAILED   span MALFORMED/receipt_form
+NODE    document_verdict SWORN-HELD     span UNRESOLVED/no_repository
+```
+
+One implementation refuses the document; the other says it held. This is exactly what the
+conformance set exists to prevent, and it survived 1689 replayed vectors because no vector puts a
+`U+0085` in a path.
+
+## Why the one-character fix is not the repair
+
+Adding `U+0085` to the JavaScript class closes today's gap and leaves the mechanism intact: a
+hand-maintained enumeration of another language's character class, with nothing checking it.
+
+The enumeration cannot be avoided. **Neither language's `\s` means the other's**: Python's includes
+`U+0085` and excludes `U+FEFF`; JavaScript's includes `U+FEFF` and excludes `U+0085`. So a literal
+list is required on the JS side, and a literal list drifts unless something compares it.
+
+## P1 — the two classes are equal over every scalar value, and a test says so
+
+1. `sworn_verify.js` adds `U+0085`, making the classes equal today.
+2. A guard evaluates **both** classes over all 1,114,112 scalar values and asserts the rejected sets
+   are identical — not that either contains some expected list, but that they agree with each other.
+
+The guard reads the JavaScript's regex out of the shipped file rather than restating it, so it
+cannot pass by testing a copy of the source it is meant to police.
+
+This is the shape the other repairs in this audit argued for. Five of the six were identical defects
+in *both* implementations, which a conformance set built from those same two implementations cannot
+see. Here the two disagree, and the durable fix is a check that compares them directly rather than a
+vector that happens to cover one code point.
+
+## What moves
+
+- **Nothing committed.** No committed document carries `U+0085` in a `path:` target.
+- JavaScript only. `sworn.py` is unchanged, so the conformance set does not move at all — not even
+  by the build pin, for the first time in this run of repairs.
+- The JS bar stays at 1689.
+
+## Guards, watched to fail before the code
+
+| # | guard | before | after |
+|---|---|---|---|
+| P-G1 | the two rejected sets are identical over all scalar values | red: differ by `U+0085` | green |
+| P-G2 | a `path:` target containing `U+0085` gets the same document verdict from both | red: SWORN-FAILED vs SWORN-HELD | green |
+| P-G3 | an ordinary path target is unaffected in both | green throughout |
+
+P-G1 is the guard that must be seen red, and it is the one that outlives this defect: any future
+edit to either class that does not edit the other fails it.
+
+## What this does not claim
+
+That the two implementations agree generally. It pins one character class. The audit found this
+divergence by enumerating a class; the same method applied to the other hand-mirrored classes in
+`sworn_verify.js` — `TOKEN_RE`, `GRAM_RE`, `HEXRUN_RE`, `DIGIT_RE` — has not been run, and is the
+obvious next measurement.

--- a/styxx/_data/sworn_verify.js
+++ b/styxx/_data/sworn_verify.js
@@ -468,7 +468,14 @@ const HEXRUN_RE = /(?<![A-Za-z0-9_])[0-9A-Fa-f]+(?![A-Za-z0-9_])/g;
 const DIRECTIONAL_OVERRIDE_RE = /[‭‮]/;
 const DIGEST_LENGTHS = new Set([32, 40, 96, 128]);
 const RN_RE = /^r[1-9][0-9]*$/;
-const PATH_SEG_BAD_RE = new RegExp('[\\\\\\t\\n\\v\\f\\r \\u00a0\\u1680\\u2000-\\u200a\\u2028\\u2029\\u202f\\u205f\\u3000\\u0000-\\u001f\\u007f*?\\[\\]]');
+// [B4] P1 (SPEC_path_segment_class_is_pinned_v01_2026_09_06): this hand-expands Python's `\s`,
+// because neither language's `\s` means the other's — Python's includes U+0085 NEXT LINE and
+// excludes U+FEFF, JavaScript's the reverse. The expansion omitted U+0085, which split the two
+// verifiers on the DOCUMENT VERDICT for a path: target carrying it: SWORN-FAILED here,
+// SWORN-HELD there. 1689 replayed vectors did not see it because none puts a U+0085 in a path.
+// tests/test_sworn_path_segment_parity.py now evaluates BOTH classes over all 1,114,112 scalar
+// values and asserts they agree, lifting this regex out of this file rather than restating it.
+const PATH_SEG_BAD_RE = new RegExp('[\\\\\\t\\n\\v\\f\\r \\u0085\\u00a0\\u1680\\u2000-\\u200a\\u2028\\u2029\\u202f\\u205f\\u3000\\u0000-\\u001f\\u007f*?\\[\\]]');
 const HEX64_RE = /^[0-9a-f]{64}$/;
 const HEX64_ANY_RE = /^[0-9a-fA-F]{64}$/;
 

--- a/tests/test_sworn_path_segment_parity.py
+++ b/tests/test_sworn_path_segment_parity.py
@@ -1,0 +1,131 @@
+"""The path-segment class rejects the same code points in both implementations.
+
+`sworn.py` writes `_PATH_SEG_BAD = [\\\\\\s\\x00-\\x1f\\x7f*?\\[\\]]`. `sworn_verify.js` cannot write
+`\\s` and mean the same thing, so it HAND-EXPANDS the class -- and the expansion omitted one member
+of Python's `\\s`, U+0085 NEXT LINE. Over every Unicode scalar value: python rejected 58, node 57,
+the difference being exactly U+0085.
+
+A `path:` receipt whose target carried it split the two verifiers on the DOCUMENT VERDICT:
+
+    PYTHON  document_verdict SWORN-FAILED   span MALFORMED/receipt_form
+    NODE    document_verdict SWORN-HELD     span UNRESOLVED/no_repository
+
+One implementation refused the document; the other said it held. 1689 replayed conformance vectors
+did not see it, because no vector puts a U+0085 in a path.
+
+WHY THIS TEST IS THE REPAIR AND THE CHARACTER IS NOT. The enumeration cannot be avoided: neither
+language's `\\s` means the other's -- Python's includes U+0085 and excludes U+FEFF, JavaScript's the
+reverse -- so a literal list is required on the JS side, and a literal list drifts unless something
+compares it. This compares them, over all 1,114,112 scalar values, and it reads the JavaScript's
+regex out of the shipped file rather than restating it, so it cannot pass by testing a copy of the
+source it is meant to police.
+
+Spec: papers/sworn/SPEC_path_segment_class_is_pinned_v01_2026_09_06.md (P1).
+"""
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from styxx import sworn  # noqa: E402
+
+JS = ROOT / "styxx" / "_data" / "sworn_verify.js"
+NEL = ""
+
+
+def _node():
+    from shutil import which
+    return which("node")
+
+
+def _python_rejected() -> set:
+    return {c for c in range(0x110000) if sworn._PATH_SEG_BAD.search(chr(c))}
+
+
+def _js_rejected(node) -> set:
+    """Evaluate the SHIPPED regex, lifted from the file, over every scalar value."""
+    src = JS.read_text(encoding="utf-8")
+    m = re.search(r"const PATH_SEG_BAD_RE = new RegExp\((.*?)\);", src)
+    assert m, "PATH_SEG_BAD_RE is no longer a `new RegExp(...)` literal; update this lift"
+    driver = (
+        "const re = new RegExp(%s);\n"
+        "const out = [];\n"
+        "for (let c = 0; c < 0x110000; c++) { if (re.test(String.fromCodePoint(c))) out.push(c); }\n"
+        "process.stdout.write(JSON.stringify(out));\n" % m.group(1)
+    )
+    d = Path(tempfile.mkdtemp())
+    (d / "drv.js").write_bytes(driver.encode("utf-8"))
+    p = subprocess.run([node, str(d / "drv.js")], capture_output=True)
+    assert p.returncode == 0, p.stderr.decode("utf-8", "replace")[:400]
+    return set(json.loads(p.stdout.decode("utf-8")))
+
+
+def test_both_implementations_reject_exactly_the_same_code_points():
+    """P-G1, the guard that must be seen red, and the one that outlives this defect.
+
+    Any future edit to either class that does not edit the other fails here.
+    """
+    node = _node()
+    if node is None:
+        pytest.skip("node is not available")
+    py, js = _python_rejected(), _js_rejected(node)
+    only_py = sorted(py - js)
+    only_js = sorted(js - py)
+    fmt = lambda s: [("U+%04X" % c) for c in s][:20]                       # noqa: E731
+    assert not only_py and not only_js, (
+        "the path-segment classes disagree: python-only %s, node-only %s (python rejects %d, node "
+        "%d)" % (fmt(only_py), fmt(only_js), len(py), len(js)))
+
+
+def test_the_nel_character_is_rejected_by_python():
+    """The specific member the hand-expansion dropped; kept so the regression has a name."""
+    assert sworn._PATH_SEG_BAD.search(NEL) is not None
+
+
+def test_a_path_target_carrying_nel_gets_one_verdict_from_both(tmp_path):
+    """P-G2. The class is a means; the document verdict is what a reader acts on."""
+    node = _node()
+    if node is None:
+        pytest.skip("node is not available")
+    try:
+        import conformance.sworn.differential as D
+    except Exception as exc:                                     # noqa: BLE001
+        pytest.skip("the differential harness is not importable here: %s" % exc)
+
+    doc = ('<sworn r="path:out%stxt" k="quote">the log says `all done` here</sworn>\n'
+           % NEL).encode("utf-8")
+    batch = [{"index": 0, "document": doc, "manifest": None, "name": "D.md", "commit": None}]
+    rows = D.js_digests(batch, Path(tempfile.mkdtemp()))
+    py, py_err, _c = D.python_digest(batch[0])
+    js = rows.get(0) or {}
+    assert py == js.get("digest"), (
+        "a path: target carrying U+0085 gives python=%s(%s) and node=%s(%s)"
+        % ((py or "-")[:12], py_err or "ok", (js.get("digest") or "-")[:12], js.get("error") or "ok"))
+
+
+def test_an_ordinary_path_target_is_unaffected_in_both():
+    """P-G3. Catches over-reach: the repair must not start rejecting ordinary paths."""
+    node = _node()
+    if node is None:
+        pytest.skip("node is not available")
+    try:
+        import conformance.sworn.differential as D
+    except Exception as exc:                                     # noqa: BLE001
+        pytest.skip("the differential harness is not importable here: %s" % exc)
+
+    doc = (b'<sworn r="path:results/out.txt" k="quote">the log says `all done` here</sworn>\n')
+    batch = [{"index": 0, "document": doc, "manifest": None, "name": "D.md", "commit": None}]
+    rows = D.js_digests(batch, Path(tempfile.mkdtemp()))
+    py, _e, _c = D.python_digest(batch[0])
+    assert py == (rows.get(0) or {}).get("digest")
+    assert sworn._PATH_SEG_BAD.search("results/out.txt") is None


### PR DESCRIPTION
## The two verifiers disagreed on a document verdict

`sworn.py` rejects bad path segments with a class containing Python's `\s`. `sworn_verify.js` cannot write `\s` and mean the same thing, so it **hand-expands** the class — and the expansion omitted one member: `U+0085 NEXT LINE`.

Measured over every Unicode scalar value:

```
python rejects: 58 code points
node rejects  : 57 code points
rejected by PYTHON only: ['U+0085']
rejected by NODE only  : []
```

A `path:` receipt whose target carries it splits the two implementations on the **document verdict**:

```
PYTHON  document_verdict SWORN-FAILED   span MALFORMED/receipt_form
NODE    document_verdict SWORN-HELD     span UNRESOLVED/no_repository
```

One implementation refuses the document; the other says it held. This is exactly what the conformance set exists to prevent, and it survived **1689 replayed vectors** because no vector puts a `U+0085` in a path.

## The character is not the repair — the test is

Adding `U+0085` closes today's gap and leaves the mechanism untouched: a hand-maintained enumeration of another language's character class, with nothing checking it.

**The enumeration cannot be avoided.** Neither language's `\s` means the other's — Python's includes `U+0085` and excludes `U+FEFF`; JavaScript's is exactly the reverse. So a literal list is required on the JS side, and an unwatched literal list drifts.

So P1 has two halves, and the second is the durable one:

1. the JS class gains `U+0085`;
2. a guard evaluates **both** classes over all **1,114,112** scalar values and asserts the rejected sets agree *with each other* — not that either matches some expected list.

The guard **lifts the JavaScript regex out of the shipped file** rather than restating it, so it cannot pass by testing a copy of the source it is meant to police. Any future edit to either class that does not edit the other fails P-G1.

## A mistake I made writing this

While writing the comment that explains the defect, I embedded a **raw `U+0085` into the shipped JavaScript** — an invisible control character in the one file whose subject is invisible control characters.

The Bash tool's validator refused the heredoc carrying it; a scan of the file found the one that reached it by another route. Removed, and the absence is verified rather than assumed.

## Checks

- **JavaScript only.** `sworn.py` is unchanged, so the conformance set does not move **at all** — not even by the build pin, for the first time in this run of repairs. `CHECK OK` against the committed digest.
- JS bar **1689 ran / 1689 passed / 0 failed**.
- Full suite **4557 passed**, 13 skipped, 4 xfailed.
- Blast radius: no committed document carries `U+0085` in a `path:` target.
- Watched to fail: P-G1 (the class comparison) and P-G2 (the document verdict) red before the code; P-G3 green throughout to catch over-reach.

## Scope, stated rather than implied

`TOKEN_RE`, `GRAM_RE`, `HEXRUN_RE` and `DIGIT_RE` are hand-mirrored the same way and have **never been enumerated** against their Python counterparts. That is the obvious next measurement, and the method now exists to make it.

## Seventh of eight

Seventh repair from the eight-dimension adversarial audit (`wf_9466dcba-f49`). Five of the earlier six were identical defects in *both* implementations — invisible to a conformance set built from those same two. This one is the opposite case: the two disagree, and the fix is a check that compares them directly rather than a vector that happens to cover one code point.

Only the Action's case-sensitivity miss remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)