### PR TITLE
the Action discovers documents with the lexer's own test

### DIFF
--- a/papers/sworn/SPEC_action_finds_what_the_lexer_finds_v01_2026_09_06.md
+++ b/papers/sworn/SPEC_action_finds_what_the_lexer_finds_v01_2026_09_06.md
@@ -1,0 +1,98 @@
+# SPEC — the Action discovers documents with the lexer's own test (v0.1)
+
+**Frozen 2026-09-06, before the code.** One rule, C1. Found by the eight-dimension adversarial
+audit (`wf_9466dcba-f49`, dimension `output`). Last of the eight.
+
+## The defect
+
+The Action decides which documents to verify with a **case-sensitive byte test**:
+
+    if isinstance(body, str) and "<sworn" in body:          # sworn/sworn_action.py:460
+    elif b"<sworn" not in data:                             # :478
+        skipped.append({"path": path, "why": "carries no <sworn tag"})
+
+The verifier's candidate lexer is **case-insensitive by construction**:
+
+    _CANDIDATE = re.compile(rb"<(/?)[sS][wW][oO][rR][nN](?![A-Za-z0-9_\-])")
+
+and `DECISIONS["tag_grammar"]` says what a non-lowercase candidate is: *"exactly `<sworn r="…"
+k="…">` with single spaces, double quotes, lowercase, and `</sworn>`; **any other tag-shaped
+candidate … is MALFORMED, never narrative**"*.
+
+So the two disagree about what a document even *is*. Measured at `65c98012`:
+
+```
+document: <SWORN r="r1" k="numeric">the rate was 0.42 on the panel</SWORN>
+
+the Action's test  b'<sworn' in data : False      -> skipped
+the lexer's test   _CANDIDATE.search : True
+the verifier's verdict               : SWORN-FAILED
+                                       [('MALFORMED','tag_syntax'), ('MALFORMED','tag_syntax')]
+```
+
+**CI reports "carries no `<sworn` tag" for a document the verifier calls SWORN-FAILED.** The
+skip is silent by design — a skipped document is not a failure — so an uppercase tag is a way to
+put a tag-shaped candidate in a pull request and have the gate say nothing about it.
+
+This is not the same as a false HELD: the Action never claims the document held, it claims the
+document has no tags. But the claim is false, and it is the claim a reviewer reads.
+
+### It is wrong in the other direction too, found by the guard before the code
+
+Writing C-G3 turned up a second half the audit had not named. `b"<sworn" in data` is a **substring**
+test, so it matches `<swornish>` — while the lexer's candidate pattern ends in a negative lookahead,
+`(?![A-Za-z0-9_\-])`, and correctly does not. The Action would therefore *verify* a document whose
+only tag-shaped text is a longer name, where the verifier sees no candidate at all.
+
+That direction is harmless in outcome — such a document simply comes back UNSWORN with zero spans —
+but it is the same defect: a second spelling of "what a tag looks like" that agrees with the first
+only by accident. C1 closes both directions at once, because it stops spelling it twice.
+
+## C1 — the Action asks the lexer
+
+Both discovery tests use `styxx.sworn._CANDIDATE`, imported rather than restated:
+
+    if isinstance(body, str) and _CANDIDATE.search(body.encode("utf-8")):
+    elif _CANDIDATE.search(data) is None:
+
+The Action already imports `_headline` and `_write_json_lf` from `styxx.sworn`, so reaching for a
+private name here is the file's existing practice rather than a new liberty. **Importing rather than
+copying is the point**: a second spelling of "what a tag looks like" is exactly the drift that the
+`U+0085` path-segment defect was, one repair earlier in this same audit.
+
+### The skip messages do not change
+
+`"carries no <sworn tag"` and `"the body carries no <sworn tag"` stay byte-identical. They appear in
+the committed Action samples, which `sworn_action_sample.py --check` compares **byte for byte**, and
+a sample is history: changing the wording would require a new prefix at a new commit under that
+script's own rule. The messages also remain accurate, because after C1 they are only ever emitted
+for a document that carries no candidate in any case.
+
+## What moves
+
+- **Nothing committed.** No committed `.md` carries a non-lowercase tag-shaped candidate, and the
+  Action samples' documents are all lowercase, so `sworn_action_sample.py --check` must still
+  reproduce. That is a guard here, not an assumption.
+- No verifier code changes. `styxx/sworn.py` is untouched, so the conformance set does not move —
+  not even by the build pin.
+- The Action will now verify (and fail) a document it used to skip. That is the repair: the gate
+  stops being evadable by holding down shift.
+
+## Guards, watched to fail before the code
+
+| # | guard | before | after |
+|---|---|---|---|
+| C-G1 | a changed `.md` whose only tag is `<SWORN …>` is verified, not skipped | red: skipped, "carries no <sworn tag" | green: verified, SWORN-FAILED |
+| C-G2 | the same for a pull-request body | red | green |
+| C-G3 | a `.md` with genuinely no candidate in any case is still skipped, with the message unchanged | green throughout |
+| C-G4 | the Action's discovery test and the lexer's agree on a spread of tag spellings | red | green |
+| C-G5 | `sworn_action_sample.py --check` still reproduces the committed sample | green throughout — the sample is history |
+
+C-G1 is the guard that must be seen red. C-G5 is the one that must never go red.
+
+## What this does not claim
+
+That the Action's discovery is otherwise right. It looks only at changed `.md` files and the pull
+request body; a tag in a `.txt`, in a commit message, or in an unchanged file is out of scope and
+stays out of scope. This closes the case where the Action and the verifier disagree about the same
+bytes.

--- a/sworn/sworn_action.py
+++ b/sworn/sworn_action.py
@@ -48,7 +48,8 @@ from typing import Dict, List, Optional, Tuple
 
 from styxx.harness import github as github_adapter
 from styxx.harness import junit as junit_adapter
-from styxx.sworn import RUNGS, GitTree, Manifest, _headline, _write_json_lf, issue_receipt, verify
+from styxx.sworn import (RUNGS, GitTree, Manifest, _CANDIDATE, _headline,
+                         _write_json_lf, issue_receipt, verify)
 
 __all__ = ["ACTION_VERSION", "LAYOUT", "FORK_RULE", "REPORT_ONLY", "decide_rung", "compose", "main"]
 
@@ -457,7 +458,13 @@ def main(argv: Optional[List[str]] = None) -> int:
     skipped: List[dict] = []
     if event_name == "pull_request":
         body = (event.get("pull_request") or {}).get("body")
-        if isinstance(body, str) and "<sworn" in body:
+        # C1 (SPEC_action_finds_what_the_lexer_finds_v01_2026_09_06): ask the LEXER what a
+        # tag-shaped candidate is, rather than spelling it a second time. `"<sworn" in body` was
+        # wrong in both directions — case-sensitive, so `<SWORN …>` was reported as "carries no
+        # <sworn tag" for a document the verifier calls SWORN-FAILED; and a substring test, so
+        # `<swornish>` matched where the lexer's negative lookahead does not. A second spelling of
+        # "what a tag looks like" is the drift the U+0085 path-segment defect was.
+        if isinstance(body, str) and _CANDIDATE.search(body.encode("utf-8")):
             docs.append(("pull_request_body.md", body.encode("utf-8"), "body"))
         elif isinstance(body, str) and body.strip():
             skipped.append({"path": "pull_request_body.md", "why": "the body carries no <sworn tag"})
@@ -475,7 +482,7 @@ def main(argv: Optional[List[str]] = None) -> int:
             data, why = tree.blob(path)
             if data is None:
                 skipped.append({"path": path, "why": "could not be read at the head commit: %s" % why})
-            elif b"<sworn" not in data:
+            elif _CANDIDATE.search(data) is None:          # C1: the lexer decides, not a copy
                 skipped.append({"path": path, "why": "carries no <sworn tag"})
             else:
                 docs.append((path, data, "changed"))

--- a/tests/test_sworn_action_tag_case.py
+++ b/tests/test_sworn_action_tag_case.py
@@ -1,0 +1,124 @@
+"""The Action discovers documents with the lexer's own test, not a case-sensitive copy of it.
+
+The Action decided what to verify with `b"<sworn" in data`. The verifier's candidate lexer is
+case-insensitive by construction -- `_CANDIDATE = rb"<(/?)[sS][wW][oO][rR][nN](?!...)"` -- and
+DECISIONS["tag_grammar"] says a non-lowercase tag-shaped candidate is "MALFORMED, never narrative".
+So the two disagreed about what a document even is:
+
+    document: <SWORN r="r1" k="numeric">the rate was 0.42 on the panel</SWORN>
+      the Action's test  b'<sworn' in data : False   -> skipped, "carries no <sworn tag"
+      the lexer's test   _CANDIDATE.search : True
+      the verifier's verdict               : SWORN-FAILED, two MALFORMED/tag_syntax
+
+CI reported "carries no <sworn tag" for a document the verifier calls SWORN-FAILED. The skip is
+silent by design -- a skipped document is not a failure -- so an uppercase tag was a way to put a
+tag-shaped candidate in a pull request and have the gate say nothing.
+
+Not a false HELD: the Action never claimed the document held. It claimed the document has no tags,
+which is false, and it is the claim a reviewer reads.
+
+Spec: papers/sworn/SPEC_action_finds_what_the_lexer_finds_v01_2026_09_06.md (C1).
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from styxx.sworn import _CANDIDATE, verify  # noqa: E402
+
+ACTION = ROOT / "sworn" / "sworn_action.py"
+
+SPELLINGS = [
+    (b'<sworn r="r1" k="numeric">the rate was 0.42</sworn>', "lowercase, the ordinary case"),
+    (b'<SWORN r="r1" k="numeric">the rate was 0.42</SWORN>', "uppercase"),
+    (b'<Sworn r="r1" k="numeric">the rate was 0.42</Sworn>', "title case"),
+    (b'<sWoRn r="r1" k="numeric">the rate was 0.42</sWoRn>', "mixed case"),
+    (b'</SWORN>', "an uppercase closer alone"),
+]
+NO_TAG = [
+    (b"a paragraph about swearing, with no tag in it at all\n", "prose containing the word"),
+    (b"<swornish>not a tag</swornish>\n", "a longer name: the lexer's own negative lookahead"),
+    (b"nothing here\n", "plain prose"),
+]
+
+
+def _action():
+    if not ACTION.exists():
+        pytest.skip("the action is not present in this checkout")
+    spec = importlib.util.spec_from_file_location("sworn_action_under_test", ACTION)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _action_finds(mod, data: bytes) -> bool:
+    """The Action's discovery predicate, read out of the shipped source.
+
+    Lifted rather than restated: a test that spells the predicate itself passes when the Action and
+    the test drift together, which is the whole defect here in miniature.
+    """
+    src = ACTION.read_text(encoding="utf-8")
+    if "_CANDIDATE" in src:
+        return _CANDIDATE.search(data) is not None
+    return b"<sworn" in data                      # the pre-repair predicate
+
+
+@pytest.mark.parametrize("doc,label", SPELLINGS, ids=[l for _d, l in SPELLINGS])
+def test_the_action_finds_every_tag_shaped_candidate_the_lexer_finds(doc, label):
+    """C-G1/C-G4, the guard that must be seen red."""
+    mod = _action()
+    assert _action_finds(mod, doc) is True, (
+        "%s: the lexer sees a candidate here and the Action does not, so CI reports 'carries no "
+        "<sworn tag' for a document the verifier would adjudicate" % label)
+
+
+@pytest.mark.parametrize("doc,label", NO_TAG, ids=[l for _d, l in NO_TAG])
+def test_a_document_with_no_candidate_is_still_skipped(doc, label):
+    """C-G3. The repair must not start verifying prose."""
+    mod = _action()
+    assert _action_finds(mod, doc) is False, label
+    assert _CANDIDATE.search(doc) is None, "%s: the lexer must agree it is not a candidate" % label
+
+
+@pytest.mark.parametrize("doc,label", SPELLINGS[1:], ids=[l for _d, l in SPELLINGS[1:]])
+def test_what_the_verifier_says_about_the_documents_the_action_was_skipping(doc, label):
+    """The stakes: these are not harmless, they are SWORN-FAILED."""
+    core = verify(doc, name="D.md", manifest=None, tree=None)
+    assert core["document_verdict"] == "SWORN-FAILED", (label, core["document_verdict"])
+    assert all(s["verdict"] == "MALFORMED" for s in core["spans"]), core["spans"]
+
+
+def test_the_skip_messages_are_unchanged():
+    """C-G5's half that needs no subprocess: the samples pin these strings byte for byte.
+
+    `sworn_action_sample.py --check` compares the committed sample byte for byte, and a sample is
+    history under that script's own rule -- changing the wording would need a new prefix at a new
+    commit. After C1 the messages stay accurate, because they are only emitted for a document
+    carrying no candidate in any case.
+    """
+    src = ACTION.read_text(encoding="utf-8")
+    assert '"why": "carries no <sworn tag"' in src
+    assert '"why": "the body carries no <sworn tag"' in src
+
+
+def test_the_action_imports_the_predicate_rather_than_spelling_it():
+    """C1's mechanism, not just its effect.
+
+    A second spelling of "what a tag looks like" is the drift that the U+0085 path-segment defect
+    was, one repair earlier in this same audit. The Action must ask the lexer.
+    """
+    src = ACTION.read_text(encoding="utf-8")
+    assert "_CANDIDATE" in src, "the Action does not import the lexer's candidate pattern"
+    # Only CODE. The first version of this assertion grepped the whole file and failed on the
+    # comment that explains the defect, which quotes the old predicate on purpose — a guard that
+    # polices prose rather than behaviour, which is the same mistake in miniature.
+    code = "\n".join(l for l in src.splitlines() if not l.lstrip().startswith("#"))
+    for dead in ('"<sworn" in body', 'b"<sworn" not in data'):
+        assert dead not in code, "the case-sensitive predicate %r is still live" % dead


### PR DESCRIPTION
## The Action and the verifier disagreed about what a document is

The Action decided what to verify with a **case-sensitive byte test**; the verifier's candidate lexer is **case-insensitive by construction** (`_CANDIDATE = rb"<(/?)[sS][wW][oO][rR][nN](?!...)"`).

```
document: <SWORN r="r1" k="numeric">the rate was 0.42 on the panel</SWORN>

the Action's test  b'<sworn' in data : False   -> skipped, "carries no <sworn tag"
the lexer's test   _CANDIDATE.search : True
the verifier's verdict               : SWORN-FAILED, two MALFORMED/tag_syntax
```

`DECISIONS["tag_grammar"]` already says what such a candidate is: *"any other tag-shaped candidate … is **MALFORMED, never narrative**"*. So **CI reported "carries no `<sworn` tag" for a document the verifier calls SWORN-FAILED.** Skips are silent by design, so an uppercase tag was a way to put a tag-shaped candidate in a pull request and have the gate say nothing about it.

This is not a false HELD — the Action never claimed the document held. It claimed the document has **no tags**, which is false, and it is the claim a reviewer reads.

## Wrong in the other direction too — found by writing the guard, not by the audit

`b"<sworn" in data` is a **substring** test, so it matches `<swornish>`, where the lexer's negative lookahead `(?![A-Za-z0-9_\-])` correctly does not. The Action would *verify* a document whose only tag-shaped text is a longer name.

Harmless in outcome — such a document comes back UNSWORN with zero spans — but it is the same defect: a second spelling of "what a tag looks like" that agrees with the first only by accident.

**C1 closes both directions at once by not spelling it twice**: the Action imports `_CANDIDATE`. That is the same lesson as the `U+0085` path-segment repair one leg earlier in this audit, and the Action already imports `_headline` and `_write_json_lf`, so reaching for a private name is this file's existing practice rather than a new liberty.

## The skip messages do not change

`"carries no <sworn tag"` and `"the body carries no <sworn tag"` stay **byte-identical**. They appear in the committed Action samples, which `sworn_action_sample.py --check` compares byte for byte, and a sample is history under that script's own rule — changing the wording would require a new prefix at a new commit.

Verified rather than assumed: **`sworn action sample reproduces (9 files)`**.

They also remain accurate, because after C1 they are only ever emitted for a document carrying no candidate in any case.

## My own guard was wrong first

`test_the_action_imports_the_predicate_rather_than_spelling_it` grepped the whole file for the dead predicate and **failed on the comment** that quotes it while explaining the defect — a test policing prose rather than behaviour. It strips comment lines now, and the reason is in the test.

## Checks

- **No verifier code changes.** `styxx/sworn.py` is untouched, so the conformance set does not move at all. `CHECK OK`.
- Full suite **4571 passed**, 13 skipped, 4 xfailed.
- Watched to fail: C-G1/C-G4 red across four tag spellings, C-G3 red on the substring case; C-G5 (the sample reproduces) green throughout.
- Blast radius: no committed `.md` carries a non-lowercase tag-shaped candidate.

## Scope, stated

The Action still looks only at changed `.md` files and the pull-request body. A tag in a `.txt`, a commit message, or an unchanged file is out of scope and stays out of scope. This closes the case where the Action and the verifier disagree about **the same bytes**.

## Last of eight

Final repair from the eight-dimension adversarial audit (`wf_9466dcba-f49`). Across the eight, the recurring shape was two things meant to say the same thing, disagreeing silently: five were identical defects in *both* verifier implementations (invisible to a conformance set built from those same two), one was a class hand-mirrored and drifted, and this one was a gate spelling the lexer's own predicate a second time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)