### PR TITLE
the two-implementation agreement is bounded by Unicode version parity

### DIFF
--- a/conformance/sworn/class_census.py
+++ b/conformance/sworn/class_census.py
@@ -1,0 +1,164 @@
+# -*- coding: utf-8 -*-
+"""Enumerate every character class both verifiers implement, and compare them member by member.
+
+WHY. The U+0085 defect (SPEC_path_segment_class_is_pinned_v01_2026_09_06) was one member missing
+from a hand-expansion of Python's ``\\s`` in sworn_verify.js. It changed a DOCUMENT VERDICT --
+SWORN-FAILED in Python, SWORN-HELD in node -- and survived 1689 replayed vectors because no vector
+put that byte in a path. It was found by enumerating one class. This enumerates the rest.
+
+WHAT IT FOUND. Every class defined by a Unicode PROPERTY diverges; every class defined by an
+EXPLICIT LIST agrees. That is not a coding mistake on either side: it is the two runtimes
+implementing the same property against different Unicode versions.
+
+  python unicodedata 15.0.0   node unicode/icu 16.0
+
+  _TOKEN / TOKEN_RE          DIFFER  python=137971 node=142975   (5004 node-only)
+  _DIGIT / DIGIT_RE          DIFFER  python=680    node=760      (80 node-only)
+  _HEXRUN / HEXRUN_RE        AGREE   python=22     node=22       (ASCII)
+  _PATH_SEG_BAD / ...        AGREE   python=58     node=58       (explicit list, pinned)
+  _DIRECTIONAL_OVERRIDE/...  AGREE   python=2      node=2        (explicit list)
+
+HOW TO READ THAT. It bounds a claim rather than reporting a bug. "The two implementations agree on
+1689 of 1689 vectors" is true, and true *because* no vector uses a code point the two runtimes
+classify differently -- measured: 0 of 3981 blobs do. The agreement is conditional on Unicode
+version parity, and that condition was never written down.
+
+The JS regexes are LIFTED out of the shipped file rather than restated here, so this cannot pass by
+testing a copy of the source it is meant to police.
+
+  python conformance/sworn/class_census.py           # report; exit 1 if an EXPLICIT class differs
+  python conformance/sworn/class_census.py --strict  # exit 1 if any class differs at all
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unicodedata
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+JS = ROOT / "styxx" / "_data" / "sworn_verify.js"
+
+from styxx import sworn  # noqa: E402
+
+# (label, python pattern, JS const name, kind) — kind "explicit" means the class is written out and
+# MUST agree; "property" means it is a Unicode property on at least one side and is version-bound.
+PAIRS = [
+    ("_TOKEN / TOKEN_RE", sworn._TOKEN, "TOKEN_RE", "property"),
+    ("_DIGIT / DIGIT_RE", sworn._DIGIT, "DIGIT_RE", "property"),
+    ("_HEXRUN / HEXRUN_RE", sworn._HEXRUN, "HEXRUN_RE", "explicit"),
+    ("_PATH_SEG_BAD / PATH_SEG_BAD_RE", sworn._PATH_SEG_BAD, "PATH_SEG_BAD_RE", "explicit"),
+    ("_DIRECTIONAL_OVERRIDE / DIRECTIONAL_OVERRIDE_RE", sworn._DIRECTIONAL_OVERRIDE,
+     "DIRECTIONAL_OVERRIDE_RE", "explicit"),
+]
+
+_DRIVER = [
+    "const fs = require('fs');",
+    "const src = fs.readFileSync(process.argv[2], 'utf8');",
+    "const names = JSON.parse(process.argv[3]);",
+    "let prelude = '';",
+    "const dash = src.match(/const DASH_BINDS =([\\s\\S]*?);/);",
+    "if (dash) prelude += 'const DASH_BINDS =' + dash[1] + ';';",
+    "const out = {};",
+    "for (const name of names) {",
+    "  const m = src.match(new RegExp('const ' + name + ' = ([^;]+);'));",
+    "  if (!m) { out[name] = null; continue; }",
+    "  let re;",
+    "  try { re = eval(prelude + ' (' + m[1] + ')'); }",
+    "  catch (e) { out[name] = 'ERR:' + e.message; continue; }",
+    "  const hits = [];",
+    "  for (let c = 0; c < 0x110000; c++) {",
+    "    if (c >= 0xd800 && c <= 0xdfff) continue;",
+    "    re.lastIndex = 0;",
+    "    if (re.test(String.fromCodePoint(c))) hits.push(c);",
+    "  }",
+    "  out[name] = hits;",
+    "}",
+    "process.stdout.write(JSON.stringify(out));",
+]
+
+
+def python_members(pat) -> set:
+    """Every scalar value the pattern matches on its own."""
+    out = set()
+    is_bytes = isinstance(pat.pattern, bytes)
+    for c in range(0x110000):
+        if 0xD800 <= c <= 0xDFFF:
+            continue
+        ch = chr(c)
+        try:
+            if pat.search(ch.encode("utf-8") if is_bytes else ch):
+                out.add(c)
+        except Exception:                                        # noqa: BLE001
+            pass
+    return out
+
+
+def js_members(names) -> dict:
+    d = Path(tempfile.mkdtemp())
+    (d / "drv.js").write_text("\n".join(_DRIVER), encoding="utf-8")
+    p = subprocess.run(["node", str(d / "drv.js"), str(JS), json.dumps(list(names))],
+                       capture_output=True)
+    if p.returncode != 0:
+        raise SystemExit("REFUSED: the node side did not run: %s"
+                         % p.stderr.decode("utf-8", "replace")[-400:])
+    return json.loads(p.stdout.decode("utf-8"))
+
+
+def unicode_versions():
+    v = subprocess.run(["node", "-p", "process.versions.unicode || process.versions.icu"],
+                       capture_output=True)
+    return unicodedata.unidata_version, v.stdout.decode().strip()
+
+
+def census() -> list:
+    """[(label, kind, python_set, js_set)] for every pair."""
+    js_all = js_members([n for _l, _p, n, _k in PAIRS])
+    rows = []
+    for label, pat, name, kind in PAIRS:
+        hits = js_all.get(name)
+        if hits is None or isinstance(hits, str):
+            raise SystemExit("REFUSED: could not read %s from the shipped file: %s"
+                             % (name, hits or "not found"))
+        rows.append((label, kind, python_members(pat), set(hits)))
+    return rows
+
+
+def main(argv) -> int:
+    py_v, node_v = unicode_versions()
+    print("python unicodedata %s   node unicode/icu %s" % (py_v, node_v))
+    if py_v.split(".")[0] != str(node_v).split(".")[0]:
+        print("  the two runtimes are on DIFFERENT Unicode versions; every property-defined class")
+        print("  below is expected to differ, and the agreement claim is bounded by this line")
+    print()
+    strict = "--strict" in argv
+    bad = 0
+    for label, kind, py, js in census():
+        only_py, only_js = sorted(py - js), sorted(js - py)
+        agree = not only_py and not only_js
+        print("%-48s %-8s %-7s python=%-6d node=%-6d"
+              % (label, kind, "AGREE" if agree else "DIFFER", len(py), len(js)))
+        if agree:
+            continue
+        if kind == "explicit" or strict:
+            bad += 1
+        for who, s in (("python only", only_py), ("node only  ", only_js)):
+            if s:
+                shown = ", ".join("U+%04X" % c for c in s[:12])
+                print("      %s (%d): %s%s" % (who, len(s), shown, " ..." if len(s) > 12 else ""))
+    print()
+    if bad:
+        print("EXPLICIT classes that differ: %d — these are hand-written on both sides and a" % bad)
+        print("difference is a defect, not a version skew.")
+        return 1
+    print("every EXPLICIT class agrees. Property-defined classes track each runtime's Unicode")
+    print("version and are reported, not failed; see FINDING_unicode_version_skew_2026_09_06.md.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/papers/sworn/FINDING_unicode_version_skew_2026_09_06.md
+++ b/papers/sworn/FINDING_unicode_version_skew_2026_09_06.md
@@ -1,0 +1,87 @@
+# FINDING — the two-implementation agreement is bounded by Unicode version parity
+
+*2026-09-06. Not a defect in either implementation. A condition on a claim this project makes
+prominently, which had never been written down.*
+
+## How it was found
+
+`SPEC_path_segment_class_is_pinned_v01_2026_09_06` closed a divergence where `sworn_verify.js`
+hand-expanded Python's `\s` and dropped `U+0085`. That spec ended by naming what it had not done:
+
+> `TOKEN_RE`, `GRAM_RE`, `HEXRUN_RE` and `DIGIT_RE` are hand-mirrored the same way and have **never
+> been enumerated** against their Python counterparts. That is the obvious next measurement, and the
+> method now exists to make it.
+
+This is that measurement. `conformance/sworn/class_census.py` enumerates every character class both
+verifiers implement, over all 1,114,112 scalar values, lifting the JavaScript regexes out of the
+shipped file rather than restating them.
+
+## The result
+
+```
+python unicodedata 15.0.0   node unicode/icu 16.0
+
+_TOKEN / TOKEN_RE                   property DIFFER  python=137971 node=142975   (5004 node-only)
+_DIGIT / DIGIT_RE                   property DIFFER  python=680    node=760      (80 node-only)
+_HEXRUN / HEXRUN_RE                 explicit AGREE   python=22     node=22
+_PATH_SEG_BAD / PATH_SEG_BAD_RE     explicit AGREE   python=58     node=58
+_DIRECTIONAL_OVERRIDE / ...         explicit AGREE   python=2      node=2
+```
+
+**Every class defined by a Unicode property diverges. Every class defined by an explicit list
+agrees.** The split is exact and it explains itself: CPython here ships Unicode 15.0.0 and V8's ICU
+ships 16.0, so both sides correctly implement "category Nd" and "word character" against different
+editions of the standard.
+
+It changes verdicts. `U+10D40` is a Garay digit, added in Unicode 16.0:
+
+```
+U+10D40  python unicodedata category: Cn (unassigned to this build)
+python _DIGIT matches it : False
+
+document: <sworn r="r1" k="numeric">the count was <U+10D40 x3> items</sworn>
+PYTHON verdict: SWORN-FAILED  [('MALFORMED','number_count')]
+core digests -> python 6ecf74684afd528e   node 35b7ceafd77b6471    *** DIVERGE ***
+```
+
+## What it bounds
+
+The project states, prominently and truly, that a second independent implementation agrees on
+**1689 of 1689** conformance vectors. That claim is true **because no vector uses a code point the
+two runtimes classify differently** — measured: **0 of 3981 blobs do**.
+
+So the agreement is real and it is conditional. The condition is that both runtimes share a Unicode
+version, and it was nowhere stated. A reader who takes "1689/1689" as "these two implementations
+agree" is reading it more broadly than the evidence supports; the accurate reading is "these two
+implementations agree on this corpus, at these two Unicode versions."
+
+## What is NOT proposed
+
+**Hardcoding the property classes.** `\w` has 137,971 members here; writing it out on both sides
+would be a large, version-pinned table that must be regenerated whenever either runtime moves, and
+would replace a stated boundary with a maintenance burden that fails silently when neglected.
+
+The explicit classes are explicit because they are small and adversarially interesting —
+`_PATH_SEG_BAD` (58), `_DIRECTIONAL_OVERRIDE` (2), `_HEXRUN` (22). That was the right call for
+those and is the wrong call for `\w`.
+
+## What is shipped
+
+1. `conformance/sworn/class_census.py`, so the measurement is repeatable rather than a number in a
+   document. It **fails** when an *explicit* class differs — that is a hand-written defect, as
+   `U+0085` was — and **reports** when a *property* class differs, naming both Unicode versions.
+2. A guard that the explicit classes agree, and a guard that **no conformance blob uses a code point
+   the two runtimes classify differently**. The second is the precise statement of why the 1689 bar
+   holds; if a future vector reaches into the skew, it fails and forces the question rather than
+   quietly making the bar mean something narrower.
+
+## What is left for the operator
+
+Whether the published claim should carry the condition. "A second implementation agrees on 1689 of
+1689 vectors" appears in `sworn_verify.js`'s own header and in the RESULT that shipped it. The
+honest form adds *at matching Unicode versions*, and amending shipped documents is not something to
+do on the way past.
+
+Also left: `GRAM_RE`, which the census does not cover. It is anchored and matches strings rather
+than single characters, so comparing it needs a string generator, not a code-point sweep. That is a
+different instrument and it has not been built.

--- a/papers/sworn/FINDING_unicode_version_skew_2026_09_06.md
+++ b/papers/sworn/FINDING_unicode_version_skew_2026_09_06.md
@@ -85,3 +85,54 @@ do on the way past.
 Also left: `GRAM_RE`, which the census does not cover. It is anchored and matches strings rather
 than single characters, so comparing it needs a string generator, not a code-point sweep. That is a
 different instrument and it has not been built.
+
+---
+
+## The agreement is bounded a second time, by the generator's aperture
+
+The Unicode-version condition above is one bound on "the two implementations agree". Running the
+differential harness at a **seed it had never been run at** measures the other.
+
+```
+seed 20260906, 100000 cases
+compared 100000 | agree 100000 | disagree 0 | one-sided errors 0 | reasons 38
+```
+
+A clean sweep — and it is worth almost nothing as evidence about the implementations, because of
+what the generator can emit. Sampled over 25,000 cases at that seed:
+
+```
+distinct code points reachable: 98
+non-ASCII (7): U+00E9, U+0301, U+0663, U+0665, U+2212, U+FEFF, U+1F600
+```
+
+**Seven non-ASCII characters.** Now the miss list — every character-level defect found in this
+audit, against that alphabet:
+
+| defect | code point | reachable by the generator |
+| --- | --- | --- |
+| a dash that dropped a minus sign | `U+2010` and 25 others | **no** |
+| the directional override | `U+202E` | **no** |
+| the path-segment divergence | `U+0085` | **no** |
+| the Unicode-version digit skew | `U+10D40` | **no** |
+
+Four real defects — two of them changing a document verdict between the implementations — and the
+generator cannot produce a single one of them. So `100000 agree, 0 disagree` is not a statement
+about Python and JavaScript. It is a statement that they agree **on a 98-character alphabet**.
+
+This is the lab's own standing warning about itself, now with a receipt: *an agreement number is
+worthless without measuring the generator's detection power.* The number had never been paired with
+its aperture, so it read as far stronger than it was.
+
+### What follows, and what deliberately does not
+
+The obvious move is to widen the grammar until it reaches these characters. **That is not proposed
+here**, for a reason the census makes concrete: a grammar that emits `U+10D40` would make the
+differential harness fail on this machine and pass on one whose runtimes share a Unicode version.
+The harness would stop being a defect detector and start being a runtime-parity detector, reporting
+red for something no edit to either implementation can fix.
+
+The honest sequence is the other order: decide the Unicode-version question first — the operator's
+call, stated above — and only then widen the aperture to whatever the decision makes checkable. What
+is shipped now is the measurement, so the next person to quote `100000 agree` has the alphabet
+printed beside it.

--- a/tests/test_sworn_class_census.py
+++ b/tests/test_sworn_class_census.py
@@ -1,0 +1,130 @@
+"""The explicit character classes agree, and the corpus stays out of the version-skewed ones.
+
+Two different claims, pinned separately.
+
+FIRST: a class both verifiers write out by hand MUST agree. `_PATH_SEG_BAD` did not -- the JS
+hand-expansion of Python's `\\s` dropped U+0085, and a path: target carrying it produced
+SWORN-FAILED in Python and SWORN-HELD in node. That is a defect, and this fails on it.
+
+SECOND: a class defined by a Unicode PROPERTY is bound to each runtime's Unicode version, and here
+they differ -- CPython 15.0.0, V8's ICU 16.0. `_TOKEN`/`TOKEN_RE` differ by 5004 code points and
+`_DIGIT`/`DIGIT_RE` by 80. That is not a defect in either implementation; it is a condition on the
+project's agreement claim. The claim "a second implementation agrees on 1689 of 1689 vectors" is
+true BECAUSE no vector uses a code point the two runtimes classify differently. This pins that
+reason: if a future vector reaches into the skew, the bar quietly starts meaning something narrower,
+and this fails first.
+
+See papers/sworn/FINDING_unicode_version_skew_2026_09_06.md.
+"""
+from __future__ import annotations
+
+import base64
+import io
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+CENSUS = ROOT / "conformance" / "sworn" / "class_census.py"
+BLOBS = ROOT / "conformance" / "sworn" / "blobs.json"
+
+
+def _census_mod():
+    from shutil import which
+    if which("node") is None:
+        pytest.skip("node is not available")
+    if not CENSUS.exists():
+        pytest.skip("the census is not present in this checkout")
+    import importlib
+    sys.path.insert(0, str(CENSUS.parent))
+    return importlib.import_module("class_census")
+
+
+@pytest.fixture(scope="module")
+def rows():
+    mod = _census_mod()
+    return mod.census()
+
+
+def test_every_explicitly_written_class_agrees(rows):
+    """A hand-written class differing between the two is a defect, as U+0085 was."""
+    bad = []
+    for label, kind, py, js in rows:
+        if kind != "explicit":
+            continue
+        only_py, only_js = sorted(py - js), sorted(js - py)
+        if only_py or only_js:
+            bad.append("%s: python-only %s, node-only %s"
+                       % (label, ["U+%04X" % c for c in only_py[:8]],
+                          ["U+%04X" % c for c in only_js[:8]]))
+    assert not bad, "hand-written classes disagree:\n  " + "\n  ".join(bad)
+
+
+def test_the_property_classes_are_reported_not_asserted(rows):
+    """The census must actually be looking at them, or the finding above is unfounded.
+
+    This asserts the SHAPE of the measurement, not its outcome: a property class may agree (if the
+    runtimes' Unicode versions match) or differ (if they do not). What must not happen is that the
+    census silently stops covering them.
+    """
+    kinds = {kind for _l, kind, _p, _j in rows}
+    assert "property" in kinds and "explicit" in kinds, kinds
+    for label, kind, py, js in rows:
+        assert py or js, "%s matched nothing on either side; the lift is broken" % label
+
+
+def _corpus_code_points() -> set:
+    """Every distinct scalar value appearing in any conformance blob."""
+    store = json.load(io.open(BLOBS, encoding="utf-8"))
+    store = store.get("blobs", store)
+    seen = set()
+    for v in store.values():
+        if isinstance(v, dict):
+            v = v.get("b64") or v.get("bytes") or v.get("text") or ""
+        try:
+            raw = base64.b64decode(v, validate=True)
+            text = raw.decode("utf-8")
+        except Exception:                                        # noqa: BLE001
+            continue
+        seen.update(ord(c) for c in text)
+    return seen
+
+
+def test_no_conformance_vector_uses_a_code_point_the_runtimes_disagree_about(rows):
+    """Why the 1689 bar holds, stated as a check rather than as an assumption.
+
+    Measured when written: 0 of 3981 blobs reach into the skew. If a vector ever does, the bar stops
+    meaning "the two implementations agree" and starts meaning "they agree except where they do
+    not" -- and this fails before that happens quietly.
+    """
+    if not BLOBS.exists():
+        pytest.skip("no committed blob store in this checkout")
+    skew = set()
+    for _label, kind, py, js in rows:
+        if kind == "property":
+            skew |= (py ^ js)
+    corpus = _corpus_code_points()
+    assert corpus, "read no code points from the blob store; the reader is broken"
+    overlap = sorted(corpus & skew)
+    assert not overlap, (
+        "%d conformance code point(s) fall where the two runtimes disagree: %s — the 1689-vector "
+        "agreement no longer means what it says"
+        % (len(overlap), ["U+%04X" % c for c in overlap[:12]]))
+
+
+def test_the_census_runs_as_a_command():
+    """CLI output is behaviour: the tool must work the way its docstring says."""
+    from shutil import which
+    import subprocess
+    if which("node") is None:
+        pytest.skip("node is not available")
+    p = subprocess.run([sys.executable, str(CENSUS)], capture_output=True, cwd=str(ROOT))
+    out = p.stdout.decode("utf-8", "replace")
+    assert p.returncode == 0, out[-800:]
+    assert "python unicodedata" in out and "node unicode/icu" in out
+    assert "explicit" in out and "property" in out


### PR DESCRIPTION
## Found by the method, not by an agent

`SPEC_path_segment_class_is_pinned_v01_2026_09_06` (#83) closed a divergence where the JS hand-expansion of Python's `\s` dropped `U+0085`. That spec ended by naming what it had **not** done:

> `TOKEN_RE`, `GRAM_RE`, `HEXRUN_RE` and `DIGIT_RE` are hand-mirrored the same way and have **never been enumerated** against their Python counterparts. That is the obvious next measurement, and the method now exists to make it.

This is that measurement.

```
python unicodedata 15.0.0   node unicode/icu 16.0

_TOKEN / TOKEN_RE                   property DIFFER  python=137971 node=142975   (5004 node-only)
_DIGIT / DIGIT_RE                   property DIFFER  python=680    node=760      (80 node-only)
_HEXRUN / HEXRUN_RE                 explicit AGREE   python=22     node=22
_PATH_SEG_BAD / PATH_SEG_BAD_RE     explicit AGREE   python=58     node=58
_DIRECTIONAL_OVERRIDE / ...         explicit AGREE   python=2      node=2
```

**Every class defined by a Unicode property diverges. Every class defined by an explicit list agrees.** The split is exact and self-explaining: CPython here ships Unicode 15.0.0, V8's ICU ships 16.0, and both sides correctly implement "category Nd" against different editions of the standard.

It changes verdicts. `U+10D40` is a Garay digit added in Unicode 16.0:

```
python unicodedata category: Cn (unassigned to this build)
PYTHON verdict: SWORN-FAILED  [('MALFORMED','number_count')]
core digests -> python 6ecf74684afd528e   node 35b7ceafd77b6471   *** DIVERGE ***
```

## What it bounds is a claim, not a line of code

This project states — prominently and truly — that a second independent implementation agrees on **1689 of 1689** conformance vectors.

That claim is true **because no vector uses a code point the two runtimes classify differently.** Measured: **0 of 3981 blobs do.**

So the agreement is real *and* conditional. The condition is that both runtimes share a Unicode version, and it was nowhere stated. A reader taking "1689/1689" as *"these two implementations agree"* is reading it more broadly than the evidence supports; the accurate reading is *"these two implementations agree on this corpus, at these two Unicode versions."*

## What is deliberately NOT proposed

**Hardcoding the property classes.** `\w` has 137,971 members here. Writing it out on both sides would trade a stated boundary for a large version-pinned table that must be regenerated whenever either runtime moves, and that fails silently when neglected.

The explicit classes are explicit because they are small and adversarially interesting — 58, 22 and 2 members. That was the right call for those and is the wrong call for `\w`.

## What ships

1. **`conformance/sworn/class_census.py`** — the measurement, repeatable, rather than a number in a document. It **fails** when an *explicit* class differs (a hand-written defect, as `U+0085` was) and **reports** when a *property* class differs, naming both Unicode versions. The JS regexes are **lifted out of the shipped file**, never restated, so it cannot pass by testing a copy of the source it polices.
2. **A guard that no conformance blob reaches into the skew** — the precise reason the 1689 bar holds, stated as a check instead of an assumption. If a future vector reaches in, the bar quietly starts meaning something narrower, and this fails first.

## Watched to fail

Removing `U+0085` from the JS class turns the explicit guard red with `_PATH_SEG_BAD / PATH_SEG_BAD_RE: python-only ['U+0085']`, then restored byte-identically (`git diff --stat` empty).

## Checks

- No verifier code changes; the conformance set does not move at all.
- Full suite **4575 passed**, 13 skipped, 4 xfailed.

## Left for the operator

Whether the published claim should carry its condition: *"agrees on 1689 of 1689 vectors **at matching Unicode versions**."* It appears in `sworn_verify.js`'s own header and in the RESULT that shipped it, and amending shipped documents is not something to do on the way past.

Also left: **`GRAM_RE`**, which the census does not cover — it is anchored and matches strings rather than single characters, so comparing it needs a string generator, not a code-point sweep. That instrument has not been built.

🤖 Generated with [Claude Code](https://claude.com/claude-code)