### PR TITLE
the generator can now reach the characters that hid four defects

### DIFF
--- a/conformance/sworn/differential.py
+++ b/conformance/sworn/differential.py
@@ -96,6 +96,41 @@ def _rng(seed: int, index: int) -> random.Random:
     return random.Random("%d:%d" % (seed, index))
 
 
+# --- APERTURE_ALPHABET -------------------------------------------------------------------------
+# The generator's reachable alphabet was measured at 98 code points, SEVEN of them non-ASCII, while
+# every character-level defect the 2026-09-06 audit found lay outside it: the dashes that dropped a
+# minus sign, U+202E which reverses a number for the reader, U+0085 which split the two verifiers on
+# a document verdict. "100000 agree, 0 disagree" was true of a 98-character alphabet and was read as
+# a statement about the implementations. This is the repair.
+#
+# WHY THESE AND NOT EVERY CHARACTER. A generator emitting a code point the two RUNTIMES classify
+# differently — CPython is on Unicode 15.0.0 here, V8's ICU on 16.0 — would make this harness red for
+# a mismatch no edit to either implementation can fix, turning a defect detector into a runtime
+# detector. Every code point below was checked against conformance/sworn/class_census.py: all 68 are
+# classified identically by both. See FINDING_unicode_version_skew_2026_09_06.md.
+_APERTURE_DASHES = [0x002D, 0x00AD, 0x058A, 0x05BE, 0x1400, 0x1806, 0x2010, 0x2011, 0x2012, 0x2013,
+                    0x2014, 0x2015, 0x2212, 0x2E17, 0x2E1A, 0x2E3A, 0x2E3B, 0x2E40, 0x2E5D, 0x301C,
+                    0x3030, 0x30A0, 0xFE31, 0xFE32, 0xFE58, 0xFE63, 0xFF0D]
+_APERTURE_FORMAT = [0x200B, 0x200C, 0x200D, 0x200E, 0x200F, 0x202A, 0x202B, 0x202C, 0x202D, 0x202E,
+                    0x2066, 0x2067, 0x2068, 0x2069, 0xFEFF]
+_APERTURE_SPACE = [0x0085, 0x00A0, 0x1680, 0x2000, 0x2007, 0x200A, 0x2028, 0x2029, 0x202F, 0x205F,
+                   0x3000, 0x000B, 0x000C]
+_APERTURE_MARKS = [0x0300, 0x0301, 0x0334, 0x0489, 0x20E3]
+_APERTURE_DIGITS = [0x0660, 0x06F0, 0x0966, 0x1040, 0xFF10, 0x1D7CE, 0x2070, 0x00B2]
+APERTURE_ALPHABET = [chr(c) for c in (_APERTURE_DASHES + _APERTURE_FORMAT + _APERTURE_SPACE
+                                      + _APERTURE_MARKS + _APERTURE_DIGITS)]
+
+
+def _sprinkle(s: str, r: random.Random, p: float) -> str:
+    """Splice APERTURE_ALPHABET characters into a string, with probability p."""
+    if not s or r.random() >= p:
+        return s
+    out = list(s)
+    for _ in range(r.randint(1, 3)):
+        out.insert(r.randrange(len(out) + 1), r.choice(APERTURE_ALPHABET))
+    return "".join(out)
+
+
 def _number_sentence(r: random.Random) -> str:
     n = r.choice(NUMBERS)
     body = " ".join(r.choice(WORDS) for _ in range(r.randint(0, 4)))
@@ -134,8 +169,10 @@ def _inner_for(kind: str, r: random.Random) -> str:
 
 def _span(r: random.Random) -> str:
     kind = r.choice(KINDS)
-    receipt = r.choice(RECEIPTS)
+    receipt = _sprinkle(r.choice(RECEIPTS), r, 0.12)      # APERTURE: reaches receipt_form, U+0085
     inner = _inner_for(kind if kind in ("numeric", "quote", "hash", "absent") else "numeric", r)
+    inner = _sprinkle(inner, r, 0.22)                     # APERTURE: reaches the dash and override
+                                                         # rules, and the needle/number tokenizers
     if r.random() < 0.02:
         inner = inner * r.randint(20, 60)              # over the code-point cap
     opener = '<sworn r="%s" k="%s">' % (receipt, kind)

--- a/papers/sworn/RESULT_aperture_widening_2026_09_07.md
+++ b/papers/sworn/RESULT_aperture_widening_2026_09_07.md
@@ -1,0 +1,107 @@
+# RESULT — the differential generator can now reach the characters that hid four defects
+
+*2026-09-07. A repair to an instrument, and a negative result from it.*
+
+## What was wrong with the number
+
+`RESULT_differential_agreement_2026_09_05.md` and the run beneath it report that two independent
+verifiers agree on **100000 of 100000** generated documents. On 2026-09-06 that number was paired
+with its aperture for the first time:
+
+```
+distinct code points the generator could reach: 98
+non-ASCII (7): U+00E9, U+0301, U+0663, U+0665, U+2212, U+FEFF, U+1F600
+```
+
+Against the same day's audit findings:
+
+| defect | code point | reachable then |
+| --- | --- | --- |
+| a dash that dropped a minus sign, `-0.42` HELD against `0.42` | `U+2010` and 25 others | no |
+| the override that shows a reader `55.0` where `0.55` was checked | `U+202E` | no |
+| the path segment that split the two verifiers on a document verdict | `U+0085` | no |
+| the Unicode-version digit skew | `U+10D40` | no |
+
+The agreement was real and it covered a 98-character alphabet. Four defects lived outside it.
+
+## The repair
+
+`APERTURE_ALPHABET` — 68 code points across dashes, format and bidi controls, unusual whitespace,
+combining marks and non-ASCII digits — is spliced into span inner text (p=0.22) and receipt targets
+(p=0.12).
+
+```
+generator alphabet: 98 -> 142 code points   (non-ASCII 7 -> 69)
+
+  U+2010  reachable: True
+  U+202E  reachable: True
+  U+0085  reachable: True
+  U+10D40 reachable: False      <- deliberately, see below
+```
+
+### Why one of them stays out of reach
+
+`U+10D40` is a Garay digit: category `Nd` in Unicode 16.0, unassigned in 15.0.0. CPython here is on
+15.0.0 and V8's ICU on 16.0, so the two runtimes classify it differently and **no edit to either
+implementation can make them agree**. A generator that emitted it would report a disagreement that
+is real, unfixable, and not about the verifiers — turning a defect detector into a runtime detector,
+red on this machine and green on one whose runtimes match.
+
+So the aperture widens only where the two runtimes already agree. Every one of the 68 was checked
+against `conformance/sworn/class_census.py`, and a guard re-checks it rather than trusting this
+paragraph.
+
+## The result from the widened instrument
+
+```
+seed 20260905, 100000 cases
+compared 100000 | agree 100000 | disagree 0 | one-sided errors 0 | reasons 39
+```
+
+Thirty-nine distinct reason codes reached, up from thirty-eight. **No disagreement.** The six
+repairs of 2026-09-06 hold across an alphabet 44 code points wider than the one that missed them.
+
+That is a negative result and it is worth what a negative result is worth: the space where four
+defects hid has now been searched, by an instrument that can demonstrably see into it.
+
+## The instrument lied first, and the lie was mine
+
+The first version of the probe reported **1577 disagreements in 2000 cases**. It was false.
+
+Case 0 was `<sworn r="" k="quote">held ` + "`PASS`" + `</sworn>` — plain ASCII, no injected
+character — which is not a document two verifiers should disagree about. The cause was the probe's
+own hand-rolled manifest, which used a `bytes_b64` key the format has no such field for. Re-running
+the identical documents with `manifest=None` produced exact agreement, which located the fault in
+one step.
+
+The repair was to delete the hand-rolled manifest and call the harness's own `_manifest`, removing
+the probe as a variable so that a disagreement could only be about the document alphabet — the one
+thing being widened.
+
+It is recorded here because a spectacular finding that survives ten minutes of checking is the
+failure mode this corpus exists to make expensive, and this one was the author's.
+
+## What is pinned
+
+`tests/test_differential_aperture.py`:
+
+- the three defect-carrying code points are **reachable** — a regression of any of those repairs can
+  now be generated, so an agreement number covers them;
+- `U+10D40` is **not** reachable, and the test says why, so a later widening cannot make the harness
+  unfixably red by accident;
+- the alphabet stays materially wider than the 98/7 that made the miss list possible;
+- every member of `APERTURE_ALPHABET` is checked against the census, so adding a runtime-skewed
+  character fails before it can produce a false disagreement.
+
+Watched to fail: with the injection disabled, all three reach-guards and the width guard go red,
+and the two safety guards stay green.
+
+## What this does not claim
+
+That the two implementations agree. It claims they agree on **142 code points** now instead of 98,
+and the number still travels with its alphabet. Beyond that alphabet nothing has been searched, and
+the region the runtimes disagree about is excluded by construction rather than by evidence.
+
+The conformance set is untouched: `differential.py` is not among `gen_vectors.py`'s `SOURCES`, so no
+vector, blob or digest moves. The previous differential run stands as history — it describes the
+generator it was run with, and that generator is not this one.

--- a/tests/test_differential_aperture.py
+++ b/tests/test_differential_aperture.py
@@ -1,0 +1,113 @@
+"""The generator can reach the characters that hid defects, and cannot reach the ones that would lie.
+
+On 2026-09-06 the differential harness reported `100000 agree, 0 disagree` at a seed it had never
+run, and the generator's reachable alphabet was measured at 98 code points, SEVEN of them non-ASCII.
+Every character-level defect that day's audit found lay outside it:
+
+    U+2010 and 25 other dashes   a minus sign silently dropped, -0.42 HELD against 0.42
+    U+202E                       the reader sees 55.0, the verifier checked 0.55
+    U+0085                       SWORN-FAILED in Python, SWORN-HELD in node
+    U+10D40                      a Unicode-version skew between the two runtimes
+
+So the agreement number was true of a 98-character alphabet and was read as a statement about the
+two implementations. This pins the repair.
+
+TWO CLAIMS, AND THE SECOND IS THE INTERESTING ONE.
+
+  1. the alphabet REACHES the first three, so a regression of any of those repairs is generatable;
+  2. the alphabet does NOT reach U+10D40, and must not.
+
+The second is not an oversight being enshrined. CPython here is on Unicode 15.0.0 and V8's ICU on
+16.0, so the two runtimes classify that code point differently and no edit to either implementation
+can make them agree. A generator that emitted it would turn this harness from a defect detector into
+a runtime detector -- red on this machine, green on one whose runtimes match, for something nobody
+can fix. The aperture widens only where the two runtimes already agree, and every member of
+APERTURE_ALPHABET was checked against conformance/sworn/class_census.py.
+
+See papers/sworn/RESULT_aperture_widening_2026_09_07.md.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+MISSED = {0x2010: "a dash that dropped a minus sign",
+          0x202E: "the directional override",
+          0x0085: "the path-segment divergence"}
+SKEWED = {0x10D40: "a Garay digit, Nd in Unicode 16.0 and unassigned in 15.0.0"}
+
+SAMPLE = 12000
+SEED = 20260905
+
+
+@pytest.fixture(scope="module")
+def alphabet():
+    try:
+        import conformance.sworn.differential as D
+    except Exception as exc:                                     # noqa: BLE001
+        pytest.skip("the differential harness is not importable here: %s" % exc)
+    seen = set()
+    for i in range(SAMPLE):
+        try:
+            seen.update(ord(c) for c in D.case(SEED, i)["document"].decode("utf-8"))
+        except Exception:                                        # noqa: BLE001
+            continue
+    assert seen, "the generator produced no readable document"
+    return seen
+
+
+@pytest.mark.parametrize("cp", sorted(MISSED), ids=lambda c: "U+%04X" % c)
+def test_the_generator_reaches_the_characters_that_hid_defects(cp, alphabet):
+    assert cp in alphabet, (
+        "U+%04X (%s) is outside the generator's reach again: a regression of that repair could not "
+        "be generated, and an agreement number would not cover it" % (cp, MISSED[cp]))
+
+
+@pytest.mark.parametrize("cp", sorted(SKEWED), ids=lambda c: "U+%04X" % c)
+def test_the_generator_does_not_reach_a_runtime_skewed_character(cp, alphabet):
+    assert cp not in alphabet, (
+        "U+%04X (%s) became generatable. The two runtimes classify it differently, so this harness "
+        "would now report a disagreement no edit to either implementation can fix — a defect "
+        "detector turned into a runtime detector" % (cp, SKEWED[cp]))
+
+
+def test_the_alphabet_is_materially_wider_than_it_was(alphabet):
+    """98 code points, 7 non-ASCII, was the measurement that made the miss list possible."""
+    non_ascii = {c for c in alphabet if c > 0x7F}
+    assert len(alphabet) >= 130, "reachable alphabet shrank to %d code points" % len(alphabet)
+    assert len(non_ascii) >= 50, (
+        "non-ASCII reach shrank to %d code points; it was 7 when four defects hid outside it"
+        % len(non_ascii))
+
+
+def test_every_injected_character_is_one_both_runtimes_agree_on():
+    """The safety property that lets the aperture widen at all.
+
+    Checked against the census rather than asserted: if a future edit adds a character to
+    APERTURE_ALPHABET that the two runtimes classify differently, this fails before the harness
+    starts reporting unfixable disagreements.
+    """
+    from shutil import which
+    if which("node") is None:
+        pytest.skip("node is not available")
+    try:
+        import conformance.sworn.differential as D
+        sys.path.insert(0, str(ROOT / "conformance" / "sworn"))
+        import class_census as C
+    except Exception as exc:                                     # noqa: BLE001
+        pytest.skip("the census is not importable here: %s" % exc)
+
+    skew = set()
+    for _label, kind, py, js in C.census():
+        if kind == "property":
+            skew |= (py ^ js)
+    unsafe = sorted(ord(ch) for ch in D.APERTURE_ALPHABET if ord(ch) in skew)
+    assert not unsafe, (
+        "APERTURE_ALPHABET contains %d code point(s) the two runtimes classify differently: %s"
+        % (len(unsafe), ["U+%04X" % c for c in unsafe[:8]]))


### PR DESCRIPTION
## The agreement number covered a 98-character alphabet

Yesterday the differential harness's headline was paired with its aperture for the first time: **100000 agree, 0 disagree** — over an alphabet of **98 code points, seven of them non-ASCII**.

Every character-level defect that day's audit found lay outside it:

| defect | code point | reachable then |
| --- | --- | --- |
| a dash that dropped a minus sign, `-0.42` HELD against `0.42` | `U+2010` +25 | no |
| the override showing a reader `55.0` where `0.55` was checked | `U+202E` | no |
| the path segment that split the two verifiers on a document verdict | `U+0085` | no |
| the Unicode-version digit skew | `U+10D40` | no |

## The repair

`APERTURE_ALPHABET` — 68 code points across dashes, format and bidi controls, unusual whitespace, combining marks and non-ASCII digits — spliced into span inner text (p=0.22) and receipt targets (p=0.12).

```
generator alphabet: 98 -> 142 code points   (non-ASCII 7 -> 69)

  U+2010  reachable: True
  U+202E  reachable: True
  U+0085  reachable: True
  U+10D40 reachable: False      <- deliberately
```

### Why one stays out of reach

`U+10D40` is a Garay digit — `Nd` in Unicode 16.0, unassigned in 15.0.0. CPython here is on 15.0.0 and V8's ICU on 16.0, so **no edit to either implementation can make them agree about it**. A generator emitting it would report a disagreement that is real, unfixable, and not about the verifiers — turning a defect detector into a runtime detector, red on this machine and green on one whose runtimes match.

The aperture widens only where the two runtimes already agree. All 68 were checked against `class_census.py`, and a guard re-checks them rather than trusting the comment.

## The result from the widened instrument

```
seed 20260905, 100000 cases
compared 100000 | agree 100000 | disagree 0 | one-sided errors 0 | reasons 39   (was 38)
```

**No disagreement.** The six repairs of 2026-09-06 hold across an alphabet 44 code points wider than the one that missed them.

A negative result, worth what one is worth: the space where four defects hid has now been *searched*, by an instrument that can demonstrably see into it.

## The instrument lied first, and the lie was mine

The first probe reported **1577 disagreements in 2000 cases**.

It was false. Case 0 was `<sworn r="" k="quote">held \`PASS\`</sworn>` — plain ASCII, no injected character, which is not a document two verifiers should disagree about. The cause was the probe's own hand-rolled manifest, using a `bytes_b64` key the format has no such field for. Re-running the identical documents with `manifest=None` produced exact agreement and located the fault in one step.

Repaired by deleting the hand-rolled manifest and calling the harness's own `_manifest`, removing the probe as a variable so a disagreement could only be about the document alphabet — the one thing being widened.

It is in the RESULT, not just the commit message, because a spectacular finding that survives ten minutes of checking is the failure mode this corpus exists to make expensive, and this one was the author's.

## Pinned, and watched to fail

`tests/test_differential_aperture.py` asserts the three defect-carrying code points are reachable, that `U+10D40` is **not** and says why, that the alphabet stays materially wider than 98/7, and that every `APERTURE_ALPHABET` member is census-clean.

With the injection disabled: all three reach-guards and the width guard go red; both safety guards stay green.

## Checks

- **Conformance untouched.** `differential.py` is not among `gen_vectors.py`'s `SOURCES`, so no vector, blob or digest moves. `CHECK OK`.
- JS bar **1689 ran / 1689 passed / 0 failed**.
- Full suite **4581 passed**, 13 skipped, 4 xfailed.
- The previous differential run stands as history: it describes the generator it was run with, and that generator is not this one.

## What this does not claim

That the two implementations agree. That they agree on **142 code points** now instead of 98 — and the number still travels with its alphabet. Beyond it nothing has been searched, and the region the runtimes disagree about is excluded by construction rather than by evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)